### PR TITLE
Fix shared mem path in unit tests

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
@@ -33,7 +33,6 @@ import org.apache.logging.log4j.util.Supplier;
 @SuppressWarnings("checkstyle:constantname")
 public class PerformanceAnalyzerMetrics {
   private static final Logger LOG = LogManager.getLogger(PerformanceAnalyzerMetrics.class);
-  public static final String sDevShmLocation = PluginSettings.instance().getMetricsLocation();
   public static final String sDevShmScratchLocation = "performanceanalyzer_scratch";
   public static final String sIndicesPath = "indices";
   public static final String sThreadPoolPath = "thread_pool";
@@ -87,7 +86,7 @@ public class PerformanceAnalyzerMetrics {
 
   public static String generatePath(long startTime, String... keysPath) {
     Path sDevShmLocationPath =
-        Paths.get(sDevShmLocation)
+        Paths.get(PluginSettings.instance().getMetricsLocation())
             .resolve(
                 Paths.get(
                     String.valueOf(PerformanceAnalyzerMetrics.getTimeInterval(startTime)),

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/FileHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/FileHandler.java
@@ -15,7 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
 
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
@@ -37,7 +37,7 @@ public abstract class FileHandler {
   public abstract List<Event> getMetricData(Map<String, List<Event>> metricDataMap);
 
   FileHandler() {
-    this.rootLocation = PerformanceAnalyzerMetrics.sDevShmLocation;
+    this.rootLocation = PluginSettings.instance().getMetricsLocation();
   }
 
   public String[] processExtraDimensions(File file) throws IOException {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetricsTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetricsTests.java
@@ -48,19 +48,19 @@ public class PerformanceAnalyzerMetricsTests {
     System.setProperty("performanceanalyzer.metrics.log.enabled", "False");
     PerformanceAnalyzerMetrics.emitMetric(
         System.currentTimeMillis(),
-        PerformanceAnalyzerMetrics.sDevShmLocation + "/dir1/test1",
+            PluginSettings.instance().getMetricsLocation() + "/dir1/test1",
         "value1");
     assertEquals(
         "value1",
         PerformanceAnalyzerMetrics.getMetric(
-            PerformanceAnalyzerMetrics.sDevShmLocation + "/dir1/test1"));
+                PluginSettings.instance().getMetricsLocation() + "/dir1/test1"));
 
     assertEquals(
         "",
         PerformanceAnalyzerMetrics.getMetric(
-            PerformanceAnalyzerMetrics.sDevShmLocation + "/dir1/test2"));
+                PluginSettings.instance().getMetricsLocation() + "/dir1/test2"));
 
-    PerformanceAnalyzerMetrics.removeMetrics(PerformanceAnalyzerMetrics.sDevShmLocation + "/dir1");
+    PerformanceAnalyzerMetrics.removeMetrics(PluginSettings.instance().getMetricsLocation() + "/dir1");
   }
 
   // TODO: Turn it on later
@@ -70,7 +70,7 @@ public class PerformanceAnalyzerMetricsTests {
     String generatedPath =
         PerformanceAnalyzerMetrics.generatePath(startTimeInMillis, "dir1", "id", "dir2");
     String expectedPath =
-        PerformanceAnalyzerMetrics.sDevShmLocation
+            PluginSettings.instance().getMetricsLocation()
             + "/"
             + String.valueOf(PerformanceAnalyzerMetrics.getTimeInterval(startTimeInMillis))
             + "/dir1/id/dir2";


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The type of "sDevShmLocation" is currently declared as final which is not an issue if we run unit test on Linux based machine. However, if we run it on MacOS, the shared mem location will be overwritten as a temp directory by CustomMetricsLocationtestBase(MacOS does not have /dev/shm). As a result, race condition might occur as the sDevShmLocation could either be the default "/dev/shm" or it could be the newly generated temp dir on MacOS when it is being assigned.  Thus some unit tests might fail as a result. 
So what we do here is to remove the final variable "sDevShmLocation" and alway fetch shared mem path from PluginSettings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
