### PR TITLE
Add gRPC build support and proto defintion for reader RPC APIs.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ plugins {
     id 'checkstyle'
     id 'application'
     id 'maven-publish'
+    id 'com.google.protobuf' version '0.8.8'
 }
 
 application {
@@ -117,6 +118,10 @@ dependencies {
     compile 'com.fasterxml.jackson.core:jackson-databind:2.8.11'
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.8'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.8'
+    implementation 'io.grpc:grpc-netty-shaded:1.25.0'
+    implementation 'io.grpc:grpc-protobuf:1.25.0'
+    implementation 'io.grpc:grpc-stub:1.25.0'
+    implementation 'javax.annotation:javax.annotation-api:1.3.2'
 
     // JDK9+ has to run powermock 2+. https://github.com/powermock/powermock/issues/888
     testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.0'
@@ -132,4 +137,22 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest:2.1'
     testCompile 'org.hamcrest:hamcrest-library:2.1'
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:3.10.0"
+    }
+
+    plugins {
+        grpc {
+            artifact = 'io.grpc:protoc-gen-grpc-java:1.25.0'
+        }
+
+    }
+    generateProtoTasks {
+        all()*.plugins {
+            grpc {}
+        }
+    }
 }

--- a/src/main/proto/inter_node_rpc_service.proto
+++ b/src/main/proto/inter_node_rpc_service.proto
@@ -1,0 +1,87 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc";
+option java_outer_classname = "PANetworking";
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc;
+
+service InterNodeRpcService {
+    // Sends a flowunit to whoever is interested in it.
+    rpc Publish (stream FlowUnitMessage) returns (PublishResponse) {
+    }
+
+    // Sends a subscription request to a node for a particular metric.
+    rpc Subscribe (SubscribeMessage) returns (SubscribeResponse) {
+    }
+
+    // get Metrics for a particular node
+    rpc GetMetrics(MetricsRequest) returns (MetricsResponse) {}
+}
+
+/*
+ Structure that describes the subscription message.
+*/
+message SubscribeMessage {
+    string requester_node = 1;
+    string destination_node = 2;
+    map<string, string> tags = 3;
+}
+
+message SubscribeResponse {
+    enum SubscriptionStatus {
+        SUCCESS = 0;
+        TAG_MISMATCH = 1;
+    }
+    SubscriptionStatus subscription_status = 1;
+}
+
+/*
+ List of Strings.
+*/
+message StringList {
+    repeated string values = 1;
+}
+
+/*
+ A single FlowUnit that will be transferred across the network for RCA computation.
+*/
+message FlowUnitMessage {
+    uint64 timestamp = 1;
+    repeated StringList values = 2;
+    string graphNode = 3;
+    string esNode = 4;
+
+    /*
+     ResourceContext that comes along with ResourceFlowUnit
+    */
+    message ResourceContextMessage {
+        int32 state = 1;
+        int32 resource = 2;
+    }
+    ResourceContextMessage resourceContext = 5;
+}
+
+message PublishResponse {
+    enum PublishResponseStatus {
+        SUCCESS = 0;
+        NODE_SHUTDOWN = 1;
+    }
+    PublishResponseStatus data_status = 1;
+}
+
+/*
+ Request Parameters for GetMetrics API
+*/
+message MetricsRequest {
+    repeated string metric_list = 1;
+    repeated string agg_list = 2;
+    repeated string dim_list = 3;
+}
+
+/*
+ GetMetrics function returns string as a response
+*/
+message MetricsResponse {
+    string metrics_result = 1;
+}


### PR DESCRIPTION
*Description of changes:*
This commit adds protobuff gradle plugin, gRPC dependencies, and protoc plugin for gRPC code generation.

The commit also adds the inter_node_rpc_service proto definition which contains the API details.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
