### PR TITLE
exclude grpc from jacoco test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 ## Performance Analyzer RCA
 
-The Performance Analyzer RCA is a framework that builds on the Performance Analyzer engine to support Root Cause Analysis (RCA) of performance and reliability problems in Elasticsearch clusters. This framework executes real time root cause analyses using Performance Analyzer metrics. Root cause analysis can significantly improve operations, administration and provisioning of Elasticsearch clusters, and it can enable Elasticsearch client teams to tune their workloads to reduce errors.
+The Performance Analyzer RCA is a framework that builds
+on the Performance Analyzer engine to support Root
+Cause Analysis (RCA) of performance and reliability
+problems in Elasticsearch clusters. This framework
+executes real time root cause analyses using Performance Analyzer
+metrics. Root cause analysis can significantly improve
+operations, administration and provisioning of
+Elasticsearch clusters, and it can enable Elasticsearch
+client teams to tune their workloads to reduce errors.
+
+## Overview
+The RCA framework is a distributed data-flow graph where the data enters from
+the top as Performance Analyzer metrics referred to as Leaf nodes in the code,
+the intermediate nodes perform calculations and out comes the RCA.
 
 ## License
 

--- a/build.gradle
+++ b/build.gradle
@@ -76,8 +76,16 @@ jacoco {
 jacocoTestReport {
     reports {
         xml.enabled false
+        html.enabled true
         csv.enabled false
-        html.destination file("${buildDir}/jacocoHtml")
+    }
+
+    afterEvaluate {
+        classDirectories.from = files(classDirectories.files.collect {
+            fileTree(dir: it,
+                    exclude: [
+                            '**/com/amazon/opendistro/elasticsearch/performanceanalyzer/grpc/**'])
+        })
     }
 }
 
@@ -88,6 +96,7 @@ if (isSnapshot) {
 
 test {
     enabled = true
+
 }
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
GRPC files are auto generated and therefore including them in the code coverage is misleading.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
