### PR TITLE
per run metric colletor framework

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerApp.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerApp.java
@@ -21,12 +21,20 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsC
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.TroubleshootingConfig;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.core.Util;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsRestUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.GRPCConnectionManager;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetClient;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetServer;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaController;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.MetricsDBProvider;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.RcaStatsReporter;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.collectors.aggregator.SampleAggregator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.emitters.PeriodicSamplers;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.aggregated.ExceptionsAndErrors;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.aggregated.RcaFrameworkMeasurements;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.aggregated.RcaGraphMeasurements;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.sampled.JvmMeasurements;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ReaderMetricsProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rest.QueryMetricsRequestHandler;
@@ -39,8 +47,12 @@ import java.net.InetSocketAddress;
 import java.security.KeyStore;
 import java.security.Security;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.KeyManagerFactory;
@@ -66,8 +78,28 @@ public class PerformanceAnalyzerApp {
       Executors.newScheduledThreadPool(
           2, new ThreadFactoryBuilder().setNameFormat("network-thread-%d").build());
 
+  private static final ScheduledExecutorService resourceStateSamplerExecutor =
+      Executors.newScheduledThreadPool(
+          1, new ThreadFactoryBuilder().setNameFormat("resource-sampler-%d").build());
+
   private static RcaController rcaController = null;
   private static Thread rcaNetServerThread = null;
+
+
+  public static final SampleAggregator RCA_GRAPH_SAMPLE_AGGREGATOR =
+          new SampleAggregator(RcaGraphMeasurements.values());
+  public  static final SampleAggregator RCA_FRAMEWORK_SAMPLE_AGGREGATOR =
+          new SampleAggregator(RcaFrameworkMeasurements.values());
+
+  public static final SampleAggregator ERRORS_AND_EXCEPTIONS =
+          new SampleAggregator(ExceptionsAndErrors.values());
+
+  public static final SampleAggregator SYSTEM_RESOURCE_SAMPLER =
+          new SampleAggregator(JvmMeasurements.values());
+
+  public static final RcaStatsReporter RCA_STATS_REPORTER =
+          new RcaStatsReporter(Arrays.asList(RCA_GRAPH_SAMPLE_AGGREGATOR,
+                  RCA_FRAMEWORK_SAMPLE_AGGREGATOR, ERRORS_AND_EXCEPTIONS, SYSTEM_RESOURCE_SAMPLER));
 
   public static void main(String[] args) throws Exception {
     // Initialize settings before creating threads.
@@ -102,8 +134,15 @@ public class PerformanceAnalyzerApp {
             });
     readerThread.start();
 
-    ClientServers clientServers = startServers();
+    ClientServers clientServers = startServers(Util.RPC_PORT, getPortNumber());
     startRcaController(clientServers);
+
+    int frequency =
+        (MetricsConfiguration.CONFIG_MAP.get(StatsCollector.class).samplingInterval) / 2;
+    TimeUnit timeUnit = TimeUnit.MILLISECONDS;
+    // This should come after the RcaController as the RcaControllers creates the necessary
+    // collectors to collect samples.
+    startResourceStateSampler(resourceStateSamplerExecutor, frequency, timeUnit);
   }
 
   /**
@@ -114,16 +153,16 @@ public class PerformanceAnalyzerApp {
    *
    * @return gRPC client and the gRPC server and the httpServer wrapped in a class.
    */
-  public static ClientServers startServers() {
+  public static ClientServers startServers(int rpcServerPort, int httpServerPort) {
     boolean useHttps = PluginSettings.instance().getHttpsEnabled();
 
     GRPCConnectionManager connectionManager = new GRPCConnectionManager(useHttps);
-    NetServer netServer = new NetServer(Util.RPC_PORT, 1, useHttps);
+    NetServer netServer = new NetServer(rpcServerPort, 1, useHttps);
     NetClient netClient = new NetClient(connectionManager);
     MetricsRestUtil metricsRestUtil = new MetricsRestUtil();
 
     startRpcServerThread(netServer);
-    HttpServer httpServer = createInternalServer(PluginSettings.instance(), getPortNumber());
+    HttpServer httpServer = createInternalServer(PluginSettings.instance(), httpServerPort);
     httpServer.createContext(QUERY_URL, new QueryMetricsRequestHandler(netClient, metricsRestUtil));
 
     return new ClientServers(httpServer, netServer, netClient);
@@ -161,9 +200,29 @@ public class PerformanceAnalyzerApp {
             RcaConsts.rcaNannyPollerPeriodicity,
             RcaConsts.rcaConfPollerPeriodicity,
             RcaConsts.nodeRolePollerPeriodicity,
-            RcaConsts.rcaPollerPeriodicityTimeUnit);
+            RcaConsts.rcaPollerPeriodicityTimeUnit,
+                new MetricsDBProvider());
 
     rcaController.startPollers();
+  }
+
+  private static void startResourceStateSampler(
+      ScheduledExecutorService executor, long freq, TimeUnit timeUnit) {
+    ScheduledFuture<?> future =
+        executor.scheduleAtFixedRate(
+            new PeriodicSamplers(SYSTEM_RESOURCE_SAMPLER), 0, freq, timeUnit);
+    new Thread(
+            () -> {
+              try {
+                future.get();
+              } catch (CancellationException cex) {
+                LOG.info("Resource State Executor cancellation requested.");
+              } catch (Exception ex) {
+                LOG.error("Resource state poller exception cause : {}", ex.getCause());
+                ex.printStackTrace();
+              }
+            })
+        .start();
   }
 
   public static HttpServer createInternalServer(PluginSettings settings, int internalPort) {
@@ -258,7 +317,7 @@ public class PerformanceAnalyzerApp {
     return server;
   }
 
-  private static int getPortNumber() {
+  public static int getPortNumber() {
     String readerPortValue;
     try {
       readerPortValue = PluginSettings.instance().getSettingValue(WEBSERVICE_PORT_CONF_NAME);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/Version.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/Version.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca;
+
+/**
+ * The version of the RCA framework and the graphs combined. The version is a combination of the
+ * major and the minor versions together.
+ */
+public final class Version {
+  // This will hopefully never change.
+  public static final String RCA_VERSION_STR = "rca-version";
+
+  /**
+   * An increase in the major version means that the flow units are in-compatible and if
+   * different instances(physical nodes) are running different versions of the framework, then
+   * the transferred packets should be dropped. Every increment here should be accompanied with a
+   * line of note.
+   */
+  final class Major {
+    static final int RCA_MAJ_VERSION = 0;
+  }
+
+  /**
+   * This is expected to increment with each noticeable change in the framework and also with
+   * addition of new RCAs or enhancement of the old ones. But given this, we don't expect the
+   * minor version to change for every single release and each increment should have a line
+   * stating what changed.
+   */
+  final class Minor {
+      static final String RCA_MINOR_VERSION = ".0.1";
+  }
+
+  /**
+   *
+   * @return The version string.
+   */
+  public static String getRcaVersion() {
+    return Major.RCA_MAJ_VERSION + Minor.RCA_MINOR_VERSION;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/Symptom.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/Symptom.java
@@ -15,11 +15,12 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.SymptomFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.NonLeafNode;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.aggregated.RcaGraphMeasurements;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import java.util.Collections;
-import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -32,7 +33,16 @@ public abstract class Symptom extends NonLeafNode<SymptomFlowUnit> {
 
   public void generateFlowUnitListFromLocal(FlowUnitOperationArgWrapper args) {
     LOG.debug("rca: Executing handleRca: {}", this.getClass().getSimpleName());
-    setFlowUnits(Collections.singletonList(this.operate()));
+
+    long startTime = System.nanoTime();
+    SymptomFlowUnit out = this.operate();
+    long endTime = System.nanoTime();
+    long durationMicro = (endTime - startTime) / 1000;
+
+    PerformanceAnalyzerApp.RCA_GRAPH_SAMPLE_AGGREGATOR.updateStat(
+        RcaGraphMeasurements.GRAPH_NODE_OPERATE_CALL, this.name(), durationMicro);
+
+    setFlowUnits(Collections.singletonList(out));
   }
 
   public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {
@@ -41,9 +51,9 @@ public abstract class Symptom extends NonLeafNode<SymptomFlowUnit> {
 
   /**
    * Persists a flow unit.
+   *
    * @param args The arg wrapper.
    */
   @Override
-  public void persistFlowUnit(FlowUnitOperationArgWrapper args) {
-  }
+  public void persistFlowUnit(FlowUnitOperationArgWrapper args) {}
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/ConnectedComponent.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/ConnectedComponent.java
@@ -27,7 +27,7 @@ import java.util.Set;
 public class ConnectedComponent {
   private List<Node<?>> leafNodes;
 
-  /* The elements in the inner list can be executed in parallel. Two inner lists have to be executed in order. */
+  /* The elements in the eval list can be executed in parallel. Two eval lists have to be executed in order. */
   private List<List<Node<?>>> dependencyOrderedNodes;
   private int graphId;
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/README.md
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/README.md
@@ -1,0 +1,74 @@
+# Health of the RCA framework
+
+The classes in this package help you gather measurements such as latency of executions and
+occurrences of events, aggregate them and then report them.
+
+## Measurements
+
+Measurements are defined in the  `stats/measurements`. They are the quantities we want to measure.
+Each measurement has a statistic associated with it
+
+### Aggregates
+They do some calculations on the raw numbers without just reporting them. The supported
+statistics are in the `stats/eval/impl`. New aggregates can be written and plugged in without
+much effort. Currently supported statistics are:
+ 1. Count
+ 1. Max
+ 1. Min
+ 1. Mean
+ 1. NamedCounter
+ 1. Sample
+ 1. Sum
+
+With max and min you can choose to send the value along with a key and then the statistic reports
+the max or the min and also the key associated with it. The way we use it here is with
+calculating the max and min of latencies for calling the operate on the graph nodes. We pass
+the name of the graph as the key to it. Therefore, for each run we get not only the maximum
+duration to execute `operate()` across all the nodes, but also the the name name of the node
+which took the longest.
+One other statistic that deserves special mention is the `NamedCounter` type. This also takes a
+key with it and finally it gives the count of occurrences for each key. This can be handy in
+cases like exception reporting. Instead of enlisting all the exceptions in the Measurement
+beforehand, we just have a few, and we can use the key to specify the cause of it and get a
+grouping over the common causes for which the exceptions are thrown.
+
+
+### Samples
+These are reported as they were witnessed, the raw numbers. Some of the examples are the JVM free
+ space or the current number of live threads in the rca system.
+
+## Emitters
+
+Emitters emit certain measurements. They can be found in two places - scattered all around the
+code to track execution latencies and the occurrence of errors or call to an expensive
+ElasticSearch API. The second place is the `stats/emitters`. These are fired at every certain
+interval.
+
+## Aggregators
+
+They collect the emitted metrics and may compute statistics on them if specified in the
+measurement definition.
+
+## Reporter
+Reporter asks the Aggregators for the metrics collected so far and generate reports. This is
+where the concept of formatters comes in. Reporting is currently handled by `StatsCollector` class.
+
+### Formatters
+
+Formatters are classes that implement the `Formatter`  interface. This is the language the
+reporter and aggregators talk in. When the reporter asks for the metrics, it sends across a
+formatter with it. The aggregator uses the formatter to format the measurements. Formatters are
+located in `stat/format`. The formatter that comes with the repo might not suit your needs and
+therefore, you might choose to write another formatter that formats the measurements in
+accordance with your metric backend.
+
+## Extending the measurements
+
+If you want to add more measurements, then you can add them to one of the three categories or
+ even create one of your own. The three categories we have, stores metrics related to:
+ 1. `RcaGraphMeasurements` : Measurements related to each run of the RCA graph.
+ 1. `RcaFrameworkMeasurements`: Measurements are concerned with the general workings of the
+  framework outside of the graph execution.
+ 1. `ExceptionsAndErrors`: To get a count of the errors and exceptions thrown by the system.
+ 1. `LivenessMeasurements`: These are the list of system samples that are collected periodically
+  rather than on occurrence of events.

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/RcaStatsReporter.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/RcaStatsReporter.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.collectors.aggregator.SampleAggregator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.format.Formatter;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.MeasurementSet;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.List;
+
+/**
+ * This is meant to be the registry for all the stats that are collected by the Rca framework and
+ * needs to be reported periodically by the {@code StatsCollector.collectMetrics}
+ */
+public class RcaStatsReporter {
+  /** The list of collectors for which a report can be generated. */
+  private final List<SampleAggregator> aggregators;
+
+  /** The index of the collector whose measurements will be reported on this iteration. */
+  private int idxOfCollectorToReport;
+
+  public RcaStatsReporter(List<SampleAggregator> aggregators) {
+    this.aggregators = aggregators;
+    idxOfCollectorToReport = 0;
+  }
+
+  /**
+   * The caller is expected to call this method with a {@code new} formatter every time. This is not
+   * thread-safe.
+   *
+   * <p>Each time this is called, this method sources a measurement type and formats it and sends
+   * it.
+   *
+   * @param formatter The formatter to use to format the measurementSet
+   * @return true if there are collectors left to be reported or false otherwise.
+   */
+  public boolean getNextReport(Formatter formatter) {
+    if (aggregators == null || aggregators.isEmpty()) {
+      return false;
+    }
+
+    SampleAggregator collector = aggregators.get(idxOfCollectorToReport);
+    collector.fillValuesAndReset(formatter);
+    boolean ret = true;
+
+    idxOfCollectorToReport += 1;
+
+    if (idxOfCollectorToReport == aggregators.size()) {
+      ret = false;
+      idxOfCollectorToReport = 0;
+    }
+    return ret;
+  }
+
+  @VisibleForTesting
+  public boolean isMeasurementCollected(MeasurementSet measure) {
+    for (SampleAggregator aggregator : aggregators) {
+      if (aggregator.isMeasurementObserved(measure)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/collectors/aggregator/SampleAggregator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/collectors/aggregator/SampleAggregator.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.collectors.aggregator;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.Count;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.Max;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.Mean;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.Min;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.NamedCounter;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.Sample;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.StatisticImpl;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.Sum;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.vals.Value;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.format.Formatter;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.MeasurementSet;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * This class is mainly to collect stats between runs of the RCA framework before we can write them
+ * using the Stats Collector.
+ *
+ * <p>This is suitable for cases where we want to calculate statistics before we report it, e.g the
+ * RCA graph evaluation. We want to know the long pole in the Graph node execution and how much it
+ * deviates from the mean but we also don't want to report the time taken by each graph node.
+ */
+public class SampleAggregator {
+
+  private static final Logger LOG = LogManager.getLogger(SampleAggregator.class);
+  /** The set of measurements its in charge of aggregating. */
+  private final MeasurementSet[] recognizedSet;
+  /**
+   * The idea is to be able to calculate multiple statistics for each measurement.
+   *
+   * <ul>
+   *   <li>key: Measurement are anything that we want to sample, say graphNodeExecution.
+   *   <li>value: The list of objects that calculates various metrics, say an object implementing
+   *       mean and another one implementing Max.
+   * </ul>
+   */
+  private ImmutableMap<MeasurementSet, List<StatisticImpl>> statMap;
+  /** When was the first updateStat was called since the last reset. */
+  private AtomicLong startTimeMillis;
+
+  public SampleAggregator(MeasurementSet[] measurementSet) {
+    this.recognizedSet = measurementSet;
+    init();
+  }
+
+  private void init() {
+    startTimeMillis = new AtomicLong(0L);
+    Map<MeasurementSet, List<StatisticImpl>> initializer = new ConcurrentHashMap<>();
+
+    for (MeasurementSet elem : recognizedSet) {
+      List<StatisticImpl> impls = new ArrayList<>();
+      for (Statistics stats : elem.getStatsList()) {
+        switch (stats) {
+          case COUNT:
+            impls.add(new Count());
+            break;
+          case MAX:
+            impls.add(new Max());
+            break;
+          case MEAN:
+            impls.add(new Mean());
+            break;
+          case MIN:
+            impls.add(new Min());
+            break;
+          case NAMED_COUNTERS:
+            impls.add(new NamedCounter());
+            break;
+          case SAMPLE:
+            impls.add(new Sample());
+            break;
+          case SUM:
+            impls.add(new Sum());
+            break;
+          default:
+            throw new IllegalArgumentException("Unimplemented stat: " + stats);
+        }
+      }
+      initializer.put(elem, impls);
+    }
+    this.statMap = ImmutableMap.copyOf(initializer);
+  }
+
+  /**
+   * This is called whenever the framework hits a measurement of interest. This is thread safe.
+   *
+   * @param metric Determined by the Enum MeasurementType
+   * @param key multiple points in the code can emit the same measurement, say RCA1 and RCA2, both
+   *     will emit a measurement how long each of them took and then this metric will determine
+   *     which of the two took the longest(Max).
+   * @param value The actual value of the measurement.
+   * @param <V> The Type of value
+   */
+  public <V extends Number> void updateStat(MeasurementSet metric, String key, V value) {
+    List<StatisticImpl> statistics = statMap.get(metric);
+    if (statistics == null) {
+      LOG.error(
+          "'{}' asked to be aggregated, when known types are only: {}", metric, recognizedSet);
+      return;
+    }
+
+    if (startTimeMillis.get() == 0L) {
+      // The CAS operations are expensive compared to primitive type checks. Therefore, we only
+      // resort to CAS if we even stand a chance of modifying the variable. The startTime is only
+      // set by the first thread that tries to update a metric. So, we don't want all the
+      // subsequent threads to pay the price of a CAS.
+      startTimeMillis.compareAndSet(0L, System.currentTimeMillis());
+    }
+
+    for (StatisticImpl s : statistics) {
+      s.calculate(key, value);
+    }
+  }
+
+  /**
+   * This gets the current set of Measurements collected and re-initiates the objects for the next
+   * iteration.
+   *
+   * @param formatter An class that knows how to format a map of enum and lists.
+   */
+  public void fillValuesAndReset(Formatter formatter) {
+    synchronized (this) {
+      fill(formatter);
+      init();
+    }
+  }
+
+  /**
+   * Be advised that the statMap is filled in just once in the constructor. Ever since no new
+   * elements are added just existing elements are modified. Therefore, some of the statistics that
+   * have already been added at initialization might not ever be calculated, if <code>updateStat()
+   * </code> is never called on it. Therefore, it such values are not desired, then the same can be
+   * checked using the <code>calculatedAtLeastOnce()</code> flag.
+   *
+   * @param formatter Used to convert the map into a desired format.
+   */
+  public void fill(Formatter formatter) {
+    long endTime = System.currentTimeMillis();
+    formatter.setStartAndEndTime(startTimeMillis.get(), endTime);
+
+    for (Map.Entry<MeasurementSet, List<StatisticImpl>> entry : statMap.entrySet()) {
+      MeasurementSet measurement = entry.getKey();
+      for (StatisticImpl statValues : entry.getValue()) {
+        if (!statValues.isEmpty()) {
+          Statistics stat = statValues.type();
+          Collection<Value> values = statValues.get();
+          for (Value value : values) {
+            value.format(formatter, measurement, stat);
+          }
+        }
+      }
+    }
+  }
+
+  @VisibleForTesting
+  public boolean isMeasurementObserved(MeasurementSet toFind) {
+    List<StatisticImpl> statistics = statMap.get(toFind);
+    if (statistics == null) {
+      return false;
+    }
+    for (StatisticImpl statistic : statMap.get(toFind)) {
+      if (statistic != null && !statistic.isEmpty()) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/emitters/PeriodicSamplers.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/emitters/PeriodicSamplers.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.emitters;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.collectors.aggregator.SampleAggregator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.sampled.JvmMeasurements;
+import java.util.Arrays;
+import java.util.List;
+
+public class PeriodicSamplers implements Runnable {
+  private final SampleAggregator sampleCollector;
+  private List<Sampler> allSamplers;
+  private long samplingStartMillis;
+  private long samplingEndMillis;
+
+  public PeriodicSamplers(SampleAggregator sampleCollector) {
+    this.sampleCollector = sampleCollector;
+    allSamplers =
+        Arrays.asList(new JvmFreeMemSampler(), new JvmTotalMemSampler(), new ThreadCount());
+    samplingStartMillis = 0L;
+    samplingEndMillis = 0L;
+  }
+
+  @Override
+  public void run() {
+    samplingStartMillis = System.currentTimeMillis();
+    for (Sampler sampler : allSamplers) {
+      sampler.sample(sampleCollector);
+    }
+    samplingEndMillis = System.currentTimeMillis();
+  }
+
+  interface Sampler {
+    void sample(SampleAggregator sampleCollector);
+  }
+
+  /** Total amount of free memory available to the JVM. */
+  class JvmFreeMemSampler implements Sampler {
+    @Override
+    public void sample(SampleAggregator collector) {
+      collector.updateStat(
+          JvmMeasurements.JVM_FREE_MEM_SAMPLER, "", Runtime.getRuntime().freeMemory());
+    }
+  }
+
+  /** Total memeory available to the JVM at the moment. Might vary over time. */
+  class JvmTotalMemSampler implements Sampler {
+    @Override
+    public void sample(SampleAggregator sampleCollector) {
+      sampleCollector.updateStat(
+          JvmMeasurements.JVM_TOTAL_MEM_SAMPLER, "", Runtime.getRuntime().totalMemory());
+    }
+  }
+
+  /** Gives a count of all threads in the JVM */
+  class ThreadCount implements Sampler {
+    @Override
+    public void sample(SampleAggregator sampleCollector) {
+      sampleCollector.updateStat(
+          JvmMeasurements.THREAD_COUNT, "", Thread.getAllStackTraces().keySet().size());
+    }
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/Statistics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/Statistics.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval;
+
+/** List of stats that are currently supported. */
+public enum Statistics {
+  MAX,
+  MIN,
+  MEAN,
+  COUNT,
+  SUM,
+
+  // Samples are not aggregated. They are reported as they were found. They can be used when we
+  // need just a key value pairs.
+  SAMPLE,
+
+  // Think of them as a counter per name. So if you update your stats as these values:
+  // x, y, x, x, z, h
+  // then the named counter will give you something like:
+  // x: 3, y: 1, z: 1, h:1
+  // This is helpful in calculating metric like which rca nodes threw exceptions and count per
+  // graph node.
+  NAMED_COUNTERS
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/Count.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/Count.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.vals.AggregateValue;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class Count implements StatisticImpl<AggregateValue> {
+  private AtomicLong counter;
+  private boolean empty;
+
+  public Count() {
+    counter = new AtomicLong(0L);
+    empty = true;
+  }
+
+  @Override
+  public Statistics type() {
+    return Statistics.COUNT;
+  }
+
+  @Override
+  public void calculate(String key, Number value) {
+    counter.incrementAndGet();
+    empty = false;
+  }
+
+  @Override
+  public List<AggregateValue> get() {
+    return Collections.singletonList(new AggregateValue(counter, type()));
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return empty;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/Max.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/Max.java
@@ -1,0 +1,38 @@
+/*
+ *
+ *  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License").
+ *  * You may not use this file except in compliance with the License.
+ *  * A copy of the License is located at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * or in the "license" file accompanying this file. This file is distributed
+ *  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  * express or implied. See the License for the specific language governing
+ *  * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.Statistics;
+
+/** To get the maximum observed value */
+public class Max extends MinMaxCommon {
+
+  public Max() {
+    super(Long.MIN_VALUE);
+  }
+
+  @Override
+  boolean shouldUpdate(Number v) {
+    return getOldVal().doubleValue() < v.doubleValue();
+  }
+
+  @Override
+  public Statistics type() {
+    return Statistics.MAX;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/Mean.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/Mean.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.vals.AggregateValue;
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.List;
+
+public class Mean implements StatisticImpl<AggregateValue> {
+  private BigInteger sum;
+  private long count;
+
+  private boolean empty;
+
+  public Mean() {
+    this.sum = BigInteger.ZERO;
+    this.count = 0;
+    this.empty = true;
+  }
+
+  @Override
+  public Statistics type() {
+    return Statistics.MEAN;
+  }
+
+  @Override
+  public void calculate(String key, Number value) {
+    synchronized (this) {
+      BigInteger bdValue = BigInteger.valueOf(value.longValue());
+      sum = sum.add(bdValue);
+      count += 1;
+    }
+    empty = false;
+  }
+
+  @Override
+  public List<AggregateValue> get() {
+    double ret = 0.0;
+    if (count != 0) {
+      ret = sum.doubleValue() / count;
+    }
+    return Collections.singletonList(new AggregateValue(ret, type()));
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return empty;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/Min.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/Min.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.Statistics;
+
+/** To get the minimum observed value. */
+public class Min extends MinMaxCommon {
+  public Min() {
+    super(Long.MAX_VALUE);
+  }
+
+  @Override
+  boolean shouldUpdate(Number v) {
+    return v.doubleValue() < getOldVal().doubleValue();
+  }
+
+  @Override
+  public Statistics type() {
+    return Statistics.MIN;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/MinMaxCommon.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/MinMaxCommon.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.vals.NamedAggregateValue;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This is a utility class that is shares methods that are used for statistics where values are
+ * compared with all the previous samples but no mathematical calculation is done. Things such as
+ * max and min.
+ */
+abstract class MinMaxCommon implements StatisticImpl<NamedAggregateValue> {
+  private final Number initialVal;
+
+  private Number oldVal;
+  private String oldKey;
+
+  private boolean empty;
+
+  public MinMaxCommon(Number initialVal) {
+    this.initialVal = initialVal;
+    this.oldVal = initialVal;
+    this.oldKey = "";
+    this.empty = true;
+  }
+
+  /**
+   * Based on the new observation, should the metric be updated.
+   *
+   * @param v The new new observation.
+   * @return true if the member value needs to be updated, false otherwise.
+   */
+  abstract boolean shouldUpdate(Number v);
+
+  /**
+   * This is just a comparison followed by an update if required.
+   *
+   * @param key How to identify each sample in the measurement. Say, if we are measure the time
+   *     spent in the call of the operate() method of the RCA graph and want to find the RCA class
+   *     that has the most expensive call. So the key will be the name of the RCA class.
+   * @param value The measurement on which statistics are calculated.
+   */
+  @Override
+  public void calculate(String key, Number value) {
+    synchronized (this) {
+      if (shouldUpdate(value)) {
+        oldVal = value;
+        oldKey = key;
+      }
+    }
+    empty = false;
+  }
+
+  @Override
+  public List<NamedAggregateValue> get() {
+    return Collections.singletonList(new NamedAggregateValue(oldVal, type(), oldKey));
+  }
+
+  public Number getOldVal() {
+    return oldVal;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return empty;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/NamedCounter.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/NamedCounter.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.vals.NamedAggregateValue;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class NamedCounter implements StatisticImpl<NamedAggregateValue> {
+  private boolean empty;
+  private Map<String, NamedAggregateValue> counters;
+
+  public NamedCounter() {
+    counters = new ConcurrentHashMap<>();
+    empty = true;
+  }
+
+  @Override
+  public Statistics type() {
+    return Statistics.NAMED_COUNTERS;
+  }
+
+  @Override
+  public void calculate(String key, Number value) {
+    synchronized (this) {
+      NamedAggregateValue mapValue =
+          counters.getOrDefault(key, new NamedAggregateValue(0L, Statistics.NAMED_COUNTERS, key));
+      try {
+        Number numb = mapValue.getValue();
+        long number = mapValue.getValue().longValue();
+        long newNumber = number + 1;
+        mapValue.update(newNumber);
+        counters.put(key, mapValue);
+        empty = false;
+      } catch (Exception ex) {
+        ex.printStackTrace();
+      }
+    }
+  }
+
+  @Override
+  public Collection<NamedAggregateValue> get() {
+    return counters.values();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return empty;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/Sample.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/Sample.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.vals.Value;
+import java.util.Collections;
+import java.util.List;
+
+public class Sample implements StatisticImpl<Value> {
+  private Number value;
+  private boolean empty;
+
+  public Sample() {
+    empty = true;
+  }
+
+  @Override
+  public Statistics type() {
+    return Statistics.SAMPLE;
+  }
+
+  @Override
+  public void calculate(String key, Number value) {
+    this.value = value;
+    empty = false;
+  }
+
+  @Override
+  public List<Value> get() {
+    return Collections.singletonList(new Value(value));
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return empty;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/StatisticImpl.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/StatisticImpl.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.vals.Value;
+import java.util.Collection;
+
+/** This is the template of the statistic classes. Max, min etc. all follow this template. */
+public interface StatisticImpl<V extends Value> {
+
+  /**
+   * To obtain the type of statistic such as {@code Statistic.MAX} etc.
+   *
+   * @return The statistics type it implements.
+   */
+  Statistics type();
+
+  /**
+   * The actual calculation of the metric.
+   *
+   * @param key How to identify each sample in the measurement. Say, if we are measure the time
+   *     spent in the call of the operate() method of the RCA graph and want to find the RCA class
+   *     that has the most expensive call. So the key will be the name of the RCA class.
+   * @param value The measurement on which statistics are calculated.
+   */
+  void calculate(String key, Number value);
+
+  /**
+   * Get the value of the statistic.
+   *
+   * @return Get the calculated value.
+   */
+  Collection<V> get();
+
+  /**
+   * To determine if the metric has a valid value to report.
+   *
+   * @return true if this was ever calculated or else returns false;
+   */
+  boolean isEmpty();
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/Sum.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/Sum.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.vals.AggregateValue;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class Sum implements StatisticImpl<AggregateValue> {
+  private AtomicLong sum;
+  private boolean empty;
+
+  public Sum() {
+    sum = new AtomicLong(0L);
+    empty = true;
+  }
+
+  @Override
+  public Statistics type() {
+    return Statistics.SUM;
+  }
+
+  @Override
+  public void calculate(String key, Number value) {
+    sum.addAndGet(value.longValue());
+    empty = false;
+  }
+
+  @Override
+  public List<AggregateValue> get() {
+    return Collections.singletonList(new AggregateValue(sum, type()));
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return empty;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/vals/AggregateValue.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/vals/AggregateValue.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.vals;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.format.Formatter;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.MeasurementSet;
+
+public class AggregateValue extends Value {
+  private Statistics aggregationType;
+
+  public AggregateValue(Number value, Statistics type) {
+    super(value);
+    this.aggregationType = type;
+  }
+
+  public void format(Formatter formatter, MeasurementSet measurementSet, Statistics stats) {
+    formatter.formatAggregatedValue(measurementSet, stats, value);
+  }
+
+  public Statistics getAggregationType() {
+    return aggregationType;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/vals/NamedAggregateValue.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/vals/NamedAggregateValue.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.vals;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.format.Formatter;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.MeasurementSet;
+
+public class NamedAggregateValue extends AggregateValue {
+  private String name;
+
+  public NamedAggregateValue(Number value, Statistics type, String name) {
+    super(value, type);
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public void format(Formatter formatter, MeasurementSet measurementSet, Statistics stats) {
+    formatter.formatNamedAggregatedValue(
+        measurementSet, getAggregationType(), getName(), getValue());
+  }
+
+  public void update(Number value) {
+    this.value = value;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/vals/NamedValue.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/vals/NamedValue.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.vals;
+
+/**
+ * This encapsulates the key and the value. An example will be the name of the RCA node that took
+ * the longest and the how long it took.
+ */
+public abstract class NamedValue extends Value {
+  private String name;
+
+  public NamedValue(String key, Number value) {
+    super(value);
+    this.name = key;
+  }
+
+  public String getName() {
+    return name;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/vals/Value.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/vals/Value.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.vals;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.format.Formatter;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.MeasurementSet;
+
+public class Value {
+  protected Number value;
+
+  public Value(Number value) {
+    this.value = value;
+  }
+
+  public Number getValue() {
+    return value;
+  }
+
+  public void format(Formatter formatter, MeasurementSet measurementSet, Statistics stats) {
+    formatter.formatAggregatedValue(measurementSet, stats, value);
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/format/BaseFormatter.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/format/BaseFormatter.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.format;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.vals.NamedAggregateValue;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.vals.Value;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.MeasurementSet;
+import java.util.HashMap;
+import java.util.Map;
+
+public class BaseFormatter implements Formatter {
+  private Map<MeasurementSet, Map<Statistics, Value>> map;
+  private long start;
+  private long end;
+
+  public BaseFormatter() {
+    this.map = new HashMap<>();
+    this.start = 0;
+    this.end = 0;
+  }
+
+  @Override
+  public void formatNamedAggregatedValue(
+      MeasurementSet measurementSet, Statistics aggregationType, String name, Number value) {
+    map.putIfAbsent(measurementSet, new HashMap<>());
+    map.get(measurementSet)
+        .put(aggregationType, new NamedAggregateValue(value, aggregationType, name));
+  }
+
+  @Override
+  public void formatAggregatedValue(
+      MeasurementSet measurementSet, Statistics aggregationType, Number value) {
+    map.putIfAbsent(measurementSet, new HashMap<>());
+    map.get(measurementSet).put(aggregationType, new Value(value));
+  }
+
+  @Override
+  public void setStartAndEndTime(long start, long end) {
+    this.start = start;
+    this.end = end;
+  }
+
+  public Map<MeasurementSet, Map<Statistics, Value>> getFormatted() {
+    return map;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/format/Formatter.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/format/Formatter.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.format;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.MeasurementSet;
+
+/**
+ * A formatter is used to get the final formatted output of an aggregation.
+ *
+ * <p>The idea is without having to know the internal structure of the aggregator, one should be
+ * able to get a formatted result out. When the caller, passes on a formatter to get(), the get
+ * internally calls formatNamedValue and formatValue multiple times one for each statistic value per
+ * aggregated Measurement. Say, if you are measuring min, max, mean for X and min and max for Y,
+ * then internally formatNamedValue or formatvalue will be called five times in total; 3 times for
+ * min, max and mean for X and 2 times for min and max.
+ *
+ * <p>It is upto the implementing class to store the values however it wants.
+ */
+public interface Formatter {
+
+  /**
+   * This function that knows what to do with named value types or knows how to store them.
+   *
+   * @param measurementSet The name of the measurement.
+   * @param aggregationType whether this is min, max, mean or other statistic.
+   * @param name The name of the value.
+   * @param value The value of the value.
+   */
+  void formatNamedAggregatedValue(
+      MeasurementSet measurementSet, Statistics aggregationType, String name, Number value);
+
+  /**
+   * This knows how to store the value, when called with one.
+   *
+   * @param measurementSet The name of the measurement.
+   * @param aggregationType The name of aggregation type - min, max and the like.
+   * @param value The value of the measurement, corresponding to the aggregation type.
+   */
+  void formatAggregatedValue(
+      MeasurementSet measurementSet, Statistics aggregationType, Number value);
+
+  /**
+   * This method is called by the PerRunStats to set the start and end time of that particular run.
+   *
+   * @param start The time when the first metric came in.
+   * @param end The time when the getAndReset was called on the PerRunMetric
+   */
+  void setStartAndEndTime(long start, long end);
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/format/StatsCollectorFormatter.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/format/StatsCollectorFormatter.java
@@ -1,0 +1,205 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.format;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.MeasurementSet;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.aggregated.ExceptionsAndErrors;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.aggregated.RcaFrameworkMeasurements;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.aggregated.RcaGraphMeasurements;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class StatsCollectorFormatter implements Formatter {
+  static final char SEPARATOR = '-';
+  static List<MeasurementSet> LATENCIES =
+      Arrays.asList(
+          RcaFrameworkMeasurements.GRAPH_EXECUTION_TIME,
+          RcaGraphMeasurements.GRAPH_NODE_OPERATE_CALL,
+          RcaGraphMeasurements.METRIC_GATHER_CALL,
+          RcaGraphMeasurements.RCA_PERSIST_CALL);
+  StatsCollectorReturn formattedValue;
+
+  public StatsCollectorReturn getFormatted() {
+    return formattedValue;
+  }
+
+  private boolean formatException(MeasurementSet measurement, String name, Number counter) {
+    for (MeasurementSet measure : ExceptionsAndErrors.values()) {
+      if (measurement == measure) {
+        if (name.isEmpty()) {
+          formattedValue.putCounter(measurement.getName(), counter.intValue());
+        } else {
+          formattedValue.putCounter(
+              new StringBuilder(measurement.getName())
+                  .append(SEPARATOR)
+                  .append(name.replaceAll(" ", "_"))
+                  .toString(),
+              counter.intValue());
+        }
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean formatSamples(MeasurementSet given, Number values, Statistics aggr) {
+    if (aggr == Statistics.SAMPLE) {
+      formattedValue.putStats(given.getName(), String.valueOf(values));
+      return true;
+    }
+    return false;
+  }
+
+  private boolean formatCounters(
+      MeasurementSet measurementSet, Number values, Statistics aggr, String name) {
+    boolean found = false;
+    if (aggr == Statistics.COUNT) {
+      formattedValue.putCounter(measurementSet.getName(), values.intValue());
+      found = true;
+    } else if (aggr == Statistics.NAMED_COUNTERS) {
+      formattedValue.putCounter(
+          new StringBuilder(measurementSet.getName())
+              .append(SEPARATOR)
+              .append(name.replaceAll(" ", "_"))
+              .toString(),
+          values.intValue());
+      found = true;
+    }
+    return found;
+  }
+
+  private boolean formatLatencies(
+      MeasurementSet given, Number value, Statistics aggr, String name) {
+    if (aggr == Statistics.NAMED_COUNTERS
+        || aggr == Statistics.NAMED_COUNTERS
+        || aggr == Statistics.SAMPLE) {
+      return false;
+    }
+    for (MeasurementSet aggregateMeasurements : LATENCIES) {
+      if (aggregateMeasurements == given) {
+        StringBuilder stringBuilder = new StringBuilder(given.getName());
+        stringBuilder.append(SEPARATOR).append(aggr);
+        stringBuilder.append(SEPARATOR).append(given.getUnit());
+        if (!name.isEmpty()) {
+          stringBuilder.append(SEPARATOR).append(name);
+        }
+        formattedValue.putLatencies(stringBuilder.toString(), value.doubleValue());
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void formatStats(MeasurementSet measurement, Number value, Statistics aggr, String name) {
+    StringBuilder stringBuilder = new StringBuilder(measurement.getName());
+    stringBuilder.append(SEPARATOR).append(aggr);
+    stringBuilder.append(SEPARATOR).append(measurement.getUnit());
+    if (!name.isEmpty()) {
+      stringBuilder.append(SEPARATOR).append(name);
+    }
+    formattedValue.putStats(stringBuilder.toString(), String.valueOf(value));
+  }
+
+  private void formatMeasurementInOrder(
+      MeasurementSet measurementSet, Statistics type, String name, Number value) {
+    boolean ret = formatSamples(measurementSet, value, type);
+    if (!ret) {
+      ret = formatException(measurementSet, name, value);
+    }
+    if (!ret) {
+      ret = formatCounters(measurementSet, value, type, name);
+    }
+    if (!ret) {
+      ret = formatLatencies(measurementSet, value, type, name);
+    }
+    if (!ret) {
+      formatStats(measurementSet, value, type, name);
+    }
+  }
+
+  @Override
+  public void formatNamedAggregatedValue(
+      MeasurementSet measurementSet, Statistics aggregationType, String name, Number value) {
+    formatMeasurementInOrder(measurementSet, aggregationType, name, value);
+  }
+
+  @Override
+  public void formatAggregatedValue(
+      MeasurementSet measurementSet, Statistics aggregationType, Number value) {
+    formatMeasurementInOrder(measurementSet, aggregationType, "", value);
+  }
+
+  @Override
+  public void setStartAndEndTime(long start, long end) {
+    formattedValue = new StatsCollectorReturn(start, end);
+  }
+
+  public class StatsCollectorReturn {
+    private Map<String, AtomicInteger> counters;
+    private Map<String, String> statsdata;
+    private Map<String, Double> latencies;
+    private long startTimeMillis;
+    private long endTimeMillis;
+
+    public StatsCollectorReturn(long startTimeMillis, long endTimeMillis) {
+      counters = new HashMap<>();
+      statsdata = new HashMap<>();
+      latencies = new HashMap<>();
+      this.startTimeMillis = startTimeMillis;
+      this.endTimeMillis = endTimeMillis;
+    }
+
+    void putCounter(String name, int value) {
+      counters.put(name, new AtomicInteger(value));
+    }
+
+    void putLatencies(String name, double value) {
+      latencies.put(name, value);
+    }
+
+    void putStats(String name, String value) {
+      statsdata.put(name, value);
+    }
+
+    public Map<String, AtomicInteger> getCounters() {
+      return counters;
+    }
+
+    public Map<String, String> getStatsdata() {
+      return statsdata;
+    }
+
+    public Map<String, Double> getLatencies() {
+      return latencies;
+    }
+
+    public long getStartTimeMillis() {
+      return startTimeMillis;
+    }
+
+    public long getEndTimeMillis() {
+      return endTimeMillis;
+    }
+
+    public boolean isEmpty() {
+      return counters.isEmpty() && statsdata.isEmpty() && latencies.isEmpty();
+    }
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/measurements/MeasurementSet.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/measurements/MeasurementSet.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.Statistics;
+import java.util.List;
+
+/** This is a marker interface to bring all measurement sets under one type. */
+public interface MeasurementSet {
+  /**
+   * The statistics that should be calculated for this measurement
+   *
+   * @return The list of statistics to be calculated for this measurement.
+   */
+  List<Statistics> getStatsList();
+
+  /**
+   * The name of the measurement.
+   *
+   * @return The name of the measurement.
+   */
+  String getName();
+
+  /**
+   * The unit of measurement. This is not used for calculation but just for reference.
+   *
+   * @return The string representation of the unit.
+   */
+  String getUnit();
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/measurements/aggregated/ExceptionsAndErrors.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/measurements/aggregated/ExceptionsAndErrors.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.aggregated;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.MeasurementSet;
+import java.util.Collections;
+import java.util.List;
+
+public enum ExceptionsAndErrors implements MeasurementSet {
+  RCA_FRAMEWORK_CRASH("RcaFrameworkCrash"),
+
+  /**
+   * These are the cases when an exception was throws in the {@code operate()} method, that each RCA
+   * graph node implements.
+   */
+  EXCEPTION_IN_OPERATE("ExceptionInOperate", "namedCount", Statistics.NAMED_COUNTERS);
+
+  /** What we want to appear as the metric name. */
+  private String name;
+
+  /**
+   * The unit the measurement is in. This is not used for the statistics calculations but as an
+   * information that will be dumped with the metrics.
+   */
+  private String unit;
+
+  /**
+   * Multiple statistics can be collected for each measurement like MAX, MIN and MEAN. This is a
+   * collection of one or more such statistics.
+   */
+  private List<Statistics> statsList;
+
+  ExceptionsAndErrors(String name) {
+    this.name = name;
+    this.unit = "count";
+    this.statsList = Collections.singletonList(Statistics.COUNT);
+  }
+
+  ExceptionsAndErrors(String name, String unit, Statistics stats) {
+    this.name = name;
+    this.unit = unit;
+    this.statsList = Collections.singletonList(stats);
+  }
+
+  public String toString() {
+    return new StringBuilder(name).append("-").append(unit).toString();
+  }
+
+  @Override
+  public List<Statistics> getStatsList() {
+    return statsList;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getUnit() {
+    return unit;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/measurements/aggregated/RcaFrameworkMeasurements.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/measurements/aggregated/RcaFrameworkMeasurements.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.aggregated;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.MeasurementSet;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public enum RcaFrameworkMeasurements implements MeasurementSet {
+  /** Time taken per run of the RCA graph */
+  GRAPH_EXECUTION_TIME(
+      "RcaGraphExecution",
+      "micros",
+      Arrays.asList(Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT)),
+
+  /**
+   * These are the flow units that are sent by the RCA framework for the remote nodes. Not all of
+   * them may or may not make it over the wire.
+   */
+  FLOW_UNITS_SENT_TO_WIRE_HOPPER(
+      "FlowUnitsToWireHopper", "count", Collections.singletonList(Statistics.COUNT)),
+
+  /**
+   * This measures how many flow units are sent over the wire. If there are multiple subscribers,
+   * then the flow unit will be copied to each one of them. Each of the copies will be accounted for
+   * in the count.
+   */
+  // TODO(yojs): waiting on
+  // https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/pull/59
+  FLOW_UNITS_SENT_OVER_NETWORK(
+      "FlowUnitsSentOverNetwork", "count", Collections.singletonList(Statistics.COUNT)),
+
+  /** The number of times the framework was stopped by the operator. */
+  RCA_STOPPED_BY_OPERATOR(
+      "RcaStoppedByOperator", "count", Collections.singletonList(Statistics.COUNT)),
+
+  /** The number of times the framework was restarted by the operator. */
+  RCA_RESTARTED_BY_OPERATOR(
+      "RcaRestartedByOperator", "count", Collections.singletonList(Statistics.COUNT)),
+
+  /**
+   * ES APIs calls are expensive and we want to keep track of how many we are making. This is a
+   * named counter and therefore we can get a count per ES API.
+   */
+  ES_APIS_CALLED("ESApisCalled", "count", Collections.singletonList(Statistics.NAMED_COUNTERS));
+
+  /** What we want to appear as the metric name. */
+  private String name;
+
+  /**
+   * The unit the measurement is in. This is not used for the statistics calculations but as an
+   * information that will be dumped with the metrics.
+   */
+  private String unit;
+
+  /**
+   * Multiple statistics can be collected for each measurement like MAX, MIN and MEAN. This is a
+   * collection of one or more such statistics.
+   */
+  private List<Statistics> statsList;
+
+  RcaFrameworkMeasurements(String name, String unit, List<Statistics> statisticList) {
+    this.name = name;
+    this.unit = unit;
+    this.statsList = statisticList;
+  }
+
+  public String toString() {
+    return new StringBuilder(name).append("-").append(unit).toString();
+  }
+
+  @Override
+  public List<Statistics> getStatsList() {
+    return statsList;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getUnit() {
+    return unit;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/measurements/aggregated/RcaGraphMeasurements.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/measurements/aggregated/RcaGraphMeasurements.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.aggregated;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.MeasurementSet;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public enum RcaGraphMeasurements implements MeasurementSet {
+  /** Measures the time spent in the operate() method of a graph node. */
+  GRAPH_NODE_OPERATE_CALL("OperateCall", "micros", Arrays.asList(Statistics.MAX, Statistics.MEAN)),
+
+  /** Measures the time taken to call gather on metrics */
+  METRIC_GATHER_CALL("MetricGatherCall", "micros", Arrays.asList(Statistics.MAX, Statistics.MEAN)),
+
+  /** Measures the time spent in the persistence layer. */
+  RCA_PERSIST_CALL("RcaPersistCall", "micros", Arrays.asList(Statistics.MAX, Statistics.MEAN)),
+
+  NUM_GRAPH_NODES("NumGraphNodes", "count", Collections.singletonList(Statistics.SAMPLE)),
+
+  NUM_NODES_EXECUTED_LOCALLY(
+      "NodesExecutedLocally", "count", Collections.singletonList(Statistics.COUNT)),
+
+  NUM_NODES_EXECUTED_REMOTELY(
+      "NodesExecutedRemotely", "count", Collections.singletonList(Statistics.COUNT));
+
+  /** What we want to appear as the metric name. */
+  private String name;
+
+  /**
+   * The unit the measurement is in. This is not used for the statistics calculations but as an
+   * information that will be dumped with the metrics.
+   */
+  private String unit;
+
+  /**
+   * Multiple statistics can be collected for each measurement like MAX, MIN and MEAN. This is a
+   * collection of one or more such statistics.
+   */
+  private List<Statistics> statsList;
+
+  RcaGraphMeasurements(String name, String unit, List<Statistics> statisticList) {
+    this.name = name;
+    this.unit = unit;
+    this.statsList = statisticList;
+  }
+
+  public String toString() {
+    return new StringBuilder(name).append("-").append(unit).toString();
+  }
+
+  @Override
+  public List<Statistics> getStatsList() {
+    return statsList;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getUnit() {
+    return unit;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/measurements/sampled/JvmMeasurements.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/measurements/sampled/JvmMeasurements.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.sampled;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.MeasurementSet;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * These are the group of measurements that are sampled every so often and then they are reported.
+ * They are not aggregated.
+ */
+public enum JvmMeasurements implements MeasurementSet {
+  JVM_FREE_MEM_SAMPLER("JvmFreeMem", "bytes"),
+  JVM_TOTAL_MEM_SAMPLER("JvmTotalMem", "bytes"),
+  THREAD_COUNT("ThreadCount", "count");
+
+  private String name;
+  private String unit;
+
+  JvmMeasurements(String name, String unit) {
+    this.name = name;
+    this.unit = unit;
+  }
+
+  @Override
+  public List<Statistics> getStatsList() {
+    return Collections.singletonList(Statistics.SAMPLE);
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getUnit() {
+    return unit;
+  }
+
+  @Override
+  public String toString() {
+    return new StringBuilder(name).append("-").append(unit).toString();
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/RcaUtil.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/RcaUtil.java
@@ -15,7 +15,6 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util;
 
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.AnalysisGraph;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.ConnectedComponent;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
@@ -46,20 +45,20 @@ public class RcaUtil {
     return getAnalysisGraphComponents(graph);
   }
 
-  public static List<ConnectedComponent> getAnalysisGraphComponents(String analysisGraphClass)
-      throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException,
-          InstantiationException, IllegalAccessException {
-    AnalysisGraph graph =
-        (AnalysisGraph) Class.forName(analysisGraphClass).getDeclaredConstructor().newInstance();
+  public static List<ConnectedComponent> getAnalysisGraphComponents(AnalysisGraph graph) {
     graph.construct();
     graph.validateAndProcess();
     return Stats.getInstance().getConnectedComponents();
   }
 
-  public static List<ConnectedComponent> getAnalysisGraphComponents(AnalysisGraph graph) {
+  public static AnalysisGraph getAnalysisGraph(String analysisGraphClass)
+      throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException,
+          InvocationTargetException, InstantiationException {
+    AnalysisGraph graph =
+        (AnalysisGraph) Class.forName(analysisGraphClass).getDeclaredConstructor().newInstance();
     graph.construct();
     graph.validateAndProcess();
-    return Stats.getInstance().getConnectedComponents();
+    return graph;
   }
 
   public static boolean doTagsMatch(Node<?> node, RcaConf conf) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopper.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopper.java
@@ -15,11 +15,14 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatExceptionCode;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetClient;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.aggregated.RcaFrameworkMeasurements;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.DataMsg;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.IntentMsg;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.UnicastIntentMsg;
@@ -79,6 +82,8 @@ public class WireHopper {
     if (executor != null) {
       try {
         executor.execute(new FlowUnitTxTask(netClient, subscriptionManager, msg));
+        PerformanceAnalyzerApp.RCA_FRAMEWORK_SAMPLE_AGGREGATOR.updateStat(
+                RcaFrameworkMeasurements.FLOW_UNITS_SENT_TO_WIRE_HOPPER, "send", 1);
       } catch (final RejectedExecutionException ree) {
         LOG.warn("Dropped sending flow unit because the threadpool queue is full");
         StatsCollector.instance()

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/GraphNodeOperations.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/GraphNodeOperations.java
@@ -15,6 +15,8 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.aggregated.RcaGraphMeasurements;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -23,6 +25,8 @@ public class GraphNodeOperations {
 
   static void readFromLocal(FlowUnitOperationArgWrapper args) {
     args.getNode().generateFlowUnitListFromLocal(args);
+    PerformanceAnalyzerApp.RCA_GRAPH_SAMPLE_AGGREGATOR.updateStat(
+        RcaGraphMeasurements.NUM_NODES_EXECUTED_LOCALLY, "", 1);
     args.getNode().persistFlowUnit(args);
   }
 
@@ -30,5 +34,7 @@ public class GraphNodeOperations {
   static void readFromWire(FlowUnitOperationArgWrapper args) {
     // flowUnits.forEach(i -> LOG.info("rca: Read from wire: {}", i));
     args.getNode().generateFlowUnitListFromWire(args);
+    PerformanceAnalyzerApp.RCA_GRAPH_SAMPLE_AGGREGATOR.updateStat(
+        RcaGraphMeasurements.NUM_NODES_EXECUTED_REMOTELY, "", 1);
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/Tasklet.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/Tasklet.java
@@ -15,8 +15,10 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Queryable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.aggregated.ExceptionsAndErrors;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.DataMsg;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.WireHopper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.NetPersistor;
@@ -130,6 +132,8 @@ public class Tasklet {
                 executorPool)
             .exceptionally(
                 ex -> {
+                  PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS.updateStat(
+                      ExceptionsAndErrors.EXCEPTION_IN_OPERATE, node.name(), 1);
                   ex.printStackTrace();
                   return new TaskletResult(null);
                 });

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/FaultyAnalysisGraph.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/FaultyAnalysisGraph.java
@@ -1,0 +1,53 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.DummyGraph.DATA_NODE;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.DummyGraph.LOCUS;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.AnalysisGraph;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Symptom;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.SymptomFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.CPU_Utilization;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_AllocRate;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Paging_MajfltRate;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Sched_Waittime;
+import java.util.Arrays;
+
+public class FaultyAnalysisGraph extends AnalysisGraph {
+
+    @Override
+    public void construct() {
+        Metric cpuUtilization = new CPU_Utilization(5);
+        Metric heapUsed = new Sched_Waittime(5);
+        Metric pageMaj = new Paging_MajfltRate(5);
+        Metric heapAlloc = new Heap_AllocRate(5);
+
+        addLeaf(cpuUtilization);
+        addLeaf(heapUsed);
+        addLeaf(pageMaj);
+        addLeaf(heapAlloc);
+
+        Symptom s1 = new HighCpuSymptom(5, cpuUtilization, heapUsed);
+        s1.addTag(LOCUS, DATA_NODE);
+        s1.addAllUpstreams(Arrays.asList(cpuUtilization, heapUsed));
+
+        System.out.println(this.getClass().getName() + " graph constructed..");
+    }
+
+    class HighCpuSymptom extends Symptom {
+        Metric cpu;
+        Metric heapUsed;
+
+        public HighCpuSymptom(long evaluationIntervalSeconds, Metric cpu, Metric heapUsed) {
+            super(evaluationIntervalSeconds);
+            this.cpu = cpu;
+            this.heapUsed = heapUsed;
+        }
+
+        @Override
+        public SymptomFlowUnit operate() {
+            int x = 5 / 0;
+            return new SymptomFlowUnit(0L);
+        }
+    }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
@@ -2,11 +2,15 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.ClientServers;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.core.Util;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.GRPCConnectionManager;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.emitters.PeriodicSamplers;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.RCAScheduler;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.RcaSchedulerState;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.spec.MetricsDBProviderTestHelper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -19,9 +23,12 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jooq.tools.json.JSONObject;
 import org.junit.After;
 import org.junit.Assert;
@@ -41,16 +48,22 @@ public class RcaControllerTest {
   private HttpServer dummyEsServer;
   private RcaController rcaController;
   private String masterIP;
+  private Path testStatsLogs;
+  private Path testPerformanceAnalyzerLogs;
 
   @Before
-  public void setUp() throws IOException {
+  public void setUp() throws Exception {
+    testPerformanceAnalyzerLogs = Paths.get("/tmp/PerformanceAnalyzer.test.log");
+    testStatsLogs = Paths.get("/tmp/performance_analyzer_agent_stats.test.log");
+
     String cwd = System.getProperty("user.dir");
     rcaEnabledFileLoc = Paths.get(cwd, "src", "test", "resources", "rca");
     rcaEnabledFile = Paths.get(rcaEnabledFileLoc.toString(), RcaController.getRcaEnabledConfFile());
     netOperationsExecutor =
         Executors.newScheduledThreadPool(
             3, new ThreadFactoryBuilder().setNameFormat("test-network-thread-%d").build());
-    clientServers = PerformanceAnalyzerApp.startServers();
+    clientServers = PerformanceAnalyzerApp.startServers(Util.RPC_PORT,
+            PerformanceAnalyzerApp.getPortNumber());
 
     URI uri = URI.create(RcaController.getCatMasterUrl());
     masterIP = "";
@@ -95,7 +108,8 @@ public class RcaControllerTest {
             1,
             1,
             1,
-            TimeUnit.MILLISECONDS);
+            TimeUnit.MILLISECONDS,
+               new MetricsDBProviderTestHelper());
 
     setMyIp(masterIP, AllMetrics.NodeRole.UNKNOWN);
     rcaController.startPollers();
@@ -193,6 +207,36 @@ public class RcaControllerTest {
     eventProcessor.processEvent(
         new Event("", jtime.toString() + System.lineSeparator() + jNode.toString(), 0));
   }
+
+  @Test
+  public void statGeneration() {
+    Logger LOG = LogManager.getLogger(RcaControllerTest.class);
+    LOG.error("hello - test log");
+    StatsCollector statsCollector = new StatsCollector("test-stats", 1000, new HashMap<>());
+    PeriodicSamplers periodicSamplers =
+            new PeriodicSamplers(PerformanceAnalyzerApp.SYSTEM_RESOURCE_SAMPLER);
+    periodicSamplers.run();
+
+    // Execute An Rca graph
+    try {
+      Thread.sleep(2000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+    statsCollector.collectMetrics(0);
+    // cleanUpLogs();
+  }
+
+  private void cleanUpLogs() {
+    try {
+      Files.deleteIfExists(testPerformanceAnalyzerLogs);
+      Files.deleteIfExists(testStatsLogs);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+  }
+
 
   enum RcaState {
     RUN,

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaFrameworkMeasurementTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaFrameworkMeasurementTest.java
@@ -1,0 +1,49 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.AnalysisGraph;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.aggregated.ExceptionsAndErrors;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaUtil;
+import java.lang.reflect.InvocationTargetException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(GradleTaskForRca.class)
+public class RcaFrameworkMeasurementTest {
+  @Before
+  public void cleanup() {
+    RcaTestFrameworkSetup.cleanUpLogs();
+  }
+
+  @Test
+  public void metricEmission() {
+    try {
+      AnalysisGraph graph =
+          RcaUtil.getAnalysisGraph(
+              "com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.FaultyAnalysisGraph");
+      RcaTestFrameworkSetup setup = new RcaTestFrameworkSetup(graph);
+      while (!PerformanceAnalyzerApp.RCA_STATS_REPORTER.isMeasurementCollected(
+          ExceptionsAndErrors.EXCEPTION_IN_OPERATE)) {
+        try {
+          Thread.sleep(1);
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
+      }
+      setup.getStatsCollector().collectMetrics(0);
+    } catch (ClassNotFoundException e) {
+      e.printStackTrace();
+    } catch (NoSuchMethodException e) {
+      e.printStackTrace();
+    } catch (InvocationTargetException e) {
+      e.printStackTrace();
+    } catch (InstantiationException e) {
+      e.printStackTrace();
+    } catch (IllegalAccessException e) {
+      e.printStackTrace();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaTestFrameworkSetup.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaTestFrameworkSetup.java
@@ -1,0 +1,316 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.ClientServers;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.core.Util;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.GRPCConnectionManager;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetClient;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetServer;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.AnalysisGraph;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.ConnectedComponent;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Queryable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Stats;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.RcaStatsReporter;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.format.BaseFormatter;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.MeasurementSet;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.spec.MetricsDBProviderTestHelper;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import org.jooq.tools.json.JSONObject;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+/** This is the base class to set up Rca framework. */
+public class RcaTestFrameworkSetup {
+  private ScheduledExecutorService netOperationsExecutor;
+  private ClientServers clientServers;
+  private GRPCConnectionManager connectionManager;
+  private Path rcaEnabledFileLoc;
+  private Path testResourcesPath;
+  private Path rcaEnabledFile;
+  private HttpServer dummyEsServer;
+  private RcaControllerOverride rcaController;
+  private String masterIP;
+  private Path testStatsLogs;
+  private Path testPerformanceAnalyzerLogs;
+  private int rpcServerPort;
+  private int webServerPort;
+
+  public Path getTestStatsLogs() {
+    return testStatsLogs;
+  }
+
+  public Path getTestPerformanceAnalyzerLogs() {
+    return testPerformanceAnalyzerLogs;
+  }
+
+  public StatsCollector getStatsCollector() {
+    return statsCollector;
+  }
+
+  private StatsCollector statsCollector;
+
+  private class RcaControllerOverride extends RcaController {
+    private AnalysisGraph analysisGraph;
+
+    public RcaControllerOverride(
+        ScheduledExecutorService netOpsExecutorService,
+        GRPCConnectionManager grpcConnectionManager,
+        NetClient rcaNetClient,
+        NetServer rcaNetServer,
+        HttpServer httpServer,
+        String rca_enabled_conf_location,
+        String electedMasterRcaConf,
+        String masterRcaConf,
+        String rcaConf,
+        long rcaNannyPollerPeriodicity,
+        long rcaConfPollerPeriodicity,
+        long nodeRolePollerPeriodicty,
+        TimeUnit timeUnit,
+        Queryable metricsDB) {
+      super(
+          netOpsExecutorService,
+          grpcConnectionManager,
+          rcaNetClient,
+          rcaNetServer,
+          httpServer,
+          rca_enabled_conf_location,
+          electedMasterRcaConf,
+          masterRcaConf,
+          rcaConf,
+          rcaNannyPollerPeriodicity,
+          rcaConfPollerPeriodicity,
+          nodeRolePollerPeriodicty,
+          timeUnit,
+          metricsDB);
+    }
+
+    // TODO: implement this.
+    @Override
+    protected List<ConnectedComponent> getRcaGraphConnectedComponents(RcaConf rcaConf) {
+      return Stats.getInstance().getConnectedComponents();
+    }
+  }
+
+  RcaTestFrameworkSetup(String analysisGraph) throws Exception {
+    this(3, Util.RPC_PORT, PerformanceAnalyzerApp.getPortNumber(), AllMetrics.NodeRole.DATA);
+  }
+
+  RcaTestFrameworkSetup(AnalysisGraph analysisGraph) throws Exception {
+    this(3, Util.RPC_PORT, PerformanceAnalyzerApp.getPortNumber(), AllMetrics.NodeRole.DATA);
+  }
+
+  RcaTestFrameworkSetup(
+      int netServerThreadCount, int rpcServerPort, int webServerPort, AllMetrics.NodeRole nodeRole)
+      throws Exception {
+    this.rpcServerPort = rpcServerPort;
+    this.webServerPort = webServerPort;
+    this.statsCollector = new StatsCollector("test-stats", 1000, new HashMap<>());
+
+    initFilePaths();
+    netOperationsExecutor =
+        Executors.newScheduledThreadPool(
+            netServerThreadCount,
+            new ThreadFactoryBuilder().setNameFormat("test-network-thread-%d").build());
+    clientServers = PerformanceAnalyzerApp.startServers(this.rpcServerPort, this.webServerPort);
+
+    masterIP = "10.10.192.168";
+    setDummyEsServer();
+    boolean useHttps = PluginSettings.instance().getHttpsEnabled();
+    connectionManager = new GRPCConnectionManager(useHttps);
+    rcaController =
+        new RcaControllerOverride(
+            netOperationsExecutor,
+            connectionManager,
+            clientServers.getNetClient(),
+            clientServers.getNetServer(),
+            clientServers.getHttpServer(),
+            rcaEnabledFileLoc.toString(),
+            Paths.get(rcaEnabledFileLoc.toString(), "rca_elected_master.conf").toString(),
+            Paths.get(rcaEnabledFileLoc.toString(), "rca_master.conf").toString(),
+            Paths.get(rcaEnabledFileLoc.toString(), "rca.conf").toString(),
+            1,
+            1,
+            1,
+            TimeUnit.MILLISECONDS,
+            new MetricsDBProviderTestHelper());
+
+    setMyIp(masterIP, nodeRole);
+    rcaController.startPollers();
+
+    // We just want to wait enough so that we all the pollers start up.
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private void initFilePaths() {
+    String cwd = System.getProperty("user.dir");
+    testResourcesPath = Paths.get(cwd, "src", "test", "resources");
+    rcaEnabledFileLoc = Paths.get(testResourcesPath.toString(), "rca");
+    rcaEnabledFile = Paths.get(rcaEnabledFileLoc.toString(), RcaController.getRcaEnabledConfFile());
+    try {
+      testPerformanceAnalyzerLogs = Paths.get(getLogFilePath("PerformanceAnalyzerLog"));
+      testStatsLogs = Paths.get(getLogFilePath("StatsLog"));
+    } catch (ParserConfigurationException e) {
+      e.printStackTrace();
+    } catch (IOException e) {
+      e.printStackTrace();
+    } catch (SAXException e) {
+      e.printStackTrace();
+    } catch (XPathExpressionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private void setMyIp(String ip, AllMetrics.NodeRole nodeRole) {
+    JSONObject jtime = new JSONObject();
+    jtime.put("current_time", 1566414001749L);
+
+    JSONObject jNode = new JSONObject();
+    jNode.put(AllMetrics.NodeDetailColumns.ID.toString(), "4sqG_APMQuaQwEW17_6zwg");
+    jNode.put(AllMetrics.NodeDetailColumns.HOST_ADDRESS.toString(), ip);
+    jNode.put(AllMetrics.NodeDetailColumns.ROLE.toString(), nodeRole);
+    if (nodeRole != AllMetrics.NodeRole.UNKNOWN) {
+      jNode.put(
+          AllMetrics.NodeDetailColumns.IS_MASTER_NODE.toString(),
+          nodeRole == AllMetrics.NodeRole.MASTER);
+    }
+
+    ClusterDetailsEventProcessor eventProcessor = new ClusterDetailsEventProcessor();
+    eventProcessor.processEvent(
+        new Event("", jtime.toString() + System.lineSeparator() + jNode.toString(), 0));
+  }
+
+  private void setDummyEsServer() throws IOException {
+    URI uri = URI.create(RcaController.getCatMasterUrl());
+
+    dummyEsServer =
+        HttpServer.create(
+            new InetSocketAddress(InetAddress.getByName(uri.getHost()), uri.getPort()), 1);
+    dummyEsServer.createContext(
+        "/",
+        exchange -> {
+          String response = "Only supported endpoint is " + uri.getPath();
+          exchange.sendResponseHeaders(200, response.getBytes().length);
+          OutputStream os = exchange.getResponseBody();
+          os.write(response.getBytes());
+          os.close();
+        });
+    dummyEsServer.createContext(
+        uri.getPath(),
+        exchange -> {
+          String response = masterIP;
+          exchange.sendResponseHeaders(200, response.getBytes().length);
+          OutputStream os = exchange.getResponseBody();
+          os.write(response.getBytes());
+          os.close();
+        });
+    dummyEsServer.start();
+    System.out.println("Started dummy endpoint..");
+  }
+
+  private static String getLogFilePath(String filename)
+      throws ParserConfigurationException, IOException, SAXException, XPathExpressionException {
+    String cwd = System.getProperty("user.dir");
+    String testResourcesPath =
+        Paths.get(Paths.get(cwd, "src", "test", "resources").toString(), "log4j2.xml").toString();
+
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    DocumentBuilder builder = factory.newDocumentBuilder();
+    Document doc = builder.parse(testResourcesPath);
+    XPathFactory xPathfactory = XPathFactory.newInstance();
+    XPath xpath = xPathfactory.newXPath();
+    return xpath.evaluate(
+        String.format("Configuration/Appenders/File[@name='%s']/@fileName", filename), doc);
+  }
+
+  public static void cleanUpLogs() {
+      try {
+        Files.deleteIfExists(Paths.get(getLogFilePath("PerformanceAnalyzerLog")));
+        Files.deleteIfExists(Paths.get(getLogFilePath("StatsLog")));
+      } catch (ParserConfigurationException e) {
+        e.printStackTrace();
+      } catch (SAXException e) {
+        e.printStackTrace();
+      } catch (XPathExpressionException e) {
+        e.printStackTrace();
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+  }
+
+  public static List<String> getAllLinesFromStatsLog() {
+    try {
+      return Files.readAllLines(Paths.get(getLogFilePath("StatsLog")));
+    } catch (IOException e) {
+      e.printStackTrace();
+    } catch (ParserConfigurationException e) {
+      e.printStackTrace();
+    } catch (SAXException e) {
+      e.printStackTrace();
+    } catch (XPathExpressionException e) {
+      e.printStackTrace();
+    }
+    return null;
+  }
+
+  public static void printStatsLogs() {
+    try {
+      for (String line: Files.readAllLines(Paths.get(getLogFilePath("StatsLog")))) {
+        System.out.println(line);
+      }
+    } catch (IOException e) {
+      e.printStackTrace();
+    } catch (ParserConfigurationException e) {
+      e.printStackTrace();
+    } catch (SAXException e) {
+      e.printStackTrace();
+    } catch (XPathExpressionException e) {
+      e.printStackTrace();
+    }
+
+  }
+
+  public static List<String> stringExistsInFile(Path file, String pattern) {
+    List<String> files = new ArrayList<>();
+    try {
+      for (String line: Files.readAllLines(file)) {
+        if (line.matches(pattern)) {
+          files.add(line);
+        }
+      }
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return files;
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/SampleAggregatorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/SampleAggregatorTest.java
@@ -1,0 +1,199 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.collectors.aggregator.SampleAggregator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.vals.NamedAggregateValue;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.vals.NamedValue;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.vals.Value;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.format.BaseFormatter;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.format.StatsCollectorFormatter;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.MeasurementSet;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.aggregated.RcaGraphMeasurements;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(GradleTaskForRca.class)
+public class SampleAggregatorTest {
+
+  boolean match(
+      Map<MeasurementSet, Map<Statistics, Value>> map,
+      long longVal,
+      String name,
+      double doubleVal,
+      boolean matchName) {
+    for (Map.Entry<Statistics, Value> s :
+        map.get(RcaGraphMeasurements.GRAPH_NODE_OPERATE_CALL).entrySet()) {
+      if (s.getKey() == Statistics.MAX) {
+        Value v = s.getValue();
+        if (longVal != v.getValue().longValue()) {
+          System.out.println(longVal + " didn't match " + v.getValue().longValue());
+          return false;
+        }
+        if (matchName) {
+          if (v instanceof NamedAggregateValue) {
+            String key = ((NamedAggregateValue) v).getName();
+            if (!key.equals(name)) {
+              System.out.println(key + " didn't match " + name);
+              return false;
+            }
+          } else {
+            Assert.fail();
+          }
+        }
+      } else if (s.getKey() == Statistics.MEAN) {
+        Value v = s.getValue();
+        double c = doubleVal - v.getValue().doubleValue();
+        if (Math.abs(c - 1.0) <= 0.001) {
+          System.out.println(doubleVal + " didn't match " + v.getValue().doubleValue());
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  @Test
+  public void updateStat() {
+    SampleAggregator sampleAggregator = new SampleAggregator(RcaGraphMeasurements.values());
+    sampleAggregator.updateStat(RcaGraphMeasurements.GRAPH_NODE_OPERATE_CALL, "rca1", 200L);
+    sampleAggregator.updateStat(RcaGraphMeasurements.GRAPH_NODE_OPERATE_CALL, "rca2", 400L);
+    sampleAggregator.updateStat(RcaGraphMeasurements.GRAPH_NODE_OPERATE_CALL, "rca1", 200L);
+    sampleAggregator.updateStat(RcaGraphMeasurements.GRAPH_NODE_OPERATE_CALL, "rca2", 100L);
+    sampleAggregator.updateStat(RcaGraphMeasurements.GRAPH_NODE_OPERATE_CALL, "rca0", 200L);
+    sampleAggregator.updateStat(RcaGraphMeasurements.GRAPH_NODE_OPERATE_CALL, "rca3", 500L);
+
+    BaseFormatter formatter = new BaseFormatter();
+    sampleAggregator.fill(formatter);
+    Map<MeasurementSet, Map<Statistics, Value>> map = formatter.getFormatted();
+
+    Assert.assertTrue(match(map, 500, "rca3", 1600.0 / 6, true));
+
+    formatter = new BaseFormatter();
+    sampleAggregator.fillValuesAndReset(formatter);
+    map = formatter.getFormatted();
+    Assert.assertTrue(match(map, 500, "rca3", 1600.0 / 6, true));
+
+    formatter = new BaseFormatter();
+    sampleAggregator.fill(formatter);
+    map = formatter.getFormatted();
+    Assert.assertEquals(0, map.size());
+  }
+
+  @Test
+  public void updateStatsConcurrent() {
+
+    int N = 100000;
+    int T = 1000;
+
+    long[] vals = new long[N];
+
+    long min = Long.MAX_VALUE;
+    long max = Long.MIN_VALUE;
+    double mean = 0;
+    BigInteger sum = BigInteger.ONE;
+
+    Random rand = new Random();
+    for (int i = 0; i < N; i++) {
+      long x = rand.nextLong();
+      vals[i] = x;
+      if (x > max) {
+        max = x;
+      }
+      if (x < min) {
+        min = x;
+      }
+      BigInteger old = sum;
+      sum = sum.add(BigInteger.valueOf(x));
+    }
+    mean = sum.doubleValue() / N;
+
+    SampleAggregator sampleAggregator = new SampleAggregator(RcaGraphMeasurements.values());
+
+    // spin off threads
+
+    Assert.assertTrue(N > T);
+    Assert.assertEquals(0, N % T);
+    int RANGE = N / T;
+
+    List<TestThread> ths = new ArrayList<>();
+    for (int i = 0; i < T; i++) {
+      int start = RANGE * i;
+
+      ths.add(new TestThread(vals, start, RANGE, sampleAggregator));
+    }
+    for (TestThread th : ths) {
+      th.start();
+    }
+
+    for (TestThread th : ths) {
+      try {
+        th.join();
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+    }
+
+    BaseFormatter formatter = new BaseFormatter();
+    sampleAggregator.fill(formatter);
+    Map<MeasurementSet, Map<Statistics, Value>> map = formatter.getFormatted();
+    Assert.assertTrue(match(map, max, "", mean, false));
+  }
+
+  @Test
+  public void dumpStats() {
+    Map<String, String> map = new HashMap<>();
+    map.put("m1", "v1");
+    map.put("m2", "v2");
+
+    StatsCollector statsCollector = new StatsCollector("stats", 1, map);
+
+    SampleAggregator sampleAggregator = new SampleAggregator(RcaGraphMeasurements.values());
+    sampleAggregator.updateStat(RcaGraphMeasurements.GRAPH_NODE_OPERATE_CALL, "rca1", 200L);
+    sampleAggregator.updateStat(RcaGraphMeasurements.GRAPH_NODE_OPERATE_CALL, "rca2", 400L);
+    sampleAggregator.updateStat(RcaGraphMeasurements.GRAPH_NODE_OPERATE_CALL, "rca1", 200L);
+    sampleAggregator.updateStat(RcaGraphMeasurements.GRAPH_NODE_OPERATE_CALL, "rca2", 100L);
+    sampleAggregator.updateStat(RcaGraphMeasurements.GRAPH_NODE_OPERATE_CALL, "rca0", 200L);
+    sampleAggregator.updateStat(RcaGraphMeasurements.GRAPH_NODE_OPERATE_CALL, "rca3", 500L);
+
+    StatsCollectorFormatter formatter = new StatsCollectorFormatter();
+    sampleAggregator.fillValuesAndReset(formatter);
+    StatsCollectorFormatter.StatsCollectorReturn statsReturn = formatter.getFormatted();
+    statsCollector.logStatsRecord(
+            statsReturn.getCounters(),
+            statsReturn.getStatsdata(),
+            statsReturn.getLatencies(),
+            statsReturn.getStartTimeMillis(),
+            statsReturn.getEndTimeMillis());
+  }
+
+  class TestThread extends Thread {
+    SampleAggregator sampleAggregator;
+    long[] arr;
+    private int start;
+    private int end;
+
+    TestThread(long[] arr, int idx, int range, SampleAggregator sampleAggregator) {
+      this.start = idx;
+      this.end = start + range;
+      this.sampleAggregator = sampleAggregator;
+      this.arr = arr;
+    }
+
+    @Override
+    public void run() {
+      for (int i = start; i < end; i++) {
+        sampleAggregator.updateStat(
+            RcaGraphMeasurements.GRAPH_NODE_OPERATE_CALL, "th" + start, arr[i]);
+      }
+    }
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/emitters/PeriodicSamplersTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/emitters/PeriodicSamplersTest.java
@@ -1,0 +1,42 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.emitters;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaTestFrameworkSetup;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.MeasurementSet;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.measurements.sampled.JvmMeasurements;
+import java.util.HashMap;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(GradleTaskForRca.class)
+public class PeriodicSamplersTest {
+  @Before
+  public void cleanup() {
+    RcaTestFrameworkSetup.cleanUpLogs();
+  }
+
+  class TestStatsCollector extends StatsCollector {
+    TestStatsCollector() {
+      super("stats", 1, new HashMap<>());
+    }
+  }
+
+  @Test
+  public void emitters() {
+    TestStatsCollector tsc = new TestStatsCollector();
+
+    PeriodicSamplers periodicSamplers =
+        new PeriodicSamplers(PerformanceAnalyzerApp.SYSTEM_RESOURCE_SAMPLER);
+    periodicSamplers.run();
+    for (MeasurementSet measurementSet : JvmMeasurements.values()) {
+      Assert.assertTrue(
+          PerformanceAnalyzerApp.SYSTEM_RESOURCE_SAMPLER.isMeasurementObserved(measurementSet));
+    }
+    tsc.collectMetrics(0);
+    RcaTestFrameworkSetup.printStatsLogs();
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/NamedCounterTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/stats/eval/impl/NamedCounterTest.java
@@ -1,0 +1,99 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.stats.eval.impl.vals.NamedAggregateValue;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NamedCounterTest {
+
+  @Test
+  public void calculate() {
+    NamedCounter namedCounter = new NamedCounter();
+    namedCounter.calculate("x", 20);
+    namedCounter.calculate("x", 20);
+    namedCounter.calculate("x", 20);
+    namedCounter.calculate("y", 20);
+    namedCounter.calculate("y", 20);
+    namedCounter.calculate("z", 20);
+
+    for (NamedAggregateValue v : namedCounter.get()) {
+      if (v.getName().equals("x")) {
+        Assert.assertEquals(3L, v.getValue());
+      } else if (v.getName().equals("y")) {
+        Assert.assertEquals(2L, v.getValue());
+      } else if (v.getName().equals("z")) {
+        Assert.assertEquals(1L, v.getValue());
+      }
+    }
+  }
+
+  @Test
+  public void concurrentCalculate() {
+    int N = 2000000;
+    int countOfEach = 5000;
+
+    int differentKeys = N / countOfEach;
+    String[] arr = new String[N];
+
+    for (int i = 0; i < differentKeys; i++) {
+      String name = "x" + i;
+      for (int j = i; j < N; j += differentKeys) {
+        arr[j] = name;
+      }
+    }
+
+    NamedCounter namedCounter = new NamedCounter();
+    Th[] threads = new Th[countOfEach];
+
+    int thi = 0;
+    for (int i = 0; i < N; i += differentKeys, thi++) {
+      threads[thi] = new Th(arr, i, differentKeys, namedCounter);
+    }
+
+    for (int i = 0; i < thi; i++) {
+      threads[i].start();
+    }
+
+    for (int i = 0; i < thi; i++) {
+      try {
+        threads[i].join();
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+    }
+
+    for (NamedAggregateValue value : namedCounter.get()) {
+      boolean found = false;
+      for (int i = 0; i < differentKeys; i++) {
+        String name = "x" + i;
+        if (name.equals(value.getName())) {
+          Assert.assertEquals((long) countOfEach, value.getValue());
+          found = true;
+          break;
+        }
+      }
+      Assert.assertTrue(found);
+    }
+  }
+
+  class Th extends Thread {
+    String[] arr;
+    int start;
+    int delta;
+    NamedCounter namedCounter;
+
+    Th(String[] arr, int start, int delta, NamedCounter counter) {
+      this.arr = arr;
+      this.start = start;
+      this.delta = delta;
+      this.namedCounter = counter;
+    }
+
+    public void run() {
+      for (int i = start; i < start + delta; i++) {
+        namedCounter.calculate(arr[i], 0);
+        // System.out.println(Thread.currentThread().getId() + ": "+arr[i]);
+      }
+    }
+  }
+}

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -4,10 +4,12 @@
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
         </Console>
-        <File name="PerformanceAnalyzerLog" fileName="/tmp/PerformanceAnalyzer.log" immediateFlush="true" append="true">
+        <File name="PerformanceAnalyzerLog" fileName="/tmp/PerformanceAnalyzer.test.log"
+              immediateFlush="true" append="true">
             <PatternLayout pattern="%d{yyy-MM-dd HH:mm:ss.SSS} [PA:Reader] [%t] %-5level %logger{36} - %msg%n"/>
         </File>
-        <File name="StatsLog" fileName="/tmp/performance_analyzer_agent_stats.log" immediateFlush="true" append="true">
+        <File name="StatsLog" fileName="/tmp/performance_analyzer_agent_stats.test.log"
+              immediateFlush="true" append="true">
         </File>
     </Appenders>
     <Loggers>


### PR DESCRIPTION
Issue #, if available: #52

Description of changes:
This change adds a framework to the health of the RCA framework. The details can be found here.
The metrics added as part of this are:
Graph execution related:

    Time spent in the operate() call (Max, min)
    Time spent in getting the metrics for the metric nodes (max, mean)
    Time spent in making persisting RCAs (max, mean)
    Number of graph nodes
    Graph nodes executed locally
    Graph nodes executed remotely.

Framework related:

    total time to execute the graph (max, min, mean, count)
    Flow units sent to wirehopper (count)
    flow units sent across the wire (count)
    RCA stopped by operator (count)
    RCA restarted by operator (count)
    ES api calls (count)

Error types:

    RCA framework crash
    Exceptions thrown in operate method

Periodic samples:

    Jvm free memory
    JVM total memory
    Total JVM thread count

Tests:
Added new test cases. Still adding more tests.

Code coverage percentage for this patch:
The newly added stats package is 80% covered.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.