### PR TITLE
Use WildCardFilter instead of Filename filter to avoid listing all th…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -227,6 +227,7 @@ dependencies {
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.13.0'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.13.0'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
+    compile group: 'commons-io', name: 'commons-io', version: '2.3'
     implementation 'io.grpc:grpc-netty-shaded:1.25.0'
     implementation 'io.grpc:grpc-protobuf:1.25.0'
     implementation 'io.grpc:grpc-stub:1.25.0'


### PR DESCRIPTION
*Description of changes:* Use WildCardFilter instead of Filename filter to avoid listing all the files in the log directory of rca.sqlite

*Tests:* 
Performance Comparison for different strategy of getting old rca.sqlite file in the log directory
Current Code Performance - Time Elapsed: 11 ms
With NIO DirectoryStream - Time Elapsed: 7 ms
With WildCardFileFilter Elapsed: 5 ms

This has been tested for about 200 files in the folder. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
