### PR TITLE
Ktkrg multi locus fetch

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -27,6 +27,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.MetricsDBProvider;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Queryable;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Stats;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.ThresholdMain;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaUtil;
@@ -346,6 +347,7 @@ public class RcaController {
     rcaNetClient.shutdown();
     rcaNetServer.shutdown();
     removeRcaRequestHandler();
+    Stats.getInstance().reset();
   }
 
   private void restart() {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/Metric.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/Metric.java
@@ -21,7 +21,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.LeafNode;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Queryable;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
-import java.util.Collections;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -73,7 +72,7 @@ public abstract class Metric extends LeafNode<MetricFlowUnit> {
   }
 
   public void generateFlowUnitListFromLocal(FlowUnitOperationArgWrapper args) {
-    setFlowUnits(Collections.singletonList(gather(args.getQueryable())));
+    setLocalFlowUnit(gather(args.getQueryable()));
   }
 
   /**

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Node.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Node.java
@@ -51,11 +51,14 @@ public abstract class Node<T extends GenericFlowUnit> {
   protected long evaluationIntervalSeconds;
 
   /**
-   * List of flow units produced by this node obtained either from evaluating it locally or
-   * obtaining them from other nodes in the cluster.
+   * List of flow units produced by this node obtained from evaluating other nodes in the cluster.
    */
   protected List<T> flowUnits;
 
+  /**
+   * Flow unit produced by this vertex obtained from evaluating it locally.
+   */
+  protected T localFlowUnit;
   /**
    * These are matched against the tags in the rca.conf, to determine if a node is to executed at a
    * location.
@@ -136,16 +139,30 @@ public abstract class Node<T extends GenericFlowUnit> {
     flowUnits = Collections.emptyList();
   }
 
+  public void setEmptyLocalFlowUnit() {
+    this.localFlowUnit = null;
+  }
+
   @Override
   public String toString() {
     return name();
   }
 
   public List<T> getFlowUnits() {
-    return flowUnits;
+    List<T> allFlowUnits = flowUnits == null ? new ArrayList<>() : new ArrayList<>(flowUnits);
+
+    if (localFlowUnit != null) {
+      allFlowUnits.add(localFlowUnit);
+    }
+
+    return allFlowUnits;
   }
 
   public void setFlowUnits(List<T> flowUnits) {
     this.flowUnits = flowUnits;
+  }
+
+  public void setLocalFlowUnit(T localFlowUnit) {
+    this.localFlowUnit = localFlowUnit;
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/RcaConsts.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/RcaConsts.java
@@ -53,4 +53,18 @@ public class RcaConsts {
   public static final long rcaConfPollerPeriodicity = 5;
   public static final long nodeRolePollerPeriodicity = 60;
   public static final TimeUnit rcaPollerPeriodicityTimeUnit = TimeUnit.SECONDS;
+
+  /**
+   * Class defining constants that are mostly used in tag assignment and comparison context.
+   */
+  public static class RcaTagConstants {
+
+    public static final String SEPARATOR = ",";
+
+    public static final String TAG_LOCUS = "locus";
+    public static final String TAG_AGGREGATE_UPSTREAM = "aggregate-upstream";
+
+    public static final String LOCUS_DATA_NODE = "data-node";
+    public static final String LOCUS_MASTER_NODE = "master-node";
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/RcaUtil.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/RcaUtil.java
@@ -78,10 +78,10 @@ public class RcaUtil {
 
     if (confTagMap != null && nodeTagMap != null) {
       final String hostLocus = confTagMap.get(RcaTagConstants.TAG_LOCUS);
-
-      return Arrays.asList(nodeTagMap.get(RcaTagConstants.TAG_LOCUS)
-                                     .split(RcaTagConstants.SEPARATOR))
-                   .contains(hostLocus);
+      final String nodeLoci = nodeTagMap.get(RcaTagConstants.TAG_LOCUS);
+      if (nodeLoci != null && !nodeLoci.isEmpty()) {
+        return Arrays.asList(nodeLoci.split(RcaTagConstants.SEPARATOR)).contains(hostLocus);
+      }
     }
 
     // By default, if no tags are specified, execute the nodes locally.

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/RcaUtil.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/RcaUtil.java
@@ -15,12 +15,12 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util;
 
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.AnalysisGraph;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.ConnectedComponent;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Stats;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts.RcaTagConstants;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.List;
@@ -34,21 +34,21 @@ public class RcaUtil {
 
   private static AnalysisGraph getAnalysisGraphImplementor(RcaConf rcaConf)
       throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException,
-          InvocationTargetException, InstantiationException {
+      InvocationTargetException, InstantiationException {
     return (AnalysisGraph)
         Class.forName(rcaConf.getAnalysisGraphEntryPoint()).getDeclaredConstructor().newInstance();
   }
 
   public static List<ConnectedComponent> getAnalysisGraphComponents(RcaConf rcaConf)
       throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException,
-          InstantiationException, IllegalAccessException {
+      InstantiationException, IllegalAccessException {
     AnalysisGraph graph = getAnalysisGraphImplementor(rcaConf);
     return getAnalysisGraphComponents(graph);
   }
 
   public static List<ConnectedComponent> getAnalysisGraphComponents(String analysisGraphClass)
       throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException,
-          InstantiationException, IllegalAccessException {
+      InstantiationException, IllegalAccessException {
     AnalysisGraph graph =
         (AnalysisGraph) Class.forName(analysisGraphClass).getDeclaredConstructor().newInstance();
     graph.construct();
@@ -69,6 +69,22 @@ public class RcaUtil {
       return tag.getValue() != null
           && Arrays.asList(tag.getValue().split(",")).contains(rcaConfTagvalue);
     }
+    return true;
+  }
+
+  public static boolean shouldExecuteLocally(Node<?> node, RcaConf conf) {
+    final Map<String, String> confTagMap = conf.getTagMap();
+    final Map<String, String> nodeTagMap = node.getTags();
+
+    if (confTagMap != null && nodeTagMap != null) {
+      final String hostLocus = confTagMap.get(RcaTagConstants.TAG_LOCUS);
+
+      return Arrays.asList(nodeTagMap.get(RcaTagConstants.TAG_LOCUS)
+                                     .split(RcaTagConstants.SEPARATOR))
+                   .contains(hostLocus);
+    }
+
+    // By default, if no tags are specified, execute the nodes locally.
     return true;
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/SubscriptionManager.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/SubscriptionManager.java
@@ -91,7 +91,7 @@ public class SubscriptionManager {
    * @param subscriberHostAddress The host that wants to subscribe.
    * @param loci                  The locus which the subscribing host is interested in.
    * @return A SubscriptionStatus protobuf message that contains the status for the subscription
-   * request.
+   *         request.
    */
   public synchronized SubscriptionStatus addSubscriber(
       final String graphNode, final String subscriberHostAddress, final String loci) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/SubscriptionManager.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/SubscriptionManager.java
@@ -20,7 +20,9 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeRes
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeResponse.SubscriptionStatus;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.GRPCConnectionManager;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetClient;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts.RcaTagConstants;
 import io.grpc.stub.StreamObserver;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -102,9 +104,10 @@ public class SubscriptionManager {
   }
 
   public SubscriptionStatus addSubscriber(
-      final String graphNode, final String subscriberHostAddress, final String locus) {
-    if (!currentLocus.equals(locus)) {
-      LOG.debug("locus mismatch. Rejecting subscription. Req: {}, Curr: {}", locus, currentLocus);
+      final String graphNode, final String subscriberHostAddress, final String loci) {
+    final List<String> vertexLoci = Arrays.asList(loci.split(RcaTagConstants.SEPARATOR));
+    if (!vertexLoci.contains(currentLocus)) {
+      LOG.debug("locus mismatch. Rejecting subscription. Req: {}, Curr: {}", loci, currentLocus);
       return SubscriptionStatus.TAG_MISMATCH;
     }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/handler/SubscribeServerHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/handler/SubscribeServerHandler.java
@@ -18,6 +18,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.handler;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeResponse;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeResponse.SubscriptionStatus;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts.RcaTagConstants;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.SubscriptionManager;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.WireHopper;
 import io.grpc.stub.StreamObserver;
@@ -29,7 +30,6 @@ public class SubscribeServerHandler {
   private static final Logger LOG = LogManager.getLogger(SubscribeServerHandler.class);
   private static final String EMPTY_STRING = "";
   private static final String REQUESTER_KEY = "requester";
-  private static final String LOCUS_KEY = "locus";
 
   private final WireHopper hopper;
   private final SubscriptionManager subscriptionManager;
@@ -48,7 +48,7 @@ public class SubscribeServerHandler {
         request.getRequesterNode());
     final Map<String, String> tags = request.getTagsMap();
     final String requesterHostAddress = tags.getOrDefault(REQUESTER_KEY, EMPTY_STRING);
-    final String locus = tags.getOrDefault(LOCUS_KEY, EMPTY_STRING);
+    final String locus = tags.getOrDefault(RcaTagConstants.TAG_LOCUS, EMPTY_STRING);
     //        final boolean subscriptionStatus =
     // hopper.addSubscription(request.getDestinationNode(), requesterHostAddress, locus);
     final SubscriptionStatus subscriptionStatus =

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/Tasklet.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/Tasklet.java
@@ -97,6 +97,7 @@ public class Tasklet {
     if (ticks % node.getEvaluationIntervalSeconds() != 0) {
       // If its not time to run this tasklet, return an isEmpty flowUnit.
       node.setEmptyFlowUnitList();
+      node.setEmptyLocalFlowUnit();
       return CompletableFuture.supplyAsync(() -> new TaskletResult(node.getClass()));
     }
 
@@ -124,7 +125,7 @@ public class Tasklet {
                   exec.accept(new FlowUnitOperationArgWrapper(node, db, persistable, hopper));
 
                   sendToRemote();
-                  LOG.debug("RCA: set Node %s 's Flow unit", node.name());
+                  LOG.debug("RCA: set Node {}'s Flow unit", node.name());
                   return new TaskletResult(node.getClass());
                 },
                 executorPool)

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/DummyGraph.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/DummyGraph.java
@@ -23,6 +23,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.GC_Collection_Time;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Max;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Used;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts.RcaTagConstants;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HighHeapUsageClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HotNodeRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotheap.HighHeapUsageOldGenRca;
@@ -43,25 +44,38 @@ public class DummyGraph extends AnalysisGraph {
     Metric heapMax = new Heap_Max(5);
     Metric gc_Collection_Time = new GC_Collection_Time(5);
 
-    heapUsed.addTag(LOCUS, DATA_NODE);
-    gcEvent.addTag(LOCUS, DATA_NODE);
-    heapMax.addTag(LOCUS, DATA_NODE);
-    gc_Collection_Time.addTag(LOCUS, DATA_NODE);
+    heapUsed.addTag(LOCUS, String.join(RcaTagConstants.SEPARATOR, RcaTagConstants.LOCUS_DATA_NODE,
+        RcaTagConstants.LOCUS_MASTER_NODE));
+    gcEvent.addTag(LOCUS, String.join(RcaTagConstants.SEPARATOR, RcaTagConstants.LOCUS_DATA_NODE,
+        RcaTagConstants.LOCUS_MASTER_NODE));
+    heapMax.addTag(LOCUS, String.join(RcaTagConstants.SEPARATOR, RcaTagConstants.LOCUS_DATA_NODE,
+        RcaTagConstants.LOCUS_MASTER_NODE));
+    gc_Collection_Time
+        .addTag(LOCUS, String.join(RcaTagConstants.SEPARATOR, RcaTagConstants.LOCUS_DATA_NODE,
+            RcaTagConstants.LOCUS_MASTER_NODE));
     addLeaf(heapUsed);
     addLeaf(gcEvent);
     addLeaf(heapMax);
     addLeaf(gc_Collection_Time);
 
-    Rca<ResourceFlowUnit> highHeapUsageOldGenRca = new HighHeapUsageOldGenRca(12, heapUsed, gcEvent, heapMax);
-    highHeapUsageOldGenRca.addTag(LOCUS, DATA_NODE);
+    Rca<ResourceFlowUnit> highHeapUsageOldGenRca = new HighHeapUsageOldGenRca(12, heapUsed, gcEvent,
+        heapMax);
+    highHeapUsageOldGenRca.addTag(LOCUS,
+        String.join(RcaTagConstants.SEPARATOR,
+            RcaTagConstants.LOCUS_DATA_NODE,
+            RcaTagConstants.LOCUS_MASTER_NODE));
     highHeapUsageOldGenRca.addAllUpstreams(Arrays.asList(heapUsed, gcEvent, heapMax));
 
-    Rca<ResourceFlowUnit> highHeapUsageYoungGenRca = new HighHeapUsageYoungGenRca(12, heapUsed, gc_Collection_Time);
-    highHeapUsageYoungGenRca.addTag(LOCUS, DATA_NODE);
+    Rca<ResourceFlowUnit> highHeapUsageYoungGenRca = new HighHeapUsageYoungGenRca(12, heapUsed,
+        gc_Collection_Time);
+    highHeapUsageYoungGenRca.addTag(LOCUS, String.join(RcaTagConstants.SEPARATOR,
+        RcaTagConstants.LOCUS_DATA_NODE, RcaTagConstants.LOCUS_MASTER_NODE));
     highHeapUsageYoungGenRca.addAllUpstreams(Arrays.asList(heapUsed, gc_Collection_Time));
 
-    Rca<ResourceFlowUnit> hotJVMNodeRca = new HotNodeRca(12, highHeapUsageOldGenRca, highHeapUsageYoungGenRca);
-    hotJVMNodeRca.addTag(LOCUS, DATA_NODE);
+    Rca<ResourceFlowUnit> hotJVMNodeRca = new HotNodeRca(12, highHeapUsageOldGenRca,
+        highHeapUsageYoungGenRca);
+    hotJVMNodeRca.addTag(LOCUS, String.join(RcaTagConstants.SEPARATOR,
+        RcaTagConstants.LOCUS_DATA_NODE, RcaTagConstants.LOCUS_MASTER_NODE));
     hotJVMNodeRca.addAllUpstreams(Arrays.asList(highHeapUsageOldGenRca, highHeapUsageYoungGenRca));
 
     Rca<ResourceFlowUnit> highHeapUsageClusterRca =

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/HighHeapUsageYoungGenRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/HighHeapUsageYoungGenRcaTest.java
@@ -52,7 +52,9 @@ public class HighHeapUsageYoungGenRcaTest {
     Mockito.when(System.currentTimeMillis()).thenReturn(TimeUnit.SECONDS.toMillis(timeStampInSecond));
     //generate empty flowunit and run operate enough times before evaluating RCA
     heap_Used.setEmptyFlowUnitList();
+    heap_Used.setEmptyLocalFlowUnit();
     gc_Collection_Time.setEmptyFlowUnitList();
+    gc_Collection_Time.setEmptyLocalFlowUnit();
     //generate flowunit
     heap_Used.createTestFlowUnits(columnName, Arrays.asList("OldGen", String.valueOf(heapUsageVal * CONVERT_BYTES_TO_MEGABYTES)));
     gc_Collection_Time.createTestFlowUnits(columnName, Arrays.asList("totYoungGC", String.valueOf(gcCollectionTimeVal)));


### PR DESCRIPTION
*Issue #, if available:* #64  

*Description of changes:*

This change will allow vertices to consume flow units for an upstream vertex from both itself and from remote nodes.

Prior to this change, if a node computed an upstream vertex locally, it could only use the flow unit generated by local computation of the upstream vertex. Or, if the upstream vertex was computed remotely, it could only use flow units computed remotely.

This meant that we needed different graphs to support different ES configurations. This change lets the users define an aggregation locus for each vertex and the support to run on different loci .
*Tests:*
* Tested on a single node cluster: ensured that RCA tables were generated fine.
* Tested on a multi node cluster: ensured that RCA tables included data from itself and other members of the cluster.

*Code coverage percentage for this patch:*
54% line coverage, 47% branch coverage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
