### PR TITLE
Fix race condition between get() and remove()

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/net/GRPCConnectionManager.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/net/GRPCConnectionManager.java
@@ -72,8 +72,10 @@ public class GRPCConnectionManager {
    */
   public InterNodeRpcServiceStub getClientStubForHost(
       final String remoteHost) {
-    if (perHostClientStubMap.containsKey(remoteHost)) {
-      return perHostClientStubMap.get(remoteHost).get();
+    final AtomicReference<InterNodeRpcServiceStub> stubAtomicReference =
+        perHostClientStubMap.get(remoteHost);
+    if (stubAtomicReference != null) {
+      return stubAtomicReference.get();
     }
     return addOrUpdateClientStubForHost(remoteHost);
   }
@@ -99,8 +101,10 @@ public class GRPCConnectionManager {
   }
 
   private ManagedChannel getChannelForHost(final String remoteHost) {
-    if (perHostChannelMap.containsKey(remoteHost)) {
-      return perHostChannelMap.get(remoteHost).get();
+    final AtomicReference<ManagedChannel> managedChannelAtomicReference = perHostChannelMap
+        .get(remoteHost);
+    if (managedChannelAtomicReference != null) {
+      return managedChannelAtomicReference.get();
     }
 
     return addOrUpdateChannelForHost(remoteHost);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/net/NetClient.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/net/NetClient.java
@@ -135,8 +135,10 @@ public class NetClient {
 
   private StreamObserver<FlowUnitMessage> getDataStreamForHost(
       final String remoteHost, final StreamObserver<PublishResponse> serverResponseStream) {
-    if (perHostOpenDataStreamMap.containsKey(remoteHost)) {
-      return perHostOpenDataStreamMap.get(remoteHost).get();
+    final AtomicReference<StreamObserver<FlowUnitMessage>> streamObserverAtomicReference =
+        perHostOpenDataStreamMap.get(remoteHost);
+    if (streamObserverAtomicReference != null) {
+      return streamObserverAtomicReference.get();
     }
     return addOrUpdateDataStreamForHost(remoteHost, serverResponseStream);
   }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -389,6 +389,9 @@ public class RcaController {
     } catch (InterruptedException e) {
       LOG.warn("Awaiting termination interrupted. {}", e.getCause(), e);
       networkThreadPoolReference.get().shutdownNow();
+      // Set the thread's interrupt interrupt flag so that higher level interrupt handlers can
+      // take appropriate actions.
+      Thread.currentThread().interrupt();
     }
     removeRcaRequestHandler();
     Stats.getInstance().reset();


### PR DESCRIPTION
*Description of changes:*
Fix a race condition between get() and remove() on a concurrent map key which can happen in an extreme corner case. This can happen when we are shutting down a connection, and while we are shutting down, we try to send a flow unit.

*Tests:*
docker tested.

*Code coverage percentage for this patch:*
54% line, 47% branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
