### PR TITLE
Set up to emit and report RcaMetrics

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerApp.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerApp.java
@@ -21,13 +21,22 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsC
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.TroubleshootingConfig;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.core.Util;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsRestUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.GRPCConnectionManager;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetClient;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetServer;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaController;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.JvmMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaRuntimeMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.sys.AllJvmSamplers;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.RcaStatsReporter;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.collectors.SampleAggregator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.emitters.PeriodicSamplers;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ReaderMetricsProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rest.QueryMetricsRequestHandler;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -39,8 +48,10 @@ import java.net.InetSocketAddress;
 import java.security.KeyStore;
 import java.security.Security;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.KeyManagerFactory;
@@ -68,6 +79,26 @@ public class PerformanceAnalyzerApp {
 
   private static RcaController rcaController = null;
   private static Thread rcaNetServerThread = null;
+
+  public static final SampleAggregator RCA_GRAPH_METRICS_AGGREGATOR =
+          new SampleAggregator(RcaGraphMetrics.values());
+  public  static final SampleAggregator RCA_RUNTIME_METRICS_AGGREGATOR =
+          new SampleAggregator(RcaRuntimeMetrics.values());
+
+  public static final SampleAggregator ERRORS_AND_EXCEPTIONS_AGGREGATOR =
+          new SampleAggregator(ExceptionsAndErrors.values());
+
+  public static final SampleAggregator JVM_METRICS_AGGREGATOR =
+          new SampleAggregator(JvmMetrics.values());
+
+  public static final RcaStatsReporter RCA_STATS_REPORTER =
+          new RcaStatsReporter(Arrays.asList(RCA_GRAPH_METRICS_AGGREGATOR,
+                  RCA_RUNTIME_METRICS_AGGREGATOR, ERRORS_AND_EXCEPTIONS_AGGREGATOR,
+                  JVM_METRICS_AGGREGATOR));
+  private static final PeriodicSamplers PERIODIC_SAMPLERS =
+          new PeriodicSamplers(JVM_METRICS_AGGREGATOR, AllJvmSamplers.getJvmSamplers(),
+                  (MetricsConfiguration.CONFIG_MAP.get(StatsCollector.class).samplingInterval) / 2,
+                  TimeUnit.MILLISECONDS);
 
   public static void main(String[] args) throws Exception {
     // Initialize settings before creating threads.

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatsCollector.java
@@ -120,13 +120,18 @@ public class StatsCollector extends PerformanceAnalyzerMetricsCollector {
     return retVal;
   }
 
-  private StatsCollector(Map<String, String> metadata) {
-    super(
-        MetricsConfiguration.CONFIG_MAP.get(StatsCollector.class).samplingInterval,
-        "StatsCollector");
+  public StatsCollector(String name, int samplingIntervalMillis, Map<String, String> metadata) {
+    super(samplingIntervalMillis, name);
     this.metadata = metadata;
     addRcaVersionMetadata(this.metadata);
     defaultExceptionCodes.add(StatExceptionCode.TOTAL_ERROR);
+  }
+
+  private StatsCollector(Map<String, String> metadata) {
+    this(
+        "StatsCollector",
+        MetricsConfiguration.CONFIG_MAP.get(StatsCollector.class).samplingInterval,
+        metadata);
   }
 
   public void addDefaultExceptionCode(StatExceptionCode statExceptionCode) {
@@ -257,16 +262,16 @@ public class StatsCollector extends PerformanceAnalyzerMetricsCollector {
     do {
       StatsCollectorFormatter formatter = new StatsCollectorFormatter();
       hasNext = PerformanceAnalyzerApp.RCA_STATS_REPORTER.getNextReport(formatter);
-      StatsCollectorFormatter.StatsCollectorReturn statsReturn = formatter.getFormatted();
-      if (!statsReturn.isEmpty()) {
-        logStatsRecord(
-                statsReturn.getCounters(),
-                statsReturn.getStatsdata(),
-                statsReturn.getLatencies(),
-                statsReturn.getStartTimeMillis(),
-                statsReturn.getEndTimeMillis());
+      for (StatsCollectorFormatter.StatsCollectorReturn statsReturn : formatter.getAllMetrics()) {
+        if (!statsReturn.isEmpty()) {
+          logStatsRecord(
+              statsReturn.getCounters(),
+              statsReturn.getStatsdata(),
+              statsReturn.getLatencies(),
+              statsReturn.getStartTimeMillis(),
+              statsReturn.getEndTimeMillis());
+        }
       }
     } while (hasNext);
   }
-
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.core.Util;
@@ -30,6 +31,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Stats;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.ThresholdMain;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaRuntimeMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.NodeStateManager;
@@ -258,9 +260,13 @@ public class RcaController {
             if (!rcaEnabled) {
               // Need to shutdown the rca scheduler
               stop();
+              PerformanceAnalyzerApp.RCA_RUNTIME_METRICS_AGGREGATOR.updateStat(
+                      RcaRuntimeMetrics.RCA_STOPPED_BY_OPERATOR, "", 1);
             } else {
               if (rcaScheduler.getRole() != currentRole) {
                 restart();
+                PerformanceAnalyzerApp.RCA_RUNTIME_METRICS_AGGREGATOR.updateStat(
+                        RcaRuntimeMetrics.RCA_RESTARTED_BY_OPERATOR, "", 1);
               }
             }
           } else {
@@ -282,6 +288,9 @@ public class RcaController {
   private String getElectedMasterHostAddress() {
     try {
       LOG.info("Making _cat/master call");
+      PerformanceAnalyzerApp.RCA_RUNTIME_METRICS_AGGREGATOR.updateStat(
+              RcaRuntimeMetrics.ES_APIS_CALLED, "catMaster", 1);
+
       final URL url = new URL(CAT_MASTER_URL);
       HttpURLConnection connection = (HttpURLConnection) url.openConnection();
       connection.setRequestMethod("GET");

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/Version.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/Version.java
@@ -42,7 +42,9 @@ public final class Version {
     static final String RCA_MINOR_VERSION = ".0.1";
   }
 
-  /** @return The version string. */
+  /**
+   * @return The version string.
+   */
   public static String getRcaVersion() {
     return Major.RCA_MAJ_VERSION + Minor.RCA_MINOR_VERSION;
   }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/Version.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/Version.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca;
+
+/**
+ * The version of the RCA framework and the graphs combined. The version is a combination of the
+ * major and the minor versions together.
+ */
+public final class Version {
+  // This will hopefully never change.
+  public static final String RCA_VERSION_STR = "rca-version";
+
+  /**
+   * An increase in the major version means that the flow units are in-compatible and if different
+   * instances(physical nodes) are running different versions of the framework, then the transferred
+   * packets should be dropped. Every increment here should be accompanied with a line of note.
+   */
+  final class Major {
+    static final int RCA_MAJ_VERSION = 0;
+  }
+
+  /**
+   * This is expected to increment with each noticeable change in the framework and also with
+   * addition of new RCAs or enhancement of the old ones. But given this, we don't expect the minor
+   * version to change for every single release and each increment should have a line stating what
+   * changed.
+   */
+  final class Minor {
+    static final String RCA_MINOR_VERSION = ".0.1";
+  }
+
+  /** @return The version string. */
+  public static String getRcaVersion() {
+    return Major.RCA_MAJ_VERSION + Minor.RCA_MINOR_VERSION;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/formatter/StatsCollectorFormatter.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/formatter/StatsCollectorFormatter.java
@@ -1,0 +1,206 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.formatter;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaRuntimeMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.format.Formatter;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class StatsCollectorFormatter implements Formatter {
+  static final char SEPARATOR = '-';
+  static List<MeasurementSet> LATENCIES =
+      Arrays.asList(
+          RcaRuntimeMetrics.GRAPH_EXECUTION_TIME,
+          RcaGraphMetrics.GRAPH_NODE_OPERATE_CALL,
+          RcaGraphMetrics.METRIC_GATHER_CALL,
+          RcaGraphMetrics.RCA_PERSIST_CALL);
+  StatsCollectorReturn formattedValue;
+
+  public StatsCollectorReturn getFormatted() {
+    return formattedValue;
+  }
+
+  private boolean formatException(MeasurementSet measurement, String name, Number counter) {
+    for (MeasurementSet measure : ExceptionsAndErrors.values()) {
+      if (measurement == measure) {
+        if (name.isEmpty()) {
+          formattedValue.putCounter(measurement.getName(), counter.intValue());
+        } else {
+          formattedValue.putCounter(
+              new StringBuilder(measurement.getName())
+                  .append(SEPARATOR)
+                  .append(name.replaceAll(" ", "_"))
+                  .toString(),
+              counter.intValue());
+        }
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean formatSamples(MeasurementSet given, Number values, Statistics aggr) {
+    if (aggr == Statistics.SAMPLE) {
+      formattedValue.putStats(given.getName(), String.valueOf(values));
+      return true;
+    }
+    return false;
+  }
+
+  private boolean formatCounters(
+      MeasurementSet measurementSet, Number values, Statistics aggr, String name) {
+    boolean found = false;
+    if (aggr == Statistics.COUNT) {
+      formattedValue.putCounter(measurementSet.getName(), values.intValue());
+      found = true;
+    } else if (aggr == Statistics.NAMED_COUNTERS) {
+      formattedValue.putCounter(
+          new StringBuilder(measurementSet.getName())
+              .append(SEPARATOR)
+              .append(name.replaceAll(" ", "_"))
+              .toString(),
+          values.intValue());
+      found = true;
+    }
+    return found;
+  }
+
+  private boolean formatLatencies(
+      MeasurementSet given, Number value, Statistics aggr, String name) {
+    if (aggr == Statistics.NAMED_COUNTERS
+        || aggr == Statistics.NAMED_COUNTERS
+        || aggr == Statistics.SAMPLE) {
+      return false;
+    }
+    for (MeasurementSet aggregateMeasurements : LATENCIES) {
+      if (aggregateMeasurements == given) {
+        StringBuilder stringBuilder = new StringBuilder(given.getName());
+        stringBuilder.append(SEPARATOR).append(aggr);
+        stringBuilder.append(SEPARATOR).append(given.getUnit());
+        if (!name.isEmpty()) {
+          stringBuilder.append(SEPARATOR).append(name);
+        }
+        formattedValue.putLatencies(stringBuilder.toString(), value.doubleValue());
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void formatStats(MeasurementSet measurement, Number value, Statistics aggr, String name) {
+    StringBuilder stringBuilder = new StringBuilder(measurement.getName());
+    stringBuilder.append(SEPARATOR).append(aggr);
+    stringBuilder.append(SEPARATOR).append(measurement.getUnit());
+    if (!name.isEmpty()) {
+      stringBuilder.append(SEPARATOR).append(name);
+    }
+    formattedValue.putStats(stringBuilder.toString(), String.valueOf(value));
+  }
+
+  private void formatMeasurementInOrder(
+      MeasurementSet measurementSet, Statistics type, String name, Number value) {
+    boolean ret = formatSamples(measurementSet, value, type);
+    if (!ret) {
+      ret = formatException(measurementSet, name, value);
+    }
+    if (!ret) {
+      ret = formatCounters(measurementSet, value, type, name);
+    }
+    if (!ret) {
+      ret = formatLatencies(measurementSet, value, type, name);
+    }
+    if (!ret) {
+      formatStats(measurementSet, value, type, name);
+    }
+  }
+
+  @Override
+  public void formatNamedAggregatedValue(
+      MeasurementSet measurementSet, Statistics aggregationType, String name, Number value) {
+    formatMeasurementInOrder(measurementSet, aggregationType, name, value);
+  }
+
+  @Override
+  public void formatAggregatedValue(
+      MeasurementSet measurementSet, Statistics aggregationType, Number value) {
+    formatMeasurementInOrder(measurementSet, aggregationType, "", value);
+  }
+
+  @Override
+  public void setStartAndEndTime(long start, long end) {
+    formattedValue = new StatsCollectorReturn(start, end);
+  }
+
+  public class StatsCollectorReturn {
+    private Map<String, AtomicInteger> counters;
+    private Map<String, String> statsdata;
+    private Map<String, Double> latencies;
+    private long startTimeMillis;
+    private long endTimeMillis;
+
+    public StatsCollectorReturn(long startTimeMillis, long endTimeMillis) {
+      counters = new HashMap<>();
+      statsdata = new HashMap<>();
+      latencies = new HashMap<>();
+      this.startTimeMillis = startTimeMillis;
+      this.endTimeMillis = endTimeMillis;
+    }
+
+    void putCounter(String name, int value) {
+      counters.put(name, new AtomicInteger(value));
+    }
+
+    void putLatencies(String name, double value) {
+      latencies.put(name, value);
+    }
+
+    void putStats(String name, String value) {
+      statsdata.put(name, value);
+    }
+
+    public Map<String, AtomicInteger> getCounters() {
+      return counters;
+    }
+
+    public Map<String, String> getStatsdata() {
+      return statsdata;
+    }
+
+    public Map<String, Double> getLatencies() {
+      return latencies;
+    }
+
+    public long getStartTimeMillis() {
+      return startTimeMillis;
+    }
+
+    public long getEndTimeMillis() {
+      return endTimeMillis;
+    }
+
+    public boolean isEmpty() {
+      return counters.isEmpty() && statsdata.isEmpty() && latencies.isEmpty();
+    }
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/formatter/StatsCollectorFormatter.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/formatter/StatsCollectorFormatter.java
@@ -15,141 +15,65 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.formatter;
 
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaRuntimeMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.eval.impl.vals.Value;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.format.Formatter;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class StatsCollectorFormatter implements Formatter {
-  static final char SEPARATOR = '-';
-  static List<MeasurementSet> LATENCIES =
-      Arrays.asList(
-          RcaRuntimeMetrics.GRAPH_EXECUTION_TIME,
-          RcaGraphMetrics.GRAPH_NODE_OPERATE_CALL,
-          RcaGraphMetrics.METRIC_GATHER_CALL,
-          RcaGraphMetrics.RCA_PERSIST_CALL);
-  StatsCollectorReturn formattedValue;
+  StringBuilder formatted;
+  String sep = "";
+  long startTime;
+  long endTime;
 
-  public StatsCollectorReturn getFormatted() {
-    return formattedValue;
+  public StatsCollectorFormatter() {
+    formatted = new StringBuilder();
   }
 
-  private boolean formatException(MeasurementSet measurement, String name, Number counter) {
-    for (MeasurementSet measure : ExceptionsAndErrors.values()) {
-      if (measurement == measure) {
-        if (name.isEmpty()) {
-          formattedValue.putCounter(measurement.getName(), counter.intValue());
-        } else {
-          formattedValue.putCounter(
-              new StringBuilder(measurement.getName())
-                  .append(SEPARATOR)
-                  .append(name.replaceAll(" ", "_"))
-                  .toString(),
-              counter.intValue());
-        }
-        return true;
-      }
+  private void format(
+      MeasurementSet measurementSet, Statistics aggregationType, String name, Number value) {
+    formatted.append(sep);
+    formatted.append(measurementSet.getName()).append("=").append(value);
+    if (!measurementSet.getUnit().isEmpty()) {
+      formatted.append(" ").append("unit|").append(measurementSet.getUnit());
     }
-    return false;
-  }
-
-  private boolean formatSamples(MeasurementSet given, Number values, Statistics aggr) {
-    if (aggr == Statistics.SAMPLE) {
-      formattedValue.putStats(given.getName(), String.valueOf(values));
-      return true;
-    }
-    return false;
-  }
-
-  private boolean formatCounters(
-      MeasurementSet measurementSet, Number values, Statistics aggr, String name) {
-    boolean found = false;
-    if (aggr == Statistics.COUNT) {
-      formattedValue.putCounter(measurementSet.getName(), values.intValue());
-      found = true;
-    } else if (aggr == Statistics.NAMED_COUNTERS) {
-      formattedValue.putCounter(
-          new StringBuilder(measurementSet.getName())
-              .append(SEPARATOR)
-              .append(name.replaceAll(" ", "_"))
-              .toString(),
-          values.intValue());
-      found = true;
-    }
-    return found;
-  }
-
-  private boolean formatLatencies(
-      MeasurementSet given, Number value, Statistics aggr, String name) {
-    if (aggr == Statistics.NAMED_COUNTERS
-        || aggr == Statistics.NAMED_COUNTERS
-        || aggr == Statistics.SAMPLE) {
-      return false;
-    }
-    for (MeasurementSet aggregateMeasurements : LATENCIES) {
-      if (aggregateMeasurements == given) {
-        StringBuilder stringBuilder = new StringBuilder(given.getName());
-        stringBuilder.append(SEPARATOR).append(aggr);
-        stringBuilder.append(SEPARATOR).append(given.getUnit());
-        if (!name.isEmpty()) {
-          stringBuilder.append(SEPARATOR).append(name);
-        }
-        formattedValue.putLatencies(stringBuilder.toString(), value.doubleValue());
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private void formatStats(MeasurementSet measurement, Number value, Statistics aggr, String name) {
-    StringBuilder stringBuilder = new StringBuilder(measurement.getName());
-    stringBuilder.append(SEPARATOR).append(aggr);
-    stringBuilder.append(SEPARATOR).append(measurement.getUnit());
+    formatted.append(" ").append("aggr|").append(aggregationType);
     if (!name.isEmpty()) {
-      stringBuilder.append(SEPARATOR).append(name);
+      formatted.append(" ").append("key|").append(name);
     }
-    formattedValue.putStats(stringBuilder.toString(), String.valueOf(value));
-  }
-
-  private void formatMeasurementInOrder(
-      MeasurementSet measurementSet, Statistics type, String name, Number value) {
-    boolean ret = formatSamples(measurementSet, value, type);
-    if (!ret) {
-      ret = formatException(measurementSet, name, value);
-    }
-    if (!ret) {
-      ret = formatCounters(measurementSet, value, type, name);
-    }
-    if (!ret) {
-      ret = formatLatencies(measurementSet, value, type, name);
-    }
-    if (!ret) {
-      formatStats(measurementSet, value, type, name);
-    }
+    sep = ",";
   }
 
   @Override
   public void formatNamedAggregatedValue(
       MeasurementSet measurementSet, Statistics aggregationType, String name, Number value) {
-    formatMeasurementInOrder(measurementSet, aggregationType, name, value);
+    format(measurementSet, aggregationType, name, value);
   }
 
   @Override
   public void formatAggregatedValue(
       MeasurementSet measurementSet, Statistics aggregationType, Number value) {
-    formatMeasurementInOrder(measurementSet, aggregationType, "", value);
+    format(measurementSet, aggregationType, "", value);
   }
 
   @Override
   public void setStartAndEndTime(long start, long end) {
-    formattedValue = new StatsCollectorReturn(start, end);
+    this.startTime = start;
+    this.endTime = end;
+  }
+
+  public List<StatsCollectorReturn> getAllMetrics() {
+    List<StatsCollectorReturn> list = new ArrayList<>();
+    StatsCollectorReturn statsCollectorReturn = new StatsCollectorReturn(this.startTime, this.endTime);
+      statsCollectorReturn.statsdata.put("Metrics", formatted.toString());
+      list.add(statsCollectorReturn);
+
+    return list;
   }
 
   public class StatsCollectorReturn {
@@ -165,18 +89,6 @@ public class StatsCollectorFormatter implements Formatter {
       latencies = new HashMap<>();
       this.startTimeMillis = startTimeMillis;
       this.endTimeMillis = endTimeMillis;
-    }
-
-    void putCounter(String name, int value) {
-      counters.put(name, new AtomicInteger(value));
-    }
-
-    void putLatencies(String name, double value) {
-      latencies.put(name, value);
-    }
-
-    void putStats(String name, String value) {
-      statsdata.put(name, value);
     }
 
     public Map<String, AtomicInteger> getCounters() {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/Metric.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/Metric.java
@@ -82,10 +82,10 @@ public abstract class Metric extends LeafNode<MetricFlowUnit> {
   }
 
   public void generateFlowUnitListFromLocal(FlowUnitOperationArgWrapper args) {
-    long startTime = System.nanoTime();
+    long startTime = System.currentTimeMillis();
     MetricFlowUnit mfu = gather(args.getQueryable());
-    long endTime = System.nanoTime();
-    long duration = (endTime - startTime) / 1000;
+    long endTime = System.currentTimeMillis();
+    long duration = endTime - startTime;
 
     PerformanceAnalyzerApp.RCA_GRAPH_METRICS_AGGREGATOR.updateStat(
         RcaGraphMetrics.METRIC_GATHER_CALL, this.name(), duration);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/Metric.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/Metric.java
@@ -15,12 +15,15 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.MetricFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.LeafNode;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Queryable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
+import java.util.Collections;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -72,7 +75,14 @@ public abstract class Metric extends LeafNode<MetricFlowUnit> {
   }
 
   public void generateFlowUnitListFromLocal(FlowUnitOperationArgWrapper args) {
-    setLocalFlowUnit(gather(args.getQueryable()));
+    long startTime = System.nanoTime();
+    MetricFlowUnit mfu = gather(args.getQueryable());
+    long endTime = System.nanoTime();
+    long duration = (endTime - startTime) / 1000;
+
+    PerformanceAnalyzerApp.RCA_GRAPH_METRICS_AGGREGATOR.updateStat(
+            RcaGraphMetrics.METRIC_GATHER_CALL, this.name(), duration);
+    setFlowUnits(Collections.singletonList(mfu));
   }
 
   /**

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/Rca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/Rca.java
@@ -41,7 +41,7 @@ public abstract class Rca<T extends ResourceFlowUnit> extends NonLeafNode<T> {
   public void generateFlowUnitListFromLocal(FlowUnitOperationArgWrapper args) {
     LOG.debug("rca: Executing fromLocal: {}", this.getClass().getSimpleName());
 
-    long startTime = System.nanoTime();
+    long startTime = System.currentTimeMillis();
 
     T result;
     try {
@@ -52,8 +52,8 @@ public abstract class Rca<T extends ResourceFlowUnit> extends NonLeafNode<T> {
           ExceptionsAndErrors.EXCEPTION_IN_OPERATE, name(), 1);
       result = (T) T.generic();
     }
-    long endTime = System.nanoTime();
-    long duration = (endTime - startTime) / 1000;
+    long endTime = System.currentTimeMillis();
+    long duration = endTime - startTime;
 
     PerformanceAnalyzerApp.RCA_GRAPH_METRICS_AGGREGATOR.updateStat(
         RcaGraphMetrics.GRAPH_NODE_OPERATE_CALL, this.name(), duration);
@@ -63,7 +63,7 @@ public abstract class Rca<T extends ResourceFlowUnit> extends NonLeafNode<T> {
 
   @Override
   public void persistFlowUnit(FlowUnitOperationArgWrapper args) {
-    long startTime = System.nanoTime();
+    long startTime = System.currentTimeMillis();
     for (final T flowUnit : getFlowUnits()) {
       try {
         args.getPersistable().write(this, flowUnit);
@@ -74,8 +74,8 @@ public abstract class Rca<T extends ResourceFlowUnit> extends NonLeafNode<T> {
       }
     }
 
-    long endTime = System.nanoTime();
-    long duration = (endTime - startTime) / 1000;
+    long endTime = System.currentTimeMillis();
+    long duration = endTime - startTime;
     PerformanceAnalyzerApp.RCA_GRAPH_METRICS_AGGREGATOR.updateStat(
         RcaGraphMetrics.RCA_PERSIST_CALL, this.name(), duration);
   }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/Symptom.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/Symptom.java
@@ -15,8 +15,10 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.SymptomFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.NonLeafNode;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import java.util.Collections;
 import java.util.List;
@@ -32,7 +34,16 @@ public abstract class Symptom extends NonLeafNode<SymptomFlowUnit> {
 
   public void generateFlowUnitListFromLocal(FlowUnitOperationArgWrapper args) {
     LOG.debug("rca: Executing handleRca: {}", this.getClass().getSimpleName());
-    setFlowUnits(Collections.singletonList(this.operate()));
+
+    long startTime = System.nanoTime();
+    SymptomFlowUnit out = this.operate();
+    long endTime = System.nanoTime();
+    long durationMicro = (endTime - startTime) / 1000;
+
+    PerformanceAnalyzerApp.RCA_GRAPH_METRICS_AGGREGATOR.updateStat(
+            RcaGraphMetrics.GRAPH_NODE_OPERATE_CALL, this.name(), durationMicro);
+
+    setFlowUnits(Collections.singletonList(out));
   }
 
   public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/Symptom.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/Symptom.java
@@ -35,7 +35,7 @@ public abstract class Symptom extends NonLeafNode<SymptomFlowUnit> {
   public void generateFlowUnitListFromLocal(FlowUnitOperationArgWrapper args) {
     LOG.debug("rca: Executing handleRca: {}", this.getClass().getSimpleName());
 
-    long startTime = System.nanoTime();
+    long startTime = System.currentTimeMillis();
     SymptomFlowUnit result;
     try {
       result = this.operate();
@@ -44,11 +44,11 @@ public abstract class Symptom extends NonLeafNode<SymptomFlowUnit> {
           ExceptionsAndErrors.EXCEPTION_IN_OPERATE, name(), 1);
       result = SymptomFlowUnit.generic();
     }
-    long endTime = System.nanoTime();
-    long durationMicro = (endTime - startTime) / 1000;
+    long endTime = System.currentTimeMillis();
+    long durationMillis = endTime - startTime;
 
     PerformanceAnalyzerApp.RCA_GRAPH_METRICS_AGGREGATOR.updateStat(
-        RcaGraphMetrics.GRAPH_NODE_OPERATE_CALL, this.name(), durationMicro);
+        RcaGraphMetrics.GRAPH_NODE_OPERATE_CALL, this.name(), durationMillis);
 
     setFlowUnits(Collections.singletonList(result));
   }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
@@ -27,7 +27,17 @@ public enum ExceptionsAndErrors implements MeasurementSet {
    * These are the cases when an exception was throws in the {@code operate()} method, that each RCA
    * graph node implements.
    */
-  EXCEPTION_IN_OPERATE("ExceptionInOperate", "namedCount", Statistics.NAMED_COUNTERS);
+  EXCEPTION_IN_OPERATE("ExceptionInOperate", "namedCount", Statistics.NAMED_COUNTERS),
+
+  /**
+   * When calling the MetricsDB API throws an exception.
+   */
+  EXCEPTION_IN_GATHER("ExceptionInGather", "namedCount", Statistics.NAMED_COUNTERS),
+
+  /**
+   * When persisting an RCA throws an exception.
+   */
+  EXCEPTION_IN_PERSIST("ExceptionInPersist", "namedCount", Statistics.NAMED_COUNTERS);
 
   /** What we want to appear as the metric name. */
   private String name;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
+import java.util.Collections;
+import java.util.List;
+
+public enum ExceptionsAndErrors implements MeasurementSet {
+  RCA_FRAMEWORK_CRASH("RcaFrameworkCrash"),
+
+  /**
+   * These are the cases when an exception was throws in the {@code operate()} method, that each RCA
+   * graph node implements.
+   */
+  EXCEPTION_IN_OPERATE("ExceptionInOperate", "namedCount", Statistics.NAMED_COUNTERS);
+
+  /** What we want to appear as the metric name. */
+  private String name;
+
+  /**
+   * The unit the measurement is in. This is not used for the statistics calculations but as an
+   * information that will be dumped with the metrics.
+   */
+  private String unit;
+
+  /**
+   * Multiple statistics can be collected for each measurement like MAX, MIN and MEAN. This is a
+   * collection of one or more such statistics.
+   */
+  private List<Statistics> statsList;
+
+  ExceptionsAndErrors(String name) {
+    this.name = name;
+    this.unit = "count";
+    this.statsList = Collections.singletonList(Statistics.COUNT);
+  }
+
+  ExceptionsAndErrors(String name, String unit, Statistics stats) {
+    this.name = name;
+    this.unit = unit;
+    this.statsList = Collections.singletonList(stats);
+  }
+
+  public String toString() {
+    return new StringBuilder(name).append("-").append(unit).toString();
+  }
+
+  @Override
+  public List<Statistics> getStatsList() {
+    return statsList;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getUnit() {
+    return unit;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/JvmMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/JvmMetrics.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
+import java.util.Collections;
+import java.util.List;
+
+public enum JvmMetrics implements MeasurementSet {
+  JVM_FREE_MEM_SAMPLER("JvmFreeMem", "bytes"),
+  JVM_TOTAL_MEM_SAMPLER("JvmTotalMem", "bytes"),
+  THREAD_COUNT("ThreadCount", "count");
+
+  private String name;
+  private String unit;
+
+  JvmMetrics(String name, String unit) {
+    this.name = name;
+    this.unit = unit;
+  }
+
+  @Override
+  public List<Statistics> getStatsList() {
+    return Collections.singletonList(Statistics.SAMPLE);
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getUnit() {
+    return unit;
+  }
+
+  @Override
+  public String toString() {
+    return new StringBuilder(name).append("-").append(unit).toString();
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaGraphMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaGraphMetrics.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public enum RcaGraphMetrics implements MeasurementSet {
+  /** Measures the time spent in the operate() method of a graph node. */
+  GRAPH_NODE_OPERATE_CALL("OperateCall", "micros", Arrays.asList(Statistics.MAX, Statistics.MEAN)),
+
+  /** Measures the time taken to call gather on metrics */
+  METRIC_GATHER_CALL("MetricGatherCall", "micros", Arrays.asList(Statistics.MAX, Statistics.MEAN)),
+
+  /** Measures the time spent in the persistence layer. */
+  RCA_PERSIST_CALL("RcaPersistCall", "micros", Arrays.asList(Statistics.MAX, Statistics.MEAN)),
+
+  NUM_GRAPH_NODES("NumGraphNodes", "count", Collections.singletonList(Statistics.SAMPLE)),
+
+  NUM_NODES_EXECUTED_LOCALLY(
+      "NodesExecutedLocally", "count", Collections.singletonList(Statistics.COUNT)),
+
+  NUM_NODES_EXECUTED_REMOTELY(
+      "NodesExecutedRemotely", "count", Collections.singletonList(Statistics.COUNT));
+
+  /** What we want to appear as the metric name. */
+  private String name;
+
+  /**
+   * The unit the measurement is in. This is not used for the statistics calculations but as an
+   * information that will be dumped with the metrics.
+   */
+  private String unit;
+
+  /**
+   * Multiple statistics can be collected for each measurement like MAX, MIN and MEAN. This is a
+   * collection of one or more such statistics.
+   */
+  private List<Statistics> statsList;
+
+  RcaGraphMetrics(String name, String unit, List<Statistics> statisticList) {
+    this.name = name;
+    this.unit = unit;
+    this.statsList = statisticList;
+  }
+
+  public String toString() {
+    return new StringBuilder(name).append("-").append(unit).toString();
+  }
+
+  @Override
+  public List<Statistics> getStatsList() {
+    return statsList;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getUnit() {
+    return unit;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaGraphMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaGraphMetrics.java
@@ -22,13 +22,20 @@ import java.util.Collections;
 import java.util.List;
 
 public enum RcaGraphMetrics implements MeasurementSet {
+  /** Time taken per run of the RCA graph */
+  GRAPH_EXECUTION_TIME(
+          "RcaGraphExecution",
+          "millis",
+          Arrays.asList(
+                  Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
+
   /** Measures the time spent in the operate() method of a graph node. */
   GRAPH_NODE_OPERATE_CALL(
-      "OperateCall", "micros", Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
+      "OperateCall", "millis", Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
 
   /** Measures the time taken to call gather on metrics */
   METRIC_GATHER_CALL(
-      "MetricGatherCall", "micros", Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
+      "MetricGatherCall", "millis", Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
 
   /** Measures the time spent in the persistence layer. */
   RCA_PERSIST_CALL(

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaGraphMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaGraphMetrics.java
@@ -23,13 +23,16 @@ import java.util.List;
 
 public enum RcaGraphMetrics implements MeasurementSet {
   /** Measures the time spent in the operate() method of a graph node. */
-  GRAPH_NODE_OPERATE_CALL("OperateCall", "micros", Arrays.asList(Statistics.MAX, Statistics.MEAN)),
+  GRAPH_NODE_OPERATE_CALL(
+      "OperateCall", "micros", Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
 
   /** Measures the time taken to call gather on metrics */
-  METRIC_GATHER_CALL("MetricGatherCall", "micros", Arrays.asList(Statistics.MAX, Statistics.MEAN)),
+  METRIC_GATHER_CALL(
+      "MetricGatherCall", "micros", Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
 
   /** Measures the time spent in the persistence layer. */
-  RCA_PERSIST_CALL("RcaPersistCall", "micros", Arrays.asList(Statistics.MAX, Statistics.MEAN)),
+  RCA_PERSIST_CALL(
+      "RcaPersistCall", "micros", Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
 
   NUM_GRAPH_NODES("NumGraphNodes", "count", Collections.singletonList(Statistics.SAMPLE)),
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaRuntimeMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaRuntimeMetrics.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public enum RcaRuntimeMetrics implements MeasurementSet {
+  /** Time taken per run of the RCA graph */
+  GRAPH_EXECUTION_TIME(
+      "RcaGraphExecution",
+      "micros",
+      Arrays.asList(Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT)),
+
+  /**
+   * These are the flow units that are sent by the RCA framework for the remote nodes. Not all of
+   * them may or may not make it over the wire.
+   */
+  FLOW_UNITS_SENT_TO_WIRE_HOPPER(
+      "FlowUnitsToWireHopper", "count", Collections.singletonList(Statistics.COUNT)),
+
+  /**
+   * This measures how many flow units are sent over the wire. If there are multiple subscribers,
+   * then the flow unit will be copied to each one of them. Each of the copies will be accounted for
+   * in the count.
+   */
+  // TODO(yojs): waiting on
+  // https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/pull/59
+  FLOW_UNITS_SENT_OVER_NETWORK(
+      "FlowUnitsSentOverNetwork", "count", Collections.singletonList(Statistics.COUNT)),
+
+  /** The number of times the framework was stopped by the operator. */
+  RCA_STOPPED_BY_OPERATOR(
+      "RcaStoppedByOperator", "count", Collections.singletonList(Statistics.COUNT)),
+
+  /** The number of times the framework was restarted by the operator. */
+  RCA_RESTARTED_BY_OPERATOR(
+      "RcaRestartedByOperator", "count", Collections.singletonList(Statistics.COUNT)),
+
+  /**
+   * ES APIs calls are expensive and we want to keep track of how many we are making. This is a
+   * named counter and therefore we can get a count per ES API.
+   */
+  ES_APIS_CALLED("ESApisCalled", "count", Collections.singletonList(Statistics.NAMED_COUNTERS));
+
+  /** What we want to appear as the metric name. */
+  private String name;
+
+  /**
+   * The unit the measurement is in. This is not used for the statistics calculations but as an
+   * information that will be dumped with the metrics.
+   */
+  private String unit;
+
+  /**
+   * Multiple statistics can be collected for each measurement like MAX, MIN and MEAN. This is a
+   * collection of one or more such statistics.
+   */
+  private List<Statistics> statsList;
+
+  RcaRuntimeMetrics(String name, String unit, List<Statistics> statisticList) {
+    this.name = name;
+    this.unit = unit;
+    this.statsList = statisticList;
+  }
+
+  public String toString() {
+    return new StringBuilder(name).append("-").append(unit).toString();
+  }
+
+  @Override
+  public List<Statistics> getStatsList() {
+    return statsList;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getUnit() {
+    return unit;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaRuntimeMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaRuntimeMetrics.java
@@ -22,13 +22,6 @@ import java.util.Collections;
 import java.util.List;
 
 public enum RcaRuntimeMetrics implements MeasurementSet {
-  /** Time taken per run of the RCA graph */
-  GRAPH_EXECUTION_TIME(
-      "RcaGraphExecution",
-      "micros",
-      Arrays.asList(
-          Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
-
   /** The number of times the framework was stopped by the operator. */
   RCA_STOPPED_BY_OPERATOR(
       "RcaStoppedByOperator", "count", Collections.singletonList(Statistics.COUNT)),

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaRuntimeMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaRuntimeMetrics.java
@@ -26,24 +26,8 @@ public enum RcaRuntimeMetrics implements MeasurementSet {
   GRAPH_EXECUTION_TIME(
       "RcaGraphExecution",
       "micros",
-      Arrays.asList(Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT)),
-
-  /**
-   * These are the flow units that are sent by the RCA framework for the remote nodes. Not all of
-   * them may or may not make it over the wire.
-   */
-  FLOW_UNITS_SENT_TO_WIRE_HOPPER(
-      "FlowUnitsToWireHopper", "count", Collections.singletonList(Statistics.COUNT)),
-
-  /**
-   * This measures how many flow units are sent over the wire. If there are multiple subscribers,
-   * then the flow unit will be copied to each one of them. Each of the copies will be accounted for
-   * in the count.
-   */
-  // TODO(yojs): waiting on
-  // https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/pull/59
-  FLOW_UNITS_SENT_OVER_NETWORK(
-      "FlowUnitsSentOverNetwork", "count", Collections.singletonList(Statistics.COUNT)),
+      Arrays.asList(
+          Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
 
   /** The number of times the framework was stopped by the operator. */
   RCA_STOPPED_BY_OPERATOR(

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/sys/AllJvmSamplers.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/sys/AllJvmSamplers.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.sys;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.emitters.ISampler;
+import java.util.Arrays;
+import java.util.List;
+
+public class AllJvmSamplers {
+  public static List<ISampler> getJvmSamplers() {
+    return Arrays.asList(new JvmFreeMem(), new JvmTotalMem());
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/sys/JvmFreeMem.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/sys/JvmFreeMem.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.sys;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.JvmMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.collectors.SampleAggregator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.emitters.ISampler;
+
+public class JvmFreeMem implements ISampler {
+  @Override
+  public void sample(SampleAggregator sampleCollector) {
+    sampleCollector.updateStat(
+        JvmMetrics.JVM_FREE_MEM_SAMPLER, "", Runtime.getRuntime().freeMemory());
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/sys/JvmTotalMem.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/sys/JvmTotalMem.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.sys;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.JvmMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.collectors.SampleAggregator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.emitters.ISampler;
+
+public class JvmTotalMem implements ISampler {
+  @Override
+  public void sample(SampleAggregator sampleCollector) {
+    sampleCollector.updateStat(
+        JvmMetrics.JVM_TOTAL_MEM_SAMPLER, "", Runtime.getRuntime().totalMemory());
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/GraphNodeOperations.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/GraphNodeOperations.java
@@ -15,6 +15,8 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -24,11 +26,15 @@ public class GraphNodeOperations {
   static void readFromLocal(FlowUnitOperationArgWrapper args) {
     args.getNode().generateFlowUnitListFromLocal(args);
     args.getNode().persistFlowUnit(args);
+    PerformanceAnalyzerApp.RCA_GRAPH_METRICS_AGGREGATOR.updateStat(
+            RcaGraphMetrics.NUM_NODES_EXECUTED_LOCALLY, "", 1);
   }
 
   // This is the abstraction for when the data arrives on the wire from a remote dependency.
   static void readFromWire(FlowUnitOperationArgWrapper args) {
     // flowUnits.forEach(i -> LOG.info("rca: Read from wire: {}", i));
     args.getNode().generateFlowUnitListFromWire(args);
+    PerformanceAnalyzerApp.RCA_GRAPH_METRICS_AGGREGATOR.updateStat(
+            RcaGraphMetrics.NUM_NODES_EXECUTED_REMOTELY, "", 1);
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCAScheduler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCAScheduler.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatExceptionCode;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.NodeRole;
@@ -22,6 +23,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Queryable;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.ThresholdMain;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.WireHopper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.Persistable;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -127,6 +129,8 @@ public class RCAScheduler {
                     | CancellationException ex) {
                   if (!shutdownRequested) {
                     LOG.error("RCA Exception cause : {}", ex.getCause());
+                    PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+                            ExceptionsAndErrors.RCA_FRAMEWORK_CRASH, ex.getCause().toString(), 1);
                     shutdown();
                     schedulerState = RcaSchedulerState.STATE_STOPPED_DUE_TO_EXCEPTION;
                     StatsCollector.instance().logException(StatExceptionCode.RCA_SCHEDULER_STOPPED_ERROR);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCASchedulerTask.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCASchedulerTask.java
@@ -21,6 +21,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Queryable;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Stats;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaRuntimeMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts.RcaTagConstants;
@@ -105,7 +106,7 @@ public class RCASchedulerTask implements Runnable {
   // guess, who
   //  should provide the max ticks - the framework or the Runtime ? Maybe an agreement between the
   // two is better.
-  RCASchedulerTask(
+  public RCASchedulerTask(
       int maxTicks,
       final ExecutorService executorPool,
       final List<ConnectedComponent> connectedComponents,

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCASchedulerTask.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCASchedulerTask.java
@@ -356,7 +356,7 @@ public class RCASchedulerTask implements Runnable {
   public void run() {
     currTick = currTick + 1;
 
-    long runStartTime = System.nanoTime();
+    long runStartTime = System.currentTimeMillis();
     PerformanceAnalyzerApp.RCA_GRAPH_METRICS_AGGREGATOR.updateStat(
             RcaGraphMetrics.NUM_GRAPH_NODES, "", Stats.getInstance().getTotalNodesCount());
 
@@ -383,9 +383,9 @@ public class RCASchedulerTask implements Runnable {
       LOG.debug("Finished ticking.");
     }
 
-    long runEndTime = System.nanoTime();
-    long durationMicros = (runEndTime - runStartTime) / 1000;
+    long runEndTime = System.currentTimeMillis();
+    long durationMillis = runEndTime - runStartTime;
     PerformanceAnalyzerApp.RCA_RUNTIME_METRICS_AGGREGATOR.updateStat(
-            RcaRuntimeMetrics.GRAPH_EXECUTION_TIME, "", durationMicros);
+            RcaGraphMetrics.GRAPH_EXECUTION_TIME, "", durationMillis);
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/Tasklet.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/Tasklet.java
@@ -15,8 +15,10 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Queryable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.DataMsg;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.WireHopper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.NetPersistor;
@@ -131,6 +133,8 @@ public class Tasklet {
                 executorPool)
             .exceptionally(
                 ex -> {
+                  PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+                          ExceptionsAndErrors.EXCEPTION_IN_OPERATE, node.name(), 1);
                   ex.printStackTrace();
                   return new TaskletResult(null);
                 });

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/Tasklet.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/Tasklet.java
@@ -15,10 +15,8 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler;
 
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Queryable;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.DataMsg;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.WireHopper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.NetPersistor;
@@ -134,8 +132,8 @@ public class Tasklet {
                 executorPool)
             .exceptionally(
                 ex -> {
-                  //PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
-                    //      ExceptionsAndErrors.EXCEPTION_IN_OPERATE, node.name(), 1);
+                  // PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+                  //      ExceptionsAndErrors.EXCEPTION_IN_OPERATE, node.name(), 1);
                   // ex.printStackTrace();
                   return new TaskletResult(null);
                 });
@@ -165,5 +163,4 @@ public class Tasklet {
   public Node<?> getNode() {
     return node;
   }
-
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/Tasklet.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/Tasklet.java
@@ -42,6 +42,7 @@ public class Tasklet {
 
   protected Map<Tasklet, CompletableFuture<TaskletResult>> predecessorToFutureMap;
   protected List<Tasklet> predecessors;
+
   private Node<?> node;
   private final Queryable db;
   private final Persistable persistable;
@@ -133,9 +134,9 @@ public class Tasklet {
                 executorPool)
             .exceptionally(
                 ex -> {
-                  PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
-                          ExceptionsAndErrors.EXCEPTION_IN_OPERATE, node.name(), 1);
-                  ex.printStackTrace();
+                  //PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+                    //      ExceptionsAndErrors.EXCEPTION_IN_OPERATE, node.name(), 1);
+                  // ex.printStackTrace();
                   return new TaskletResult(null);
                 });
     LOG.debug("RCA: Finished creating executable future for tasklet: {}", node.name());
@@ -160,4 +161,9 @@ public class Tasklet {
   public String toString() {
     return "Tasklet for node: " + node.name() + ", with executable Func: " + exec;
   }
+
+  public Node<?> getNode() {
+    return node;
+  }
+
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/stats/format/DefaultFormatter.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/stats/format/DefaultFormatter.java
@@ -71,4 +71,12 @@ public class DefaultFormatter implements Formatter {
   public Map<MeasurementSet, Map<Statistics, List<Value>>> getFormatted() {
     return map;
   }
+
+  public long getStart() {
+    return start;
+  }
+
+  public long getEnd() {
+    return end;
+  }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/RcaStatsCollectorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/RcaStatsCollectorTest.java
@@ -1,0 +1,161 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetClient;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaTestHelper;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.AnalysisGraph;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Symptom;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.SymptomFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.CPU_Utilization;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_AllocRate;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Paging_MajfltRate;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Sched_Waittime;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.ConnectedComponent;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.JvmMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaUtil;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.NodeStateManager;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.ReceivedFlowUnitStore;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.SubscriptionManager;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.WireHopper;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.RCASchedulerTask;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.spec.MetricsDBProviderTestHelper;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
+import org.junit.Test;
+
+public class RcaStatsCollectorTest {
+  class WireHopperMock extends WireHopper {
+
+    public WireHopperMock(
+        NodeStateManager nodeStateManager,
+        NetClient netClient,
+        SubscriptionManager subscriptionManager,
+        AtomicReference<ExecutorService> executorReference,
+        ReceivedFlowUnitStore receivedFlowUnitStore) {
+      super(
+          new NodeStateManager(),
+          netClient,
+          subscriptionManager,
+          executorReference,
+          receivedFlowUnitStore);
+    }
+  }
+
+  class FaultyAnalysisGraph extends AnalysisGraph {
+    @Override
+    public void construct() {
+      Metric cpuUtilization = new CPU_Utilization(1);
+      Metric heapUsed = new Sched_Waittime(1);
+      Metric pageMaj = new Paging_MajfltRate(1);
+      Metric heapAlloc = new Heap_AllocRate(1);
+
+      addLeaf(cpuUtilization);
+      addLeaf(heapUsed);
+      addLeaf(pageMaj);
+      addLeaf(heapAlloc);
+
+      Symptom s1 = new HighCpuSymptom(1, cpuUtilization, heapUsed);
+      s1.addAllUpstreams(Arrays.asList(cpuUtilization, heapUsed));
+
+      System.out.println(this.getClass().getName() + " graph constructed..");
+    }
+
+    class HighCpuSymptom extends Symptom {
+      Metric cpu;
+      Metric heapUsed;
+
+      public HighCpuSymptom(long evaluationIntervalSeconds, Metric cpu, Metric heapUsed) {
+        super(evaluationIntervalSeconds);
+        this.cpu = cpu;
+        this.heapUsed = heapUsed;
+      }
+
+      @Override
+      public SymptomFlowUnit operate() {
+        int x = 5 / 0;
+        return new SymptomFlowUnit(0L);
+      }
+    }
+  }
+
+  @Test
+  public void rcaGraphMetrics() throws Exception {
+    RcaTestHelper.cleanUpLogs();
+
+    RcaGraphMetrics graphMetrics[] = {
+      RcaGraphMetrics.GRAPH_NODE_OPERATE_CALL,
+      RcaGraphMetrics.METRIC_GATHER_CALL,
+      RcaGraphMetrics.NUM_GRAPH_NODES,
+      RcaGraphMetrics.NUM_NODES_EXECUTED_LOCALLY,
+    };
+
+    JvmMetrics jvmMetrics[] = {JvmMetrics.JVM_FREE_MEM_SAMPLER, JvmMetrics.JVM_TOTAL_MEM_SAMPLER};
+
+    List<ConnectedComponent> connectedComponents =
+        RcaUtil.getAnalysisGraphComponents(new FaultyAnalysisGraph());
+    RcaConf rcaConf = new RcaConf(Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca.conf").toString());
+
+    RCASchedulerTask rcaSchedulerTask =
+        new RCASchedulerTask(
+            1000,
+            Executors.newFixedThreadPool(2),
+            connectedComponents,
+            new MetricsDBProviderTestHelper(true),
+            null,
+            rcaConf,
+            null);
+    rcaSchedulerTask.run();
+    StatsCollector statsCollector = new StatsCollector("test-stats", 0, new HashMap<>());
+
+    for (RcaGraphMetrics metricToCheck : graphMetrics) {
+        verify(metricToCheck);
+    }
+    for (JvmMetrics jvmMetrics1: jvmMetrics) {
+      verify(jvmMetrics1);
+    }
+    statsCollector.collectMetrics(0);
+  }
+
+  private boolean verify(MeasurementSet measurementSet) throws InterruptedException {
+    final int MAX_TIME_TO_WAIT_MILLIS = 10_000;
+    int waited_for_millis = 0;
+    while (waited_for_millis++ < MAX_TIME_TO_WAIT_MILLIS) {
+      if (PerformanceAnalyzerApp.RCA_STATS_REPORTER.isMeasurementCollected(measurementSet)) {
+        return true;
+      }
+      Thread.sleep(1);
+    }
+    return false;
+  }
+
+  @After
+  public void cleanup() {
+    // RcaTestHelper.cleanUpLogs();
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaTestHelper.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaTestHelper.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+public class RcaTestHelper {
+    public static List<String> getAllLinesFromStatsLog() {
+        try {
+            return Files.readAllLines(Paths.get(getLogFilePath("StatsLog")));
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (ParserConfigurationException e) {
+            e.printStackTrace();
+        } catch (SAXException e) {
+            e.printStackTrace();
+        } catch (XPathExpressionException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+    public static String getLogFilePath(String filename)
+            throws ParserConfigurationException, IOException, SAXException, XPathExpressionException {
+        String cwd = System.getProperty("user.dir");
+        String testResourcesPath =
+                Paths.get(Paths.get(cwd, "src", "test", "resources").toString(), "log4j2.xml").toString();
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document doc = builder.parse(testResourcesPath);
+        XPathFactory xPathfactory = XPathFactory.newInstance();
+        XPath xpath = xPathfactory.newXPath();
+        return xpath.evaluate(
+                String.format("Configuration/Appenders/File[@name='%s']/@fileName", filename), doc);
+    }
+    public static void cleanUpLogs() {
+        try {
+            Files.deleteIfExists(Paths.get(getLogFilePath("PerformanceAnalyzerLog")));
+            Files.deleteIfExists(Paths.get(getLogFilePath("StatsLog")));
+        } catch (ParserConfigurationException e) {
+            e.printStackTrace();
+        } catch (SAXException e) {
+            e.printStackTrace();
+        } catch (XPathExpressionException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaTestHelper.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaTestHelper.java
@@ -29,46 +29,48 @@ import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
 public class RcaTestHelper {
-    public static List<String> getAllLinesFromStatsLog() {
-        try {
-            return Files.readAllLines(Paths.get(getLogFilePath("StatsLog")));
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (ParserConfigurationException e) {
-            e.printStackTrace();
-        } catch (SAXException e) {
-            e.printStackTrace();
-        } catch (XPathExpressionException e) {
-            e.printStackTrace();
-        }
-        return null;
+  public static List<String> getAllLinesFromStatsLog() {
+    try {
+      return Files.readAllLines(Paths.get(getLogFilePath("StatsLog")));
+    } catch (IOException e) {
+      e.printStackTrace();
+    } catch (ParserConfigurationException e) {
+      e.printStackTrace();
+    } catch (SAXException e) {
+      e.printStackTrace();
+    } catch (XPathExpressionException e) {
+      e.printStackTrace();
     }
-    public static String getLogFilePath(String filename)
-            throws ParserConfigurationException, IOException, SAXException, XPathExpressionException {
-        String cwd = System.getProperty("user.dir");
-        String testResourcesPath =
-                Paths.get(Paths.get(cwd, "src", "test", "resources").toString(), "log4j2.xml").toString();
+    return null;
+  }
 
-        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        DocumentBuilder builder = factory.newDocumentBuilder();
-        Document doc = builder.parse(testResourcesPath);
-        XPathFactory xPathfactory = XPathFactory.newInstance();
-        XPath xpath = xPathfactory.newXPath();
-        return xpath.evaluate(
-                String.format("Configuration/Appenders/File[@name='%s']/@fileName", filename), doc);
+  public static String getLogFilePath(String filename)
+      throws ParserConfigurationException, IOException, SAXException, XPathExpressionException {
+    String cwd = System.getProperty("user.dir");
+    String testResourcesPath =
+        Paths.get(Paths.get(cwd, "src", "test", "resources").toString(), "log4j2.xml").toString();
+
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    DocumentBuilder builder = factory.newDocumentBuilder();
+    Document doc = builder.parse(testResourcesPath);
+    XPathFactory xPathfactory = XPathFactory.newInstance();
+    XPath xpath = xPathfactory.newXPath();
+    return xpath.evaluate(
+        String.format("Configuration/Appenders/File[@name='%s']/@fileName", filename), doc);
+  }
+
+  public static void cleanUpLogs() {
+    try {
+      Files.deleteIfExists(Paths.get(getLogFilePath("PerformanceAnalyzerLog")));
+      Files.deleteIfExists(Paths.get(getLogFilePath("StatsLog")));
+    } catch (ParserConfigurationException e) {
+      e.printStackTrace();
+    } catch (SAXException e) {
+      e.printStackTrace();
+    } catch (XPathExpressionException e) {
+      e.printStackTrace();
+    } catch (IOException e) {
+      e.printStackTrace();
     }
-    public static void cleanUpLogs() {
-        try {
-            Files.deleteIfExists(Paths.get(getLogFilePath("PerformanceAnalyzerLog")));
-            Files.deleteIfExists(Paths.get(getLogFilePath("StatsLog")));
-        } catch (ParserConfigurationException e) {
-            e.printStackTrace();
-        } catch (SAXException e) {
-            e.printStackTrace();
-        } catch (XPathExpressionException e) {
-            e.printStackTrace();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
+  }
 }


### PR DESCRIPTION
- Added the statscollector formatter
- RcaVersion class
- hooks in Statscollector to emit Rca metrics
- initializations in the PersormanceAnalyzerApp
- The collection of metrics we are going to emit

*Issue #, if available: #52 

*Description of changes:*
This change adds a framework to the health of the RCA framework. The details can be found here.
The metrics added as part of this are:
- Graph execution related:

  - Time spent in the operate() call (Max, min)
  - Time spent in getting the metrics for the metric nodes (max, mean)
  - Time spent in making persisting RCAs (max, mean)
  - Number of graph nodes
  - Graph nodes executed locally
  - Graph nodes executed remotely.

- Framework related:
  - total time to execute the graph (max, min, mean, count)
  - RCA stopped by operator (count)
  - RCA restarted by operator (count)
  - ES api calls (count)

 - Error types:
   - RCA framework crash
   - Exceptions thrown in operate method

- Periodic samples:
  - Jvm free memory
  - JVM total memory

*Tests:*
-- pending --


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
