### PR TITLE
Add ways to mute misbehaving Graph nodes

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Stats.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Stats.java
@@ -19,12 +19,17 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class Stats {
   private long totalNodesCount;
   private long leafNodesCount;
   private long leavesAddedToAnalysisFlowField;
   private Map<Integer, ConnectedComponent> graphs;
+
+  private Set<String> mutedGraphNodes;
+
   private static Stats instance = null;
 
   public void incrementLeavesAddedToAnalysisFlowField() {
@@ -83,7 +88,21 @@ public class Stats {
   }
 
   public List<ConnectedComponent> getConnectedComponents() {
+    mutedGraphNodes =
+            ConcurrentHashMap.newKeySet((int)getTotalNodesCount());
     return new ArrayList<>(graphs.values());
+  }
+
+  public boolean addToMutedGraphNodes(String nodeName) {
+    return mutedGraphNodes.add(nodeName);
+  }
+
+  public boolean isNodeMuted(String nodeName) {
+    return mutedGraphNodes.contains(nodeName);
+  }
+
+  public int getMutedGraphNodesCount() {
+    return mutedGraphNodes.size();
   }
 
   public static void clear() {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaGraphMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaGraphMetrics.java
@@ -24,10 +24,10 @@ import java.util.List;
 public enum RcaGraphMetrics implements MeasurementSet {
   /** Time taken per run of the RCA graph */
   GRAPH_EXECUTION_TIME(
-          "RcaGraphExecution",
-          "millis",
-          Arrays.asList(
-                  Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
+      "RcaGraphExecution",
+      "millis",
+      Arrays.asList(
+          Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
 
   /** Measures the time spent in the operate() method of a graph node. */
   GRAPH_NODE_OPERATE_CALL(
@@ -42,6 +42,9 @@ public enum RcaGraphMetrics implements MeasurementSet {
       "RcaPersistCall", "micros", Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
 
   NUM_GRAPH_NODES("NumGraphNodes", "count", Collections.singletonList(Statistics.SAMPLE)),
+
+  NUM_GRAPH_NODES_MUTED(
+      "NUMOfMutedGraphNodes", "count", Collections.singletonList(Statistics.SAMPLE)),
 
   NUM_NODES_EXECUTED_LOCALLY(
       "NodesExecutedLocally", "count", Collections.singletonList(Statistics.COUNT)),

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaRuntimeMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaRuntimeMetrics.java
@@ -17,7 +17,6 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.me
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.eval.Statistics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/listener/MisbehavingGraphOperateMethodListener.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/listener/MisbehavingGraphOperateMethodListener.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.listener;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Stats;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.listeners.IListener;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class MisbehavingGraphOperateMethodListener implements IListener {
+  private static final Logger LOG =
+      LogManager.getLogger(MisbehavingGraphOperateMethodListener.class);
+  /**
+   * A map to keep track of the graohNodeName and the number of times it threw an exception in the
+   * {@code operate()} method.
+   */
+  Map<String, AtomicInteger> map;
+
+  public static final int TOLERANCE_LIMIT = 1;
+
+  public MisbehavingGraphOperateMethodListener() {
+    map = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public Set<MeasurementSet> getMeasurementsListenedTo() {
+    return new HashSet<>(Arrays.asList(ExceptionsAndErrors.EXCEPTION_IN_OPERATE));
+  }
+
+  @Override
+  public void onOccurrence(MeasurementSet measurementSet, Number value, String key) {
+    if (!key.isEmpty()) {
+      AtomicInteger count = map.putIfAbsent(key, new AtomicInteger(1));
+      int newCount = 1;
+      if (count != null) {
+        newCount = count.incrementAndGet();
+      }
+      if (newCount > TOLERANCE_LIMIT) {
+        if (Stats.getInstance().addToMutedGraphNodes(key)) {
+          LOG.warn(
+              "Node {} got muted for throwing one or more of '{}' more than {} times.",
+              key,
+              getMeasurementsListenedTo(),
+              TOLERANCE_LIMIT);
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/GraphNodeOperations.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/GraphNodeOperations.java
@@ -16,7 +16,9 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Stats;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
+import java.util.Collections;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -24,10 +26,14 @@ public class GraphNodeOperations {
   private static final Logger LOG = LogManager.getLogger(GraphNodeOperations.class);
 
   static void readFromLocal(FlowUnitOperationArgWrapper args) {
+    if (Stats.getInstance().isNodeMuted(args.getNode().name())) {
+      args.getNode().setFlowUnits(Collections.EMPTY_LIST);
+      return;
+    }
     args.getNode().generateFlowUnitListFromLocal(args);
     args.getNode().persistFlowUnit(args);
     PerformanceAnalyzerApp.RCA_GRAPH_METRICS_AGGREGATOR.updateStat(
-            RcaGraphMetrics.NUM_NODES_EXECUTED_LOCALLY, "", 1);
+        RcaGraphMetrics.NUM_NODES_EXECUTED_LOCALLY, "", 1);
   }
 
   // This is the abstraction for when the data arrives on the wire from a remote dependency.
@@ -35,6 +41,6 @@ public class GraphNodeOperations {
     // flowUnits.forEach(i -> LOG.info("rca: Read from wire: {}", i));
     args.getNode().generateFlowUnitListFromWire(args);
     PerformanceAnalyzerApp.RCA_GRAPH_METRICS_AGGREGATOR.updateStat(
-            RcaGraphMetrics.NUM_NODES_EXECUTED_REMOTELY, "", 1);
+        RcaGraphMetrics.NUM_NODES_EXECUTED_REMOTELY, "", 1);
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCASchedulerTask.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCASchedulerTask.java
@@ -21,9 +21,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Queryable;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Stats;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaRuntimeMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts.RcaTagConstants;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.IntentMsg;
@@ -55,14 +53,10 @@ public class RCASchedulerTask implements Runnable {
    */
   private static class CreatedTasklets {
 
-    /**
-     * Tasklet for the locally executable node.
-     */
+    /** Tasklet for the locally executable node. */
     Tasklet taskletForCurrentNode;
 
-    /**
-     * List of tasklets corresponding to one or many remote nodes.
-     */
+    /** List of tasklets corresponding to one or many remote nodes. */
     List<Tasklet> remoteTasklets;
 
     CreatedTasklets(Tasklet taskletForCurrentNode) {
@@ -71,19 +65,13 @@ public class RCASchedulerTask implements Runnable {
     }
   }
 
-  /**
-   * Maximum ticks after which the counter will be reset.
-   */
+  /** Maximum ticks after which the counter will be reset. */
   private int maxTicks;
 
-  /**
-   * To keep track of the number of executions of the thread.
-   */
+  /** To keep track of the number of executions of the thread. */
   private int currTick;
 
-  /**
-   * The thread pool to execute the tasklets.
-   */
+  /** The thread pool to execute the tasklets. */
   private final ExecutorService executorPool;
 
   /**
@@ -172,18 +160,16 @@ public class RCASchedulerTask implements Runnable {
    * node. So, keep track of it, so that the scheduler remembers to send it every time new data is
    * generated for the upstream node.
    *
-   * @param orderedNodes   list of list of nodes in a connected component
-   * @param conf           The rcaConf object, used for tag matching to determine if a node will be
-   *                       executed locally.
-   * @param hopper         The network listener object, used to send intent to receive remotely
-   *                       generated data and to send data to remote nodes which needs data
-   *                       generated on this node.
-   * @param db             A abstraction which is used by the metric nodes to get data from PA
-   *                       reader.
-   * @param persistable    This object is used to write the results of the RCA evaluation to a
-   *                       persistent store.
+   * @param orderedNodes list of list of nodes in a connected component
+   * @param conf The rcaConf object, used for tag matching to determine if a node will be executed
+   *     locally.
+   * @param hopper The network listener object, used to send intent to receive remotely generated
+   *     data and to send data to remote nodes which needs data generated on this node.
+   * @param db A abstraction which is used by the metric nodes to get data from PA reader.
+   * @param persistable This object is used to write the results of the RCA evaluation to a
+   *     persistent store.
    * @param nodeTaskletMap This is a helper structure, to retrieve the Tasklet corresponding to a
-   *                       graph node.
+   *     graph node.
    * @return a level ordered list of Tasklets.
    */
   private List<List<Tasklet>> getLocallyExecutableNodes(
@@ -270,16 +256,12 @@ public class RCASchedulerTask implements Runnable {
    * tasklet representations of the remote nodes. The remote node tasklets, are used to read the
    * data on the wire corresponding to the remote node, when it is available.
    *
-   * @param graphNode                The locally running graph node for which we want to get the
-   *                                 data from upstream
-   * @param locallyExecutableNodeSet A set of inspected nodes so far that are to be executed
-   *                                 locally
-   * @param hopper                   The network proxy
-   * @param db                       This object is used to query the database to get the metrics;
-   *                                 for reads.
-   * @param persistable              The instance of the database where RCAs are to be persisted;
-   *                                 for writes.
-   * @param nodeTaskletMap           A table to get the tasklet corresponding to a graph node.
+   * @param graphNode The locally running graph node for which we want to get the data from upstream
+   * @param locallyExecutableNodeSet A set of inspected nodes so far that are to be executed locally
+   * @param hopper The network proxy
+   * @param db This object is used to query the database to get the metrics; for reads.
+   * @param persistable The instance of the database where RCAs are to be persisted; for writes.
+   * @param nodeTaskletMap A table to get the tasklet corresponding to a graph node.
    */
   protected CreatedTasklets createTaskletAndSendIntent(
       Node<?> graphNode,
@@ -310,8 +292,10 @@ public class RCASchedulerTask implements Runnable {
 
         final Map<String, String> upstreamNodeTags = upstreamNode.getTags();
         List<String> upstreamNodeLoci =
-            Arrays.asList(upstreamNodeTags.getOrDefault(RcaTagConstants.TAG_LOCUS,
-                EMPTY_STRING).split(RcaTagConstants.SEPARATOR));
+            Arrays.asList(
+                upstreamNodeTags
+                    .getOrDefault(RcaTagConstants.TAG_LOCUS, EMPTY_STRING)
+                    .split(RcaTagConstants.SEPARATOR));
         if (aggregationLocus != null && upstreamNodeLoci.contains(aggregationLocus)) {
           // This upstream vertex is also executed remotely and the current vertex's aggregation
           // locus includes one of the loci for the upstream vertex, so we need to add a task to
@@ -328,14 +312,19 @@ public class RCASchedulerTask implements Runnable {
     return ret;
   }
 
-  private void addReadFromRemoteTasklet(final Node<?> graphNode, final Node<?> upstreamNode,
-      final WireHopper hopper, final Queryable db, final Persistable persistable,
-      final Tasklet tasklet, CreatedTasklets ret) {
+  private void addReadFromRemoteTasklet(
+      final Node<?> graphNode,
+      final Node<?> upstreamNode,
+      final WireHopper hopper,
+      final Queryable db,
+      final Persistable persistable,
+      final Tasklet tasklet,
+      CreatedTasklets ret) {
     LOG.debug(
         "rca: Node '{}' sending intent to consume node: '{}'",
-        graphNode.name(), upstreamNode.name());
-    IntentMsg msg =
-        new IntentMsg(graphNode.name(), upstreamNode.name(), upstreamNode.getTags());
+        graphNode.name(),
+        upstreamNode.name());
+    IntentMsg msg = new IntentMsg(graphNode.name(), upstreamNode.name(), upstreamNode.getTags());
     hopper.sendIntent(msg);
 
     // This node is not locally present. So, we will add a virtual Tasklet that reads
@@ -358,7 +347,7 @@ public class RCASchedulerTask implements Runnable {
 
     long runStartTime = System.currentTimeMillis();
     PerformanceAnalyzerApp.RCA_GRAPH_METRICS_AGGREGATOR.updateStat(
-            RcaGraphMetrics.NUM_GRAPH_NODES, "", Stats.getInstance().getTotalNodesCount());
+        RcaGraphMetrics.NUM_GRAPH_NODES, "", Stats.getInstance().getTotalNodesCount());
 
     Map<Tasklet, CompletableFuture<TaskletResult>> taskletFutureMap = new HashMap<>();
     LOG.debug("RCA: ========== STRT Tick {} ====== ", currTick);
@@ -385,7 +374,9 @@ public class RCASchedulerTask implements Runnable {
 
     long runEndTime = System.currentTimeMillis();
     long durationMillis = runEndTime - runStartTime;
-    PerformanceAnalyzerApp.RCA_RUNTIME_METRICS_AGGREGATOR.updateStat(
-            RcaGraphMetrics.GRAPH_EXECUTION_TIME, "", durationMillis);
+    PerformanceAnalyzerApp.RCA_GRAPH_METRICS_AGGREGATOR.updateStat(
+        RcaGraphMetrics.GRAPH_EXECUTION_TIME, "", durationMillis);
+    PerformanceAnalyzerApp.RCA_GRAPH_METRICS_AGGREGATOR.updateStat(
+        RcaGraphMetrics.NUM_GRAPH_NODES_MUTED, "", Stats.getInstance().getMutedGraphNodesCount());
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/Tasklet.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/Tasklet.java
@@ -17,6 +17,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Queryable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Stats;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.DataMsg;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.WireHopper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.NetPersistor;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/stats/collectors/SampleAggregator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/stats/collectors/SampleAggregator.java
@@ -26,16 +26,18 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.eval.im
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.eval.impl.Sum;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.eval.impl.vals.Value;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.format.Formatter;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.listeners.IListener;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -66,7 +68,23 @@ public class SampleAggregator {
   /** When was the first updateStat was called since the last reset. */
   private AtomicLong startTimeMillis;
 
+  /** Listeners for the occurrence of a metric being emitted. */
+  private final IListener listener;
+
+  /** List of measurements being listened to. */
+  private final Set<MeasurementSet> listenedMeasurements;
+
   public SampleAggregator(MeasurementSet[] measurementSet) {
+    this(Collections.EMPTY_SET, null, measurementSet);
+  }
+
+  public SampleAggregator(
+      Set<MeasurementSet> listenedMeasurements,
+      IListener listener,
+      MeasurementSet[] measurementSet) {
+    Objects.requireNonNull(listenedMeasurements);
+    this.listenedMeasurements = listenedMeasurements;
+    this.listener = listener;
     this.recognizedSet = measurementSet;
     init();
   }
@@ -137,6 +155,10 @@ public class SampleAggregator {
 
     for (IStatistic s : statistics) {
       s.calculate(key, value);
+    }
+
+    if (listenedMeasurements.contains(metric)) {
+      listener.onOccurrence(metric, value, key);
     }
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/stats/listeners/IListener.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/stats/listeners/IListener.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.listeners;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
+import java.util.Set;
+
+/**
+ * This interface is implemented by the interested parties who want to to subscribe to the
+ * occurrence of a metric emission. The Aggregator makes sure it calls the listener.
+ */
+public interface IListener {
+  Set<MeasurementSet> getMeasurementsListenedTo();
+
+  void onOccurrence(MeasurementSet measurementSet, Number value, String key);
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaTestHelper.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaTestHelper.java
@@ -18,6 +18,8 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -41,7 +43,17 @@ public class RcaTestHelper {
     } catch (XPathExpressionException e) {
       e.printStackTrace();
     }
-    return null;
+    return Collections.EMPTY_LIST;
+  }
+
+  public static List<String> getAllLinesWithMatchingString(String pattern) {
+    List<String> matches = new ArrayList<>();
+    for (String line: getAllLinesFromStatsLog()) {
+      if (line.contains(pattern)) {
+        matches.add(line);
+      }
+    }
+    return matches;
   }
 
   public static String getLogFilePath(String filename)

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/stats/listeners/IListenerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/stats/listeners/IListenerTest.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.listeners;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.collectors.SampleAggregator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSetTest;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class IListenerTest {
+  class Listener implements IListener {
+    private AtomicInteger count;
+
+    public Listener() {
+      count = new AtomicInteger(0);
+    }
+
+    @Override
+    public Set<MeasurementSet> getMeasurementsListenedTo() {
+      Set<MeasurementSet> set =
+          new HashSet() {
+            {
+              this.add(MeasurementSetTest.TEST_MEASUREMENT1);
+              this.add(MeasurementSetTest.TEST_MEASUREMENT2);
+            }
+          };
+      return set;
+    }
+
+    @Override
+    public void onOccurrence(MeasurementSet measurementSet, Number value, String key) {
+      count.getAndIncrement();
+    }
+  }
+
+  @Test
+  public void onOccurrence() {
+    Listener listener = new Listener();
+    SampleAggregator sampleAggregator =
+        new SampleAggregator(
+            listener.getMeasurementsListenedTo(), listener, MeasurementSetTest.values());
+
+    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT4, "", 1);
+    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT1, "", 1);
+    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT2, "", 1);
+
+    Assert.assertEquals(2, listener.count.get());
+  }
+}


### PR DESCRIPTION
 Add ways to mute misbehaving Graph nodes

    The RCA framework supports arbitrary code in the operate() methods for Symptom and RCA nodes.
    Therefore, there can be cases where this code can throw exceptions and cause. This patch
    introduces a way to mute these nodes. Muting a node means that the node's operate will not be
    called on subsequent runs and a call to their getFlowUnit will return an empty flow unit.

    The bais for muting nodes:
    - Number of exceptions thrown in the operate method per node.

    This patch introduces only one criterion to mute a node. But the framework is extensible.
    We should be able to write muters based on any measurement we capture.

*Issue #, if available:* #73 


*Tests:*
    Unit tests are added for this path and covers the code added here.

*Code coverage percentage for this patch:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
