### PR TITLE
Fix bug where the high heap usage cluster rca does not fetch remote f…

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/DummyGraph.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/DummyGraph.java
@@ -82,6 +82,6 @@ public class DummyGraph extends AnalysisGraph {
         new HighHeapUsageClusterRca(12, hotJVMNodeRca);
     highHeapUsageClusterRca.addTag(LOCUS, MASTER_NODE);
     highHeapUsageClusterRca.addAllUpstreams(Collections.singletonList(hotJVMNodeRca));
-
+    highHeapUsageClusterRca.addTag(RcaTagConstants.TAG_AGGREGATE_UPSTREAM, DATA_NODE);
   }
 }


### PR DESCRIPTION
*Description of changes:*
The aggregation tag was missing for high heap usage cluster RCA which prevented it from fetching flow units from remote nodes when running in a non single node scenario.

*Tests:*
Tested on docker with multi node configuration, single node configuration.

*Code coverage percentage for this patch:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
