### PR TITLE
Add AggregateMetric and top k consumer summary

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/HotResourceSummary.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/HotResourceSummary.java
@@ -74,7 +74,7 @@ public class HotResourceSummary extends GenericSummary {
         resourceName = this.resourceType.getJVM().getValueDescriptor()
             .getOptions().getExtension(PANetworking.resourceTypeName);
       }
-      else if (this.resourceType.getResourceTypeOneofCase() == ResourceTypeOneofCase.HARDWARERESOURCETYPE) {
+      else if (this.resourceType.getResourceTypeOneofCase() == ResourceTypeOneofCase.HARDWARE_RESOURCE_TYPE) {
         resourceName = this.resourceType.getHardwareResourceType().getValueDescriptor()
             .getOptions().getExtension(PANetworking.resourceTypeName);
       }
@@ -124,7 +124,7 @@ public class HotResourceSummary extends GenericSummary {
         message.getValue(), message.getUnitType(), message.getTimePeriod());
     newSummary
         .setValueDistribution(message.getMinValue(), message.getMaxValue(), message.getAvgValue());
-    if (message.hasConsumers() && message.getConsumers().getConsumerCount() > 0) {
+    if (message.hasConsumers()) {
       for (int i = 0; i < message.getConsumers().getConsumerCount(); i++) {
         newSummary.addNestedSummaryList(TopConsumerSummary.buildTopConsumerSummaryFromMessage(
             message.getConsumers().getConsumer(i)));
@@ -135,8 +135,17 @@ public class HotResourceSummary extends GenericSummary {
 
   @Override
   public String toString() {
-    return this.getResourceTypeName() + " "  + this.threshold + " "
-        + this.value + " " + this.unitType + this.nestedSummaryList;
+    return new StringBuilder()
+        .append(this.getResourceTypeName())
+        .append(" ")
+        .append(this.threshold)
+        .append(" ")
+        .append(this.value)
+        .append(" ")
+        .append(this.unitType)
+        .append(" ")
+        .append(this.nestedSummaryList)
+        .toString();
   }
 
   @Override

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/TopConsumerSummary.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/TopConsumerSummary.java
@@ -53,6 +53,11 @@ public class TopConsumerSummary extends GenericSummary {
     return summaryMessageBuilder.build();
   }
 
+  /**
+   * TopConsumerSummary is the lowest level summary in the nest sunmmary hierarchy.
+   * So it doesn't carry any nested summary list and thus we override this with a empty method here.
+   * @param messageBuilder
+   */
   @Override
   public void buildSummaryMessageAndAddToFlowUnit(FlowUnitMessage.Builder messageBuilder) {
   }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/TopConsumerSummary.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/TopConsumerSummary.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.TopConsumerSummaryMessage;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
+import java.util.ArrayList;
+import java.util.List;
+import org.jooq.Field;
+import org.jooq.impl.DSL;
+
+/**
+ * TopConsumerSummary contains the name and usage of a resource consumer.
+ */
+public class TopConsumerSummary extends GenericSummary {
+
+  private final String name;
+  private final double value;
+
+  public TopConsumerSummary(final String name, final double value) {
+    super();
+    this.name = name;
+    this.value = value;
+  }
+
+  public String getName() {
+    return this.name;
+  }
+
+  public double getValue() {
+    return this.value;
+  }
+
+  @Override
+  public TopConsumerSummaryMessage buildSummaryMessage() {
+    final TopConsumerSummaryMessage.Builder summaryMessageBuilder = TopConsumerSummaryMessage.newBuilder();
+    summaryMessageBuilder.setName(this.name);
+    summaryMessageBuilder.setValue(this.value);
+    return summaryMessageBuilder.build();
+  }
+
+  @Override
+  public void buildSummaryMessageAndAddToFlowUnit(FlowUnitMessage.Builder messageBuilder) {
+  }
+
+  public static TopConsumerSummary buildTopConsumerSummaryFromMessage(TopConsumerSummaryMessage message) {
+    TopConsumerSummary newSummary = new TopConsumerSummary(message.getName(), message.getValue());
+    return newSummary;
+  }
+
+  @Override
+  public String toString() {
+    return this.name + " " + this.value;
+  }
+
+  @Override
+  public List<Field<?>> getSqlSchema() {
+    List<Field<?>> schema = new ArrayList<>();
+    schema.add(DSL.field(DSL.name(TopConsumerSummary.SQL_SCHEMA_CONSTANTS.CONSUMER_NAME_COL_NAME), String.class));
+    schema.add(DSL.field(DSL.name(TopConsumerSummary.SQL_SCHEMA_CONSTANTS.CONSUMER_VALUE_COL_NAME), Double.class));
+    return schema;
+  }
+
+  @Override
+  public List<Object> getSqlValue() {
+    List<Object> value = new ArrayList<>();
+    value.add(this.name);
+    value.add(this.value);
+    return value;
+  }
+
+  public static class SQL_SCHEMA_CONSTANTS {
+
+    public static final String CONSUMER_NAME_COL_NAME = "Name";
+    public static final String CONSUMER_VALUE_COL_NAME = "Value";
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/TopConsumerSummary.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/TopConsumerSummary.java
@@ -56,7 +56,6 @@ public class TopConsumerSummary extends GenericSummary {
   /**
    * TopConsumerSummary is the lowest level summary in the nest sunmmary hierarchy.
    * So it doesn't carry any nested summary list and thus we override this with a empty method here.
-   * @param messageBuilder
    */
   @Override
   public void buildSummaryMessageAndAddToFlowUnit(FlowUnitMessage.Builder messageBuilder) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/AggregateMetric.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/AggregateMetric.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.MetricFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Queryable;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.jooq.impl.DSL;
+
+
+/**
+ * AggregateMetric can be used to group the sqlite from from write to one or more columns
+ * and perform sum aggregation and sorting function on the result
+ * For example, we can use this metric to collect the operations for cpu usage in descending
+ * order by constructing this Metric as follows:
+ * <p>
+ * new AggregateMetric(5, CPU_Utilization.NAME, CommonDimension.OPERATION.toString());
+ * </p>
+ */
+public class AggregateMetric extends Metric {
+
+  private static final Logger LOG = LogManager.getLogger(AggregateMetric.class);
+  public static final String NAME = AggregateMetric.class.getSimpleName();
+  private final String tableName;
+  private final List<String> groupByFieldsName;
+
+  public AggregateMetric(final long evaluationIntervalSeconds, final String tableName,
+      final String... groupByFieldsName) {
+    super(AggregateMetric.NAME, evaluationIntervalSeconds);
+    this.tableName = tableName;
+    this.groupByFieldsName = new ArrayList<>(Arrays.asList(groupByFieldsName));
+  }
+
+  @Override
+  public MetricFlowUnit gather(final Queryable queryable) {
+    LOG.debug("Metric: Trying to gather metrics for {}", tableName);
+    final Result<Record> result;
+    final List<Field<?>> groupByFieldsList = new ArrayList<>();
+    final List<Field<?>> fieldsList;
+    try {
+      final MetricsDB db = queryable.getMetricsDB();
+      final DSLContext context = db.getDSLContext();
+      groupByFieldsName.forEach(f -> groupByFieldsList.add(DSL.field(DSL.name(f))));
+      final Field<Double> numDimension = DSL.field(DSL.name(MetricsDB.AVG), Double.class);
+      final Field<BigDecimal> aggDimension = DSL.sum(numDimension);
+      fieldsList = new ArrayList<>(groupByFieldsList);
+      fieldsList.add(aggDimension);
+      result = context
+          .select(fieldsList)
+          .from(tableName)
+          .groupBy(groupByFieldsList)
+          .orderBy(aggDimension.desc())
+          .fetch();
+
+    } catch (Exception e) {
+      //TODO: Emit log/stats that gathering failed.
+      LOG.error("RCA: Caught an exception while getting the DB {}", e.getMessage());
+      return MetricFlowUnit.generic();
+    }
+    final List<List<String>> flowUnitData = new ArrayList<>();
+    flowUnitData.add(fieldsList.stream()
+        .map(Field::getName)
+        .collect(Collectors.toList()));
+    for (Record record : result) {
+      flowUnitData.add(fieldsList.stream()
+          .map(f -> record.getValue(f, String.class))
+          .collect(Collectors.toList()));
+    }
+    return new MetricFlowUnit(0, flowUnitData);
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/AggregateMetric.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/AggregateMetric.java
@@ -34,9 +34,9 @@ import org.jooq.impl.DSL;
 
 
 /**
- * AggregateMetric can be used to group the sqlite from from write to one or more columns
+ * AggregateMetric can be used to group the sqlite to one or more columns
  * and perform sum aggregation and sorting function on the result
- * For example, we can use this metric to collect the operations for cpu usage in descending
+ * For example, we can get the sum of cpu usage for each operation and sort them in descending
  * order by constructing this Metric as follows:
  * <p>
  * new AggregateMetric(5, CPU_Utilization.NAME, CommonDimension.OPERATION.toString());

--- a/src/main/proto/inter_node_rpc_service.proto
+++ b/src/main/proto/inter_node_rpc_service.proto
@@ -67,7 +67,7 @@ enum HardwareEnum {
 message ResourceType {
     oneof resource_type_oneof {
       JvmEnum JVM = 1;
-      HardwareEnum hardwareResourceType = 2;
+      HardwareEnum hardware_resource_type = 2;
     }
 }
 

--- a/src/main/proto/inter_node_rpc_service.proto
+++ b/src/main/proto/inter_node_rpc_service.proto
@@ -57,20 +57,25 @@ enum JvmEnum {
   YOUNG_GEN = 1 [(resourceTypeName) = "young gen"];
 }
 
+enum HardwareEnum {
+  CPU = 0 [(resourceTypeName) = "cpu usage"];
+}
+
 /*
   message for resource type Enum
 */
 message ResourceType {
     oneof resource_type_oneof {
       JvmEnum JVM = 1;
+      HardwareEnum hardwareResourceType = 2;
     }
 }
 
 /*
  message wrappers for different types of RCA summary
 */
-message ConsumersList {
-    repeated string consumer = 1;
+message TopConsumerSummaryList {
+    repeated TopConsumerSummaryMessage consumer = 1;
 }
 message HotResourceSummaryList {
     repeated HotResourceSummaryMessage hotResourceSummary = 1;
@@ -78,9 +83,13 @@ message HotResourceSummaryList {
 message HotNodeSummaryList {
     repeated HotNodeSummaryMessage hotNodeSummary = 1;
 }
+message TopConsumerSummaryMessage {
+    string name = 1;
+    double value = 2;
+}
 message HotResourceSummaryMessage {
     ResourceType resourceType = 1;
-    ConsumersList consumers = 2;
+    TopConsumerSummaryList consumers = 2;
     double threshold = 3;
     double value = 4;
     double avgValue = 5;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/metric/AggregateMetricTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/metric/AggregateMetricTest.java
@@ -1,0 +1,82 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.store.metric;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CommonDimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.MetricFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.CPU_Utilization;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Queryable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.spec.MetricsDBProviderTestHelper;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.AggregateMetric;
+import java.util.Arrays;
+import org.junit.Test;
+
+public class AggregateMetricTest {
+  private static final String TABLE_NAME = CPU_Utilization.NAME;
+
+  @Test
+  public void testGroupByOneColumn() throws Exception {
+    Queryable queryable = new MetricsDBProviderTestHelper(false);
+
+    ((MetricsDBProviderTestHelper) queryable)
+        .addNewData(
+            TABLE_NAME, Arrays.asList("shard1", "index3", "bulk", "primary"), 1);
+    ((MetricsDBProviderTestHelper) queryable)
+        .addNewData(
+            TABLE_NAME, Arrays.asList("shard2", "index3", "bulk", "primary"), 1);
+    ((MetricsDBProviderTestHelper) queryable)
+        .addNewData(
+            TABLE_NAME, Arrays.asList("shard1", "index3", "bulk", "primary"), 1);
+    ((MetricsDBProviderTestHelper) queryable)
+        .addNewData(
+            TABLE_NAME, Arrays.asList("shard2", "index3", "other", "primary"), 3);
+    ((MetricsDBProviderTestHelper) queryable)
+        .addNewData(
+            TABLE_NAME, Arrays.asList("shard1", "index3", "other", "primary"), 3);
+    ((MetricsDBProviderTestHelper) queryable)
+        .addNewData(
+            TABLE_NAME, Arrays.asList("shard2", "index3", "other", "primary"), 3);
+    Metric testMetric = new AggregateMetric(1, TABLE_NAME, CommonDimension.OPERATION.toString());
+    MetricFlowUnit flowUnit = testMetric.gather(queryable);
+    assertFalse(flowUnit.getData() == null || flowUnit.getData().isEmpty() || flowUnit.getData().get(0).isEmpty());
+    assertEquals("other", flowUnit.getData().get(1).get(0));
+    assertEquals("9.0", flowUnit.getData().get(1).get(1));
+    assertEquals("bulk", flowUnit.getData().get(2).get(0));
+    assertEquals("3.0", flowUnit.getData().get(2).get(1));
+  }
+
+  @Test
+  public void testGroupByTwoColumns() throws Exception {
+    Queryable queryable = new MetricsDBProviderTestHelper(false);
+
+    ((MetricsDBProviderTestHelper) queryable)
+        .addNewData(
+            TABLE_NAME, Arrays.asList("shard1", "index3", "bulk", "primary"), 4);
+    ((MetricsDBProviderTestHelper) queryable)
+        .addNewData(
+            TABLE_NAME, Arrays.asList("shard2", "index3", "bulk", "primary"), 1);
+    ((MetricsDBProviderTestHelper) queryable)
+        .addNewData(
+            TABLE_NAME, Arrays.asList("shard1", "index3", "bulk", "primary"), 1);
+    ((MetricsDBProviderTestHelper) queryable)
+        .addNewData(
+            TABLE_NAME, Arrays.asList("shard2", "index3", "other", "primary"), 3);
+    ((MetricsDBProviderTestHelper) queryable)
+        .addNewData(
+            TABLE_NAME, Arrays.asList("shard1", "index3", "other", "primary"), 3);
+    ((MetricsDBProviderTestHelper) queryable)
+        .addNewData(
+            TABLE_NAME, Arrays.asList("shard3", "index3", "other", "primary"), 10);
+    Metric testMetric = new AggregateMetric(1, TABLE_NAME, CommonDimension.SHARD_ID.toString(), CommonDimension.OPERATION.toString());
+    MetricFlowUnit flowUnit = testMetric.gather(queryable);
+    assertFalse(flowUnit.getData() == null || flowUnit.getData().isEmpty() || flowUnit.getData().get(0).isEmpty());
+    assertEquals("shard3", flowUnit.getData().get(1).get(0));
+    assertEquals("other", flowUnit.getData().get(1).get(1));
+    assertEquals("10.0", flowUnit.getData().get(1).get(2));
+    assertEquals("shard1", flowUnit.getData().get(2).get(0));
+    assertEquals("bulk", flowUnit.getData().get(2).get(1));
+    assertEquals("5.0", flowUnit.getData().get(2).get(2));
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Add AggregateMetric to group the sqlite metric to one or more columns and perform sum aggregation and sorting on top. 
2. Add Top consumer summary to store the top k consumers of hot resource and persist the top k in SQL.

*Tests:*
create a unit test for AggregateMetric

*Code coverage percentage for this patch:*
92%

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
