### PR TITLE
rename MeasurementSetTest to MeasurementSetTestHelper

### DIFF
--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/stats/collectors/SampleAggregatorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/stats/collectors/SampleAggregatorTest.java
@@ -25,7 +25,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.eval.im
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.eval.impl.vals.Value;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.format.DefaultFormatter;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSetTest;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSetTestHelper;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -91,12 +91,12 @@ public class SampleAggregatorTest {
 
   @Test
   public void updateStat() {
-    SampleAggregator sampleAggregator = new SampleAggregator(MeasurementSetTest.values());
+    SampleAggregator sampleAggregator = new SampleAggregator(MeasurementSetTestHelper.values());
 
     ISampler sampler =
         sampleCollector ->
             sampleCollector.updateStat(
-                MeasurementSetTest.JVM_FREE_MEM_SAMPLER, "", Runtime.getRuntime().freeMemory());
+                MeasurementSetTestHelper.JVM_FREE_MEM_SAMPLER, "", Runtime.getRuntime().freeMemory());
 
     PeriodicSamplers periodicSamplers =
         new PeriodicSamplers(
@@ -106,76 +106,76 @@ public class SampleAggregatorTest {
 
     Map<MeasurementSet, Map<Statistics, List<Value>>> expected = new HashMap<>();
 
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT1, "key1", 50L);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT1, "key1", 200L);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT1, "key1", 200L);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT1, "key2", 200L);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT1, "key3", 500L);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT1, "key1", 200L);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT1, "key1", 200L);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT1, "key1", 200L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT1, "key1", 50L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT1, "key1", 200L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT1, "key1", 200L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT1, "key2", 200L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT1, "key3", 500L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT1, "key1", 200L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT1, "key1", 200L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT1, "key1", 200L);
 
-    expected.put(MeasurementSetTest.TEST_MEASUREMENT1, new HashMap<>());
+    expected.put(MeasurementSetTestHelper.TEST_MEASUREMENT1, new HashMap<>());
     expected
-        .get(MeasurementSetTest.TEST_MEASUREMENT1)
+        .get(MeasurementSetTestHelper.TEST_MEASUREMENT1)
         .put(
             Statistics.MAX,
             Collections.singletonList(new NamedAggregateValue(500L, Statistics.MAX, "key3")));
     expected
-        .get(MeasurementSetTest.TEST_MEASUREMENT1)
+        .get(MeasurementSetTestHelper.TEST_MEASUREMENT1)
         .put(
             Statistics.MIN,
             Collections.singletonList(new NamedAggregateValue(50L, Statistics.MIN, "key1")));
     expected
-        .get(MeasurementSetTest.TEST_MEASUREMENT1)
+        .get(MeasurementSetTestHelper.TEST_MEASUREMENT1)
         .put(
             Statistics.MEAN,
             Collections.singletonList(new AggregateValue(1750.0 / 8, Statistics.MEAN)));
-    Assert.assertTrue(match(MeasurementSetTest.TEST_MEASUREMENT1, expected, sampleAggregator));
+    Assert.assertTrue(match(MeasurementSetTestHelper.TEST_MEASUREMENT1, expected, sampleAggregator));
 
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT2, "key1", 200L);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT2, "key1", 200L);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT2, "key1", 200L);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT2, "key1", 200L);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT2, "key1", 200L);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT2, "key1", 200L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT2, "key1", 200L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT2, "key1", 200L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT2, "key1", 200L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT2, "key1", 200L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT2, "key1", 200L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT2, "key1", 200L);
 
-    expected.put(MeasurementSetTest.TEST_MEASUREMENT2, new HashMap<>());
+    expected.put(MeasurementSetTestHelper.TEST_MEASUREMENT2, new HashMap<>());
     expected
-        .get(MeasurementSetTest.TEST_MEASUREMENT2)
+        .get(MeasurementSetTestHelper.TEST_MEASUREMENT2)
         .put(Statistics.COUNT, Collections.singletonList(new AggregateValue(6, Statistics.COUNT)));
-    Assert.assertTrue(match(MeasurementSetTest.TEST_MEASUREMENT2, expected, sampleAggregator));
+    Assert.assertTrue(match(MeasurementSetTestHelper.TEST_MEASUREMENT2, expected, sampleAggregator));
 
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT4, "key1", 200L);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT4, "key1", 300L);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT4, "key1", 100L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT4, "key1", 200L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT4, "key1", 300L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT4, "key1", 100L);
 
-    expected.put(MeasurementSetTest.TEST_MEASUREMENT4, new HashMap<>());
+    expected.put(MeasurementSetTestHelper.TEST_MEASUREMENT4, new HashMap<>());
     expected
-        .get(MeasurementSetTest.TEST_MEASUREMENT4)
+        .get(MeasurementSetTestHelper.TEST_MEASUREMENT4)
         .put(Statistics.SAMPLE, Collections.singletonList(new Value(100)));
-    Assert.assertTrue(match(MeasurementSetTest.TEST_MEASUREMENT4, expected, sampleAggregator));
+    Assert.assertTrue(match(MeasurementSetTestHelper.TEST_MEASUREMENT4, expected, sampleAggregator));
 
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT5, "key1", 200L);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT5, "key1", 300L);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT5, "key1", 100L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT5, "key1", 200L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT5, "key1", 300L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT5, "key1", 100L);
 
-    expected.put(MeasurementSetTest.TEST_MEASUREMENT5, new HashMap<>());
+    expected.put(MeasurementSetTestHelper.TEST_MEASUREMENT5, new HashMap<>());
     expected
-        .get(MeasurementSetTest.TEST_MEASUREMENT5)
+        .get(MeasurementSetTestHelper.TEST_MEASUREMENT5)
         .put(Statistics.SUM, Collections.singletonList(new AggregateValue(600, Statistics.SUM)));
-    Assert.assertTrue(match(MeasurementSetTest.TEST_MEASUREMENT5, expected, sampleAggregator));
+    Assert.assertTrue(match(MeasurementSetTestHelper.TEST_MEASUREMENT5, expected, sampleAggregator));
 
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT6, "key1", 200L);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT6, "key2", 300L);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT6, "key4", 100L);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT6, "key1", 200L);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT6, "key2", 300L);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT6, "key3", 100L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT6, "key1", 200L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT6, "key2", 300L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT6, "key4", 100L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT6, "key1", 200L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT6, "key2", 300L);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT6, "key3", 100L);
 
-    expected.put(MeasurementSetTest.TEST_MEASUREMENT6, new HashMap<>());
+    expected.put(MeasurementSetTestHelper.TEST_MEASUREMENT6, new HashMap<>());
     expected
-        .get(MeasurementSetTest.TEST_MEASUREMENT6)
+        .get(MeasurementSetTestHelper.TEST_MEASUREMENT6)
         .put(
             Statistics.NAMED_COUNTERS,
             Arrays.asList(
@@ -183,15 +183,15 @@ public class SampleAggregatorTest {
                 new NamedAggregateValue(2, Statistics.NAMED_COUNTERS, "key2"),
                 new NamedAggregateValue(1, Statistics.NAMED_COUNTERS, "key3"),
                 new NamedAggregateValue(1, Statistics.NAMED_COUNTERS, "key4")));
-    Assert.assertTrue(match(MeasurementSetTest.TEST_MEASUREMENT6, expected, sampleAggregator));
+    Assert.assertTrue(match(MeasurementSetTestHelper.TEST_MEASUREMENT6, expected, sampleAggregator));
 
-    reporter.isMeasurementCollected(MeasurementSetTest.JVM_FREE_MEM_SAMPLER);
+    reporter.isMeasurementCollected(MeasurementSetTestHelper.JVM_FREE_MEM_SAMPLER);
 
     DefaultFormatter defaultFormatter = new DefaultFormatter();
     sampleAggregator.fill(defaultFormatter);
 
     Set<MeasurementSet> skipList = new HashSet<>();
-    skipList.add(MeasurementSetTest.JVM_FREE_MEM_SAMPLER);
+    skipList.add(MeasurementSetTestHelper.JVM_FREE_MEM_SAMPLER);
     Assert.assertTrue(match(defaultFormatter.getFormatted(), expected, skipList));
 
     DefaultFormatter defaultFormatter1 = new DefaultFormatter();

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/stats/listeners/IListenerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/stats/listeners/IListenerTest.java
@@ -17,7 +17,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.listen
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.collectors.SampleAggregator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSetTest;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSetTestHelper;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -37,8 +37,8 @@ public class IListenerTest {
       Set<MeasurementSet> set =
           new HashSet() {
             {
-              this.add(MeasurementSetTest.TEST_MEASUREMENT1);
-              this.add(MeasurementSetTest.TEST_MEASUREMENT2);
+              this.add(MeasurementSetTestHelper.TEST_MEASUREMENT1);
+              this.add(MeasurementSetTestHelper.TEST_MEASUREMENT2);
             }
           };
       return set;
@@ -55,11 +55,11 @@ public class IListenerTest {
     Listener listener = new Listener();
     SampleAggregator sampleAggregator =
         new SampleAggregator(
-            listener.getMeasurementsListenedTo(), listener, MeasurementSetTest.values());
+            listener.getMeasurementsListenedTo(), listener, MeasurementSetTestHelper.values());
 
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT4, "", 1);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT1, "", 1);
-    sampleAggregator.updateStat(MeasurementSetTest.TEST_MEASUREMENT2, "", 1);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT4, "", 1);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT1, "", 1);
+    sampleAggregator.updateStat(MeasurementSetTestHelper.TEST_MEASUREMENT2, "", 1);
 
     Assert.assertEquals(2, listener.count.get());
   }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/stats/measurements/MeasurementSetTestHelper.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/stats/measurements/MeasurementSetTestHelper.java
@@ -19,7 +19,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.eval.St
 import java.util.Arrays;
 import java.util.List;
 
-public enum MeasurementSetTest implements MeasurementSet {
+public enum MeasurementSetTestHelper implements MeasurementSet {
   TEST_MEASUREMENT1(
       "TestMeasurement1", "micros", Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.MIN)),
   TEST_MEASUREMENT2("TestMeasurement2", "micros", Arrays.asList(Statistics.COUNT)),
@@ -33,7 +33,7 @@ public enum MeasurementSetTest implements MeasurementSet {
   private String unit;
   private List<Statistics> statsList;
 
-  MeasurementSetTest(String name, String unit, List<Statistics> statisticList) {
+  MeasurementSetTestHelper(String name, String unit, List<Statistics> statisticList) {
     this.name = name;
     this.unit = unit;
     this.statsList = statisticList;


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
rename MeasurementSetTest to MeasurementSetTestHelper to avoid "No runnable methods" error when using junit 4.X

*Tests:*

*Code coverage percentage for this patch:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
