### PR TITLE
Reverting the change to make MetricsConfiguration.CONFIG_MAP unmodifiable and adding a spotbug exception

### DIFF
--- a/checkstyle/findbugs-exclude.xml
+++ b/checkstyle/findbugs-exclude.xml
@@ -1,6 +1,6 @@
 <FindBugsFilter>
     <Match>
-        <Bug pattern="DM_DEFAULT_ENCODING" />
+        <Bug pattern="DM_DEFAULT_ENCODING"/>
     </Match>
     <Match>
         <Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.hwnet.Disks"/>
@@ -19,27 +19,27 @@
         <Bug pattern="REC_CATCH_EXCEPTION"/>
     </Match>
     <Match>
-	<Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector"/>
+        <Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector"/>
         <Bug pattern="LI_LAZY_INIT_STATIC"/>
     </Match>
     <Match>
-	<Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector"/>
+        <Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector"/>
         <Bug pattern="MS_CANNOT_BE_FINAL"/>
     </Match>
     <Match>
-	<Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector"/>
+        <Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector"/>
         <Bug pattern="MS_SHOULD_BE_FINAL"/>
     </Match>
     <Match>
-	<Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector"/>
+        <Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector"/>
         <Bug pattern="REC_CATCH_EXCEPTION"/>
     </Match>
     <Match>
-	<Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector"/>
+        <Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector"/>
         <Bug pattern="DC_DOUBLECHECK"/>
     </Match>
     <Match>
-        <Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.collectors.SampleAggregator" />
+        <Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.collectors.SampleAggregator"/>
         <Bug pattern="EI_EXPOSE_REP2"/>
     </Match>
     <Match>
@@ -62,12 +62,16 @@
         <Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.MetricsParser"/>
         <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
     </Match>
-  <!--Exclude gRPC generated classes-->
-  <Match>
-    <Package name="com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc"/>
-    <Or>
-      <Bug pattern="SE_BAD_FIELD"/>
-      <Bug pattern="UCF_USELESS_CONTROL_FLOW"/>
-    </Or>
-  </Match>
+    <Match>
+        <Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration"/>
+        <Bug pattern="MS_MUTABLE_COLLECTION"/>
+    </Match>
+    <!--Exclude gRPC generated classes-->
+    <Match>
+        <Package name="com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc"/>
+        <Or>
+            <Bug pattern="SE_BAD_FIELD"/>
+            <Bug pattern="UCF_USELESS_CONTROL_FLOW"/>
+        </Or>
+    </Match>
 </FindBugsFilter>

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/MetricsConfiguration.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/MetricsConfiguration.java
@@ -52,30 +52,26 @@ public class MetricsConfiguration {
     }
   }
 
-  public static final Map<Class, MetricConfig> CONFIG_MAP;
+  public static final Map<Class, MetricConfig> CONFIG_MAP = new HashMap<>();
   public static final MetricConfig cdefault;
 
   static {
     cdefault = new MetricConfig(SAMPLING_INTERVAL, 0, 0);
 
-    Map<Class, MetricConfig> configMapInitializer = new HashMap<>();
-
-    configMapInitializer.put(ThreadCPU.class, cdefault);
-    configMapInitializer.put(ThreadDiskIO.class, cdefault);
-    configMapInitializer.put(ThreadSched.class, cdefault);
-    configMapInitializer.put(ThreadList.class, cdefault);
-    configMapInitializer.put(GCMetrics.class, cdefault);
-    configMapInitializer.put(HeapMetrics.class, cdefault);
-    configMapInitializer.put(NetworkE2ECollector.class, cdefault);
-    configMapInitializer.put(NetworkInterfaceCollector.class, cdefault);
-    configMapInitializer.put(OSGlobals.class, cdefault);
-    configMapInitializer.put(PerformanceAnalyzerMetrics.class, new MetricConfig(0, ROTATION_INTERVAL, 0));
-    configMapInitializer.put(
+    CONFIG_MAP.put(ThreadCPU.class, cdefault);
+    CONFIG_MAP.put(ThreadDiskIO.class, cdefault);
+    CONFIG_MAP.put(ThreadSched.class, cdefault);
+    CONFIG_MAP.put(ThreadList.class, cdefault);
+    CONFIG_MAP.put(GCMetrics.class, cdefault);
+    CONFIG_MAP.put(HeapMetrics.class, cdefault);
+    CONFIG_MAP.put(NetworkE2ECollector.class, cdefault);
+    CONFIG_MAP.put(NetworkInterfaceCollector.class, cdefault);
+    CONFIG_MAP.put(OSGlobals.class, cdefault);
+    CONFIG_MAP.put(PerformanceAnalyzerMetrics.class, new MetricConfig(0, ROTATION_INTERVAL, 0));
+    CONFIG_MAP.put(
         MetricsPurgeActivity.class, new MetricConfig(ROTATION_INTERVAL, 0, DELETION_INTERVAL));
-    configMapInitializer.put(StatsCollector.class, new MetricConfig(STATS_ROTATION_INTERVAL, 0, 0));
-    configMapInitializer.put(DisksCollector.class, cdefault);
-    configMapInitializer.put(HeapMetricsCollector.class, cdefault);
-
-    CONFIG_MAP = Collections.unmodifiableMap(configMapInitializer);
+    CONFIG_MAP.put(StatsCollector.class, new MetricConfig(STATS_ROTATION_INTERVAL, 0, 0));
+    CONFIG_MAP.put(DisksCollector.class, cdefault);
+    CONFIG_MAP.put(HeapMetricsCollector.class, cdefault);
   }
 }


### PR DESCRIPTION
*Description of changes:*
The code in the performance-analyzer repo adds to the statically initialized map here.
Making it un-modifiable stops the ES plugin from coming up.

*Tests:*

*Code coverage percentage for this patch:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
