### PR TITLE
Fix bug where metrics are not retrieved for all nodes

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerApp.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerApp.java
@@ -23,6 +23,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.Troublesho
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.core.Util;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsRestUtil;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.handler.MetricsServerHandler;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.GRPCConnectionManager;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetClient;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetServer;
@@ -159,6 +160,7 @@ public class PerformanceAnalyzerApp {
     NetClient netClient = new NetClient(connectionManager);
     MetricsRestUtil metricsRestUtil = new MetricsRestUtil();
 
+    netServer.setMetricsHandler(new MetricsServerHandler());
     startRpcServerThread(netServer);
     HttpServer httpServer = createInternalServer(PluginSettings.instance(), getPortNumber());
     httpServer.createContext(QUERY_URL, new QueryMetricsRequestHandler(netClient, metricsRestUtil));

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/net/NetServer.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/net/NetServer.java
@@ -193,10 +193,38 @@ public class NetServer extends InterNodeRpcServiceGrpc.InterNodeRpcServiceImplBa
     this.metricsServerHandler = metricsServerHandler;
   }
 
+  /**
+   * Unit test usage only.
+   * @return Current handler for /metrics rpc.
+   */
+  public MetricsServerHandler getMetricsServerHandler() {
+    return metricsServerHandler;
+  }
+
+  /**
+   * Unit test usage only.
+   * @return Current handler for /publish rpc.
+   */
+  public PublishRequestHandler getSendDataHandler() {
+    return sendDataHandler;
+  }
+
+  /**
+   * Unit test usage only.
+   * @return Current handler for /subscribe rpc.
+   */
+  public SubscribeServerHandler getSubscribeHandler() {
+    return subscribeHandler;
+  }
+
   public void stop() {
     LOG.debug("indicating upstream nodes that current node is going down..");
     if (sendDataHandler != null) {
       sendDataHandler.terminateUpstreamConnections();
     }
+
+    // Remove handlers.
+    sendDataHandler = null;
+    subscribeHandler = null;
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -356,7 +356,6 @@ public class RcaController {
       this.rcaScheduler =
           new RCAScheduler(connectedComponents, db, rcaConf, thresholdMain, persistable, net);
 
-      rcaNetServer.setMetricsHandler(new MetricsServerHandler());
       rcaNetServer.setSendDataHandler(new PublishRequestHandler(
           nodeStateManager, receivedFlowUnitStore, networkThreadPoolReference));
       rcaNetServer.setSubscribeHandler(

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
@@ -26,7 +26,6 @@ import org.jooq.tools.json.JSONObject;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -158,9 +157,11 @@ public class RcaControllerTest {
     changeRcaRunState(RcaState.RUN);
     AllMetrics.NodeRole nodeRole = AllMetrics.NodeRole.MASTER;
     setMyIp("192.168.0.1", nodeRole);
-    Assert.assertTrue(check(new RcaSchedulerRunningEval(rcaController), RcaSchedulerState.STATE_STARTED));
+    Assert.assertTrue(
+        check(new RcaSchedulerRunningEval(rcaController), RcaSchedulerState.STATE_STARTED));
     Assert.assertTrue(check(new RcaSchedulerRoleEval(rcaController), nodeRole));
-    Assert.assertEquals(RcaSchedulerState.STATE_STARTED, rcaController.getRcaScheduler().getState());
+    Assert
+        .assertEquals(RcaSchedulerState.STATE_STARTED, rcaController.getRcaScheduler().getState());
 
     nodeRole = AllMetrics.NodeRole.ELECTED_MASTER;
     setMyIp("192.168.0.1", nodeRole);
@@ -171,13 +172,45 @@ public class RcaControllerTest {
 
     nodeRole = AllMetrics.NodeRole.DATA;
     setMyIp("192.168.0.1", nodeRole);
-    Assert.assertTrue(check(new RcaSchedulerRunningEval(rcaController), RcaSchedulerState.STATE_STARTED));
+    Assert.assertTrue(
+        check(new RcaSchedulerRunningEval(rcaController), RcaSchedulerState.STATE_STARTED));
     Assert.assertTrue(check(new RcaSchedulerRoleEval(rcaController), nodeRole));
     Assert.assertEquals(rcaController.getRcaScheduler().getRole(), nodeRole);
 
     changeRcaRunState(RcaState.STOP);
-    Assert.assertTrue(check(new RcaSchedulerRunningEval(rcaController), RcaSchedulerState.STATE_STOPPED));
-    Assert.assertEquals(RcaSchedulerState.STATE_STOPPED, rcaController.getRcaScheduler().getState());
+    Assert.assertTrue(
+        check(new RcaSchedulerRunningEval(rcaController), RcaSchedulerState.STATE_STOPPED));
+    Assert
+        .assertEquals(RcaSchedulerState.STATE_STOPPED, rcaController.getRcaScheduler().getState());
+  }
+
+  @Test
+  public void testHandlers() throws IOException {
+    // Only the metrics rpc handler should be set.
+    Assert.assertNotNull(clientServers.getNetServer().getMetricsServerHandler());
+    Assert.assertNull(clientServers.getNetServer().getSubscribeHandler());
+    Assert.assertNull(clientServers.getNetServer().getSendDataHandler());
+
+    changeRcaRunState(RcaState.RUN);
+    AllMetrics.NodeRole nodeRole = AllMetrics.NodeRole.MASTER;
+    setMyIp("192.168.0.1", nodeRole);
+    Assert.assertTrue(
+        check(new RcaSchedulerRunningEval(rcaController), RcaSchedulerState.STATE_STARTED));
+    Assert.assertTrue(check(new RcaSchedulerRoleEval(rcaController), nodeRole));
+
+    // Both RCA and metrics handlers should be set.
+    Assert.assertNotNull(clientServers.getNetServer().getMetricsServerHandler());
+    Assert.assertNotNull(clientServers.getNetServer().getSubscribeHandler());
+    Assert.assertNotNull(clientServers.getNetServer().getSendDataHandler());
+
+    // Metrics handler should still be set.
+    changeRcaRunState(RcaState.STOP);
+    Assert.assertTrue(
+        check(new RcaSchedulerRunningEval(rcaController), RcaSchedulerState.STATE_STOPPED));
+
+    Assert.assertNotNull(clientServers.getNetServer().getMetricsServerHandler());
+    Assert.assertNull(clientServers.getNetServer().getSubscribeHandler());
+    Assert.assertNull(clientServers.getNetServer().getSendDataHandler());
   }
 
   private void setMyIp(String ip, AllMetrics.NodeRole nodeRole) {
@@ -229,10 +262,12 @@ public class RcaControllerTest {
   }
 
   interface IEval<T> {
+
     boolean evaluateAndCheck(T t);
   }
 
   class RcaEnabledEval implements IEval<Boolean> {
+
     private final RcaController rcaController;
 
     RcaEnabledEval(RcaController rcaController) {
@@ -246,6 +281,7 @@ public class RcaControllerTest {
   }
 
   class NodeRoleEval implements IEval<AllMetrics.NodeRole> {
+
     private final RcaController rcaController;
 
     NodeRoleEval(RcaController rcaController) {
@@ -259,6 +295,7 @@ public class RcaControllerTest {
   }
 
   class RcaSchedulerRoleEval implements IEval<AllMetrics.NodeRole> {
+
     private final RcaController rcaController;
 
     RcaSchedulerRoleEval(RcaController rcaController) {
@@ -273,6 +310,7 @@ public class RcaControllerTest {
   }
 
   class RcaSchedulerRunningEval implements IEval<RcaSchedulerState> {
+
     private final RcaController rcaController;
 
     RcaSchedulerRunningEval(RcaController rcaController) {


### PR DESCRIPTION
*Issue #, if available:*
NA
*Description of changes:*
Currently, if only performance analyzer is turned on, then the handler for /metrics RPC is not registered at all. This will cause perf-top to not show metrics for other nodes in the cluster as the requests time out due to no handler being set for the /metrics RPC.

We only register the handler when RCA is turned on in the start() method of the controller.

This change registers the metrics RPC handler regardless of RCA state if performance analyzer is turned on. It is de-registered only when the sidecar is killed which happens when performance analyzer is disabled.

*Tests:*
Added new test case for the RCA Controller to checks the state of the handlers during turning on and off of RCA.

*Code coverage percentage for this patch:*
line: 63%, branch: 56%

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
