### PR TITLE
RCA persistence framework refactorings.

### DIFF
--- a/checkstyle/findbugs-exclude.xml
+++ b/checkstyle/findbugs-exclude.xml
@@ -66,6 +66,10 @@
         <Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration"/>
         <Bug pattern="MS_MUTABLE_COLLECTION"/>
     </Match>
+    <Match>
+        <Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.FileRotate"/>
+        <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
+    </Match>
     <!--Exclude gRPC generated classes-->
     <Match>
         <Package name="com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc"/>

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -369,7 +369,8 @@ public class RcaController {
         | InstantiationException
         | IllegalAccessException
         | MalformedConfig
-        | SQLException e) {
+        | SQLException
+            | IOException e) {
       LOG.error("Couldn't build connected components or persistable.. Ran into {}", e.getMessage());
       e.printStackTrace();
     }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/RcaConsts.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/RcaConsts.java
@@ -60,7 +60,7 @@ public class RcaConsts {
   public static final String DATASTORE_STATE_COL_NAME = "state";
   public static final String DATASTORE_STORAGE_FILE_RETENTION_COUNT = "storage-file-retention-count";
 
-  // The next two lines says that that the RCA sqlite files needs to be rotated every hour
+  // The next two lines says that the RCA sqlite files needs to be rotated every hour
   public static final TimeUnit DB_FILE_ROTATION_TIME_UNIT = TimeUnit.HOURS;
   public static final long ROTATION_PERIOD = 1;
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/RcaConsts.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/RcaConsts.java
@@ -60,6 +60,10 @@ public class RcaConsts {
   public static final String DATASTORE_STATE_COL_NAME = "state";
   public static final String DATASTORE_STORAGE_FILE_RETENTION_COUNT = "storage-file-retention-count";
 
+  // The next two lines says that that the RCA sqlite files needs to be rotated every hour
+  public static final TimeUnit DB_FILE_ROTATION_TIME_UNIT = TimeUnit.HOURS;
+  public static final long ROTATION_PERIOD = 1;
+
   public static final long rcaNannyPollerPeriodicity = 5;
   public static final long rcaConfPollerPeriodicity = 5;
   public static final long nodeRolePollerPeriodicity = 60;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/FileGC.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/FileGC.java
@@ -1,0 +1,147 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.comparator.LastModifiedFileComparator;
+import org.apache.commons.io.filefilter.WildcardFileFilter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/** This makes sure that we only keep a fixed number of DB files based on age and count. */
+public class FileGC {
+  private static final Logger LOG = LogManager.getLogger(FileGC.class);
+
+  private final Path DB_DIR;
+  private final String BASE_DB_FILENAME;
+  private final TimeUnit TIME_UNIT;
+  private final long PERIODICITY;
+  private final int FILES_COUNT;
+
+  private final String WILDCARD_CHARACTER = "*";
+
+  protected Deque<File> eligibleForGc;
+
+  FileGC(
+      Path db_dir,
+      String base_db_filename,
+      TimeUnit time_unit,
+      long periodicity1,
+      int files_count) {
+    this(
+        db_dir, base_db_filename, time_unit, periodicity1, files_count, System.currentTimeMillis());
+  }
+
+  FileGC(
+      Path db_dir,
+      String base_db_filename,
+      TimeUnit time_unit,
+      long periodicity1,
+      int files_count,
+      long currentMillis) {
+    DB_DIR = db_dir;
+    BASE_DB_FILENAME = base_db_filename;
+
+    TIME_UNIT = time_unit;
+    PERIODICITY = periodicity1;
+    FILES_COUNT = files_count;
+
+    List<File> remainingFiles = cleanupAndGetRemaining(currentMillis);
+
+    eligibleForGc = new LinkedList<>(remainingFiles);
+  }
+
+  /**
+   * When we add a newly rotated file, this method checks if the current count of the garbage files
+   * is above the threshold, then it removes the oldest file to keep the count under FILES_COUNT.
+   *
+   * @param filename The name of the new file to be added.
+   */
+  void eligibleForGc(String filename) {
+    File file = Paths.get(DB_DIR.toString(), filename).toFile();
+    if (file.exists()) {
+      eligibleForGc.addLast(file);
+
+      if (eligibleForGc.size() > FILES_COUNT) {
+        File oldestFile = eligibleForGc.removeFirst();
+        delete(oldestFile);
+      }
+    }
+  }
+
+  protected List<File> cleanupAndGetRemaining(long currentMillis) {
+    String[] files = getDbFiles();
+    List<File> afterCleaningOldFiles = timeBasedCleanup(files, currentMillis);
+    return countBasedCleanup(afterCleaningOldFiles);
+  }
+
+  protected String[] getDbFiles() {
+    return DB_DIR
+        .toFile()
+        .list(new WildcardFileFilter(BASE_DB_FILENAME + "." + WILDCARD_CHARACTER));
+  }
+
+  protected List<File> timeBasedCleanup(String[] files, final long currentMillis) {
+    long timeDelta = TimeUnit.MILLISECONDS.convert(PERIODICITY, TIME_UNIT) * (FILES_COUNT + 1);
+    long timeLimit = currentMillis - timeDelta;
+
+    List<File> remainingFiles = new ArrayList<>();
+
+    for (String file : files) {
+      Path filePath = Paths.get(DB_DIR.toString(), file);
+      long lastModified = filePath.toFile().lastModified();
+
+      if (lastModified < timeLimit) {
+        delete(filePath.toFile());
+      } else {
+        remainingFiles.add(filePath.toFile());
+      }
+    }
+    return remainingFiles;
+  }
+
+  protected List<File> countBasedCleanup(List<File> files) {
+    int numToDelete = files.size() - FILES_COUNT;
+    Collections.sort(files, LastModifiedFileComparator.LASTMODIFIED_COMPARATOR);
+
+    int deletedSoFar = 0;
+    List<File> remainingFiles = new ArrayList<>();
+
+    for (File file : files) {
+      if (deletedSoFar < numToDelete) {
+        delete(file);
+        deletedSoFar += 1;
+      } else {
+        remainingFiles.add(file);
+      }
+    }
+    return remainingFiles;
+  }
+
+  private void delete(File file) {
+    if (!file.delete()) {
+      LOG.error("Could not delete file: '{}'", file.getName());
+    }
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/FileRotate.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/FileRotate.java
@@ -1,0 +1,133 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence;
+
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.DateFormat;
+import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class FileRotate {
+  private static final Logger LOG = LogManager.getLogger(FileRotate.class);
+
+  private final Path FILE_TO_ROTATE;
+  private final String FILENAME;
+  private final TimeUnit ROTATION_TIME_UNIT;
+  private final long ROTATION_PERIOD;
+  private final DateFormat ROTATED_FILE_FORMAT;
+  protected long lastRotatedMillis;
+  private static final String FILE_PART_SEPARATOR = ".";
+
+  FileRotate(
+      Path file_to_rotate,
+      TimeUnit rotation_time_unit,
+      long rotation_period,
+      DateFormat rotated_file_format) {
+    FILE_TO_ROTATE = file_to_rotate;
+    FILENAME = file_to_rotate.toFile().getName();
+    ROTATION_TIME_UNIT = rotation_time_unit;
+    ROTATION_PERIOD = rotation_period;
+    ROTATED_FILE_FORMAT = rotated_file_format;
+    lastRotatedMillis = System.currentTimeMillis();
+  }
+
+  /**
+   * Try to rotate the file.
+   *
+   * <p>The file is rotated only if the current time is past the ROTATION_PERIOD.
+   *
+   * @return null if the file was not rotated because it is not old enough, or the name of the file
+   *     after rotation.
+   */
+  Path tryRotate(long currentTimeMillis) throws IOException {
+    if (shouldRotate(currentTimeMillis)) {
+      return rotate(currentTimeMillis);
+    }
+    return null;
+  }
+
+  /**
+   * This does not check for the validity of the condition for rotation. Just rotates the file.
+   *
+   * <p>This can be called when say, the DB file is corrupted and we just want to rotate and create
+   * a new file instead of throwing away data in this iteration.
+   *
+   * @return Path to the file after it is rotated or null if it ran into a problem trying to do so.
+   */
+  Path forceRotate(long currentTimeMillis) throws IOException {
+    return rotate(currentTimeMillis);
+  }
+
+  /**
+   * This checks for the condition for file rotation.
+   *
+   * <p>This usually checks if the time since last rotation is past the {@code ROTATION_PERIOD}.
+   *
+   * @return
+   */
+  protected boolean shouldRotate(long currentTimeMillis) {
+    long timeSinceLastRotation = currentTimeMillis - lastRotatedMillis;
+    long timeUnitsPassed = ROTATION_TIME_UNIT.convert(timeSinceLastRotation, TimeUnit.MILLISECONDS);
+    return timeUnitsPassed >= ROTATION_PERIOD;
+  }
+
+  /**
+   * Rotate the file.
+   *
+   * <p>Rotating a file renames it to filename.#current time in the date format specified#. For
+   * cases the file could not be renamed, we attempt to delete the file. If the file could not be
+   * deleted either, we throw an IOException for the caller to handle or take the necessary action.
+   *
+   * @return Returns the path to the file after it was rotated.
+   */
+  protected Path rotate(long currentMillis) throws IOException {
+    if (!FILE_TO_ROTATE.toFile().exists()) {
+      return null;
+    }
+    if (FILE_TO_ROTATE.getParent() == null) {
+      return null;
+    }
+
+    String dir = FILE_TO_ROTATE.getParent().toString();
+    StringBuilder targetFileName = new StringBuilder(FILENAME);
+    targetFileName.append(FILE_PART_SEPARATOR).append(ROTATED_FILE_FORMAT.format(currentMillis));
+
+    Path targetFilePath = Paths.get(dir, targetFileName.toString());
+    try {
+      lastRotatedMillis = System.currentTimeMillis();
+      Files.move(FILE_TO_ROTATE, targetFilePath);
+    } catch (FileAlreadyExistsException fae) {
+      LOG.error(fae);
+    } catch (IOException e) {
+      LOG.error(
+          "Could not RENAME file '{}' to '{}'. Error: {}", FILENAME, targetFileName, e.getCause());
+      try {
+        LOG.info("Attempting to delete file '{}'", FILENAME);
+        Files.deleteIfExists(FILE_TO_ROTATE);
+      } catch (IOException ex) {
+        LOG.error("Could not DELETE file '{}'. Error: {}", FILENAME, ex.getCause());
+        throw ex;
+      }
+      return null;
+    }
+    return targetFilePath;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
@@ -18,6 +18,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.response.RcaResponse;
+import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
 
@@ -38,7 +39,7 @@ public interface Persistable {
    * @param node Node whose flow unit is persisted.
    * @param flowUnit The flow unit that is persisted.
    */
-  <T extends ResourceFlowUnit> void write(Node<?> node, T flowUnit);
+  <T extends ResourceFlowUnit> void write(Node<?> node, T flowUnit) throws SQLException, IOException;
 
   void close() throws SQLException;
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistenceFactory.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistenceFactory.java
@@ -18,6 +18,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.exceptions.MalformedConfig;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
+import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Map;
 
@@ -31,14 +32,15 @@ import java.util.Map;
  * OSS can write an adaptor to their favorite data store.
  */
 public class PersistenceFactory {
-  public static Persistable create(RcaConf rcaConf) throws MalformedConfig, SQLException {
+  public static Persistable create(RcaConf rcaConf) throws MalformedConfig, SQLException, IOException {
     Map<String, String> datastore = rcaConf.getDatastore();
     switch (datastore.get(RcaConsts.DATASTORE_TYPE_KEY).toLowerCase()) {
       case "sqlite":
         return new SQLitePersistor(
             datastore.get(RcaConsts.DATASTORE_LOC_KEY),
             datastore.get(RcaConsts.DATASTORE_FILENAME),
-            datastore.get(RcaConsts.DATASTORE_STORAGE_FILE_RETENTION_COUNT));
+            datastore.get(RcaConsts.DATASTORE_STORAGE_FILE_RETENTION_COUNT),
+                RcaConsts.DB_FILE_ROTATION_TIME_UNIT, RcaConsts.ROTATION_PERIOD);
       default:
         String err = "The datastore value can only be sqlite in any case format";
         throw new MalformedConfig(rcaConf.getConfigFileLoc(), err);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistorBase.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistorBase.java
@@ -55,6 +55,11 @@ public abstract class PersistorBase implements Persistable {
   private final FileRotate fileRotate;
   private final FileGC fileGC;
 
+  enum RotationType {
+    TRY_ROTATE,
+    FORCE_ROTATE
+  }
+
   PersistorBase(String dir, String filename, String dbProtocolString,
                 String storageFileRetentionCount, TimeUnit fileRotationTimeUnit,
                 long fileRotationPeriod) throws SQLException, IOException {
@@ -155,28 +160,64 @@ public abstract class PersistorBase implements Persistable {
       return;
     }
 
-    Path rotatedFile = fileRotate.tryRotate(System.currentTimeMillis());
-    if (rotatedFile != null) {
-      fileGC.eligibleForGc(rotatedFile.toFile().getName());
-      openNewDBFile();
-    }
+    rotateRegisterGarbageThenCreateNewDB(RotationType.TRY_ROTATE);
 
     try {
       writeFlowUnit(flowUnit, node.name());
     } catch (SQLException e) {
       LOG.error(
-          "RCA: Caught SQLException while writing flowuni.", e);
+          "RCA: Multiple attempts to write the data for table '{}' failed", node.name(), e);
+
+      // We rethrow this exception so that framework can take appropriate action.
+      throw e;
     }
   }
 
-  private synchronized <T extends ResourceFlowUnit> void writeFlowUnit(
-      T flowUnit, String tableName) throws SQLException {
+  private void rotateRegisterGarbageThenCreateNewDB(RotationType type) throws IOException, SQLException {
+    Path rotatedFile = null;
+    switch (type) {
+      case FORCE_ROTATE:
+        rotatedFile = fileRotate.forceRotate(System.currentTimeMillis());
+        break;
+      case TRY_ROTATE:
+        rotatedFile = fileRotate.tryRotate(System.currentTimeMillis());
+        break;
+    }
+    if (rotatedFile != null) {
+      fileGC.eligibleForGc(rotatedFile.toFile().getName());
+      openNewDBFile();
+    }
+  }
+
+  /**
+   * Writing a flow unit can fail if the DB file does not exist or if it is corrupted. In such
+   * cases, we create a new file and attempt to write the data in the new file.
+   * @param flowUnit The flow unit to be persisted.
+   * @param tableName The name of the table the data is to be persisted in.
+   * @param <T> The Type of flowUnit.
+   * @throws SQLException This is thrown when the DB files does not exist or the schema is
+   *     corrupted.
+   * @throws IOException This is thrown if the attempt to create a new DB file fails.
+   */
+  private <T extends ResourceFlowUnit> void writeFlowUnit(
+      T flowUnit, String tableName) throws SQLException, IOException {
     try {
+        tryWriteFlowUnit(flowUnit, tableName);
+    } catch (SQLException e) {
+      LOG.info(
+          "RCA: Fail to write to table '{}', try creating a new DB", tableName);
+      rotateRegisterGarbageThenCreateNewDB(RotationType.FORCE_ROTATE);
+      tryWriteFlowUnit(flowUnit, tableName);
+    }
+  }
+
+  private <T extends ResourceFlowUnit> void tryWriteFlowUnit(
+          T flowUnit, String tableName) throws SQLException {
       if (!tableNames.contains(tableName)) {
         LOG.info(
-            "RCA: Table '{}' does not exist. Creating one with columns: {}",
-            tableName,
-            flowUnit.getSqlSchema());
+                "RCA: Table '{}' does not exist. Creating one with columns: {}",
+                tableName,
+                flowUnit.getSqlSchema());
         createTable(tableName, flowUnit.getSqlSchema());
         tableNames.add(tableName);
       }
@@ -184,21 +225,15 @@ public abstract class PersistorBase implements Persistable {
 
       if (flowUnit.hasResourceSummary()) {
         writeSummary(
-            flowUnit.getResourceSummary(),
-            tableName,
-            getPrimaryKeyColumnName(tableName),
-            lastPrimaryKey);
+                flowUnit.getResourceSummary(),
+                tableName,
+                getPrimaryKeyColumnName(tableName),
+                lastPrimaryKey);
       }
-    } catch (SQLException e) {
-      LOG.info(
-          "RCA: Fail to write into table '{}', try recreating the DB", tableName);
-      openNewDBFile();
-    }
   }
 
-
   /** recursively insert nested summary to sql tables */
-  private synchronized void writeSummary(
+  private void writeSummary(
       GenericSummary summary,
       String referenceTable,
       String referenceTablePrimaryKeyFieldName,

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistorBase.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistorBase.java
@@ -20,21 +20,19 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.response.RcaResponse;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.text.DateFormat;
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.apache.commons.io.filefilter.WildcardFileFilter;
+import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jooq.Field;
@@ -42,7 +40,7 @@ import org.jooq.Field;
 // TODO: Scheme to rotate the current file and garbage collect older files.
 public abstract class PersistorBase implements Persistable {
   private static final Logger LOG = LogManager.getLogger(PersistorBase.class);
-  protected final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd-HH-mm");
+  protected final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss");
   protected String dir;
   protected String filename;
   protected Connection conn;
@@ -50,24 +48,22 @@ public abstract class PersistorBase implements Persistable {
   protected Date fileCreateTime;
   protected String filenameParam;
   protected String dbProtocol;
-  private static final int FILE_ROTATION_PERIOD_SECS = 3600;
   private final int STORAGE_FILE_RETENTION_COUNT;
   private static final int STORAGE_FILE_RETENTION_COUNT_DEFAULT_VALUE = 5;
   private final File dirDB;
-  private static final String WILDCARD_CHARACTER = "*";
 
-  PersistorBase(String dir, String filename, String dbProtocolString, String storageFileRetentionCount) throws SQLException {
+  private final FileRotate fileRotate;
+  private final FileGC fileGC;
+
+  PersistorBase(String dir, String filename, String dbProtocolString,
+                String storageFileRetentionCount, TimeUnit fileRotationTimeUnit,
+                long fileRotationPeriod) throws SQLException, IOException {
     this.dir = dir;
     this.filenameParam = filename;
     this.dbProtocol = dbProtocolString;
-    this.fileCreateTime = new Date(System.currentTimeMillis());
-    this.filename =
-        String.format(
-            "%s.%s", Paths.get(dir, filename).toString(), dateFormat.format(this.fileCreateTime));
-    this.tableNames = new HashSet<>();
-    String url = String.format("%s%s", dbProtocolString, this.filename);
-    conn = DriverManager.getConnection(url);
+
     this.dirDB = new File(this.dir);
+
     int parsedStorageFileRetentionCount;
     try {
       parsedStorageFileRetentionCount = Integer.parseInt(storageFileRetentionCount);
@@ -76,6 +72,14 @@ public abstract class PersistorBase implements Persistable {
       LOG.error(String.format("Unable to parse '%s' as integer", storageFileRetentionCount));
     }
     this.STORAGE_FILE_RETENTION_COUNT = parsedStorageFileRetentionCount;
+
+    Path path = Paths.get(dir, filenameParam);
+    fileRotate = new FileRotate(path, fileRotationTimeUnit, fileRotationPeriod, dateFormat);
+    fileRotate.forceRotate(System.currentTimeMillis());
+
+    fileGC =  new FileGC(Paths.get(dir), filenameParam, fileRotationTimeUnit, fileRotationPeriod,
+            STORAGE_FILE_RETENTION_COUNT);
+    openNewDBFile();
   }
 
   @Override
@@ -122,10 +126,7 @@ public abstract class PersistorBase implements Persistable {
 
   public synchronized void openNewDBFile() throws SQLException {
     this.fileCreateTime = new Date(System.currentTimeMillis());
-    this.filename =
-        String.format(
-            "%s.%s",
-            Paths.get(dir, filenameParam).toString(), dateFormat.format(this.fileCreateTime));
+    this.filename = Paths.get(dir, filenameParam).toString();
     this.tableNames = new HashSet<>();
     String url = String.format("%s%s", this.dbProtocol, this.filename);
     close();
@@ -135,88 +136,33 @@ public abstract class PersistorBase implements Persistable {
   }
 
   /**
-   * This method check if there is a need to delete old sqlite files and create a new one.
-   * Ideally we will be using new sqlite files at the start of every hour, ideally the whenever the
-   * function write is called for the first time in that very hour
+   * This is used to persist a FlowUnit in the database.
+   *
+   * <p>Before, we write anything the flowUnit is not empty and if we are past the rotation period,
+   * then we rotate the database file and create a new one.
+   * @param node Node whose flow unit is persisted. The graph node whose data is being written
+   * @param flowUnit The flow unit that is persisted. The data taht will be persisted.
+   * @param <T> The FlowUnit type
+   * @throws SQLException A SQLException is thrown if we are unable to create a new connection
+   *     after the file rotation or while writing to the data base.
+   * @throws IOException This is thrown if we are unable to delete the old database files.
    */
-  public synchronized void rotateDBIfRequired() throws ParseException, SQLException {
-    LocalDateTime currentLocalDateTime = getLocalDateTimeFromDateObj(new Date());
-    LocalDateTime currentFileLocalDateTime = getLocalDateTimeFromDateObj(this.fileCreateTime);
-    // this means file creation date and hour is less than current hour, hence we will rotate the file
-    if (currentFileLocalDateTime.isBefore(currentLocalDateTime)) {
-      openNewDBFile();
-      deleteOldDBFile();
-    }
-  }
-
-  public LocalDateTime getLocalDateTimeFromDateObj(Date dateToConvert) {
-    return dateToConvert.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime().truncatedTo(
-        ChronoUnit.HOURS);
-  }
-
-  public synchronized String getFilesInDirDB(String datePrefix) {
-    String[] files =
-        this.dirDB.list(
-            new WildcardFileFilter(
-                String.format("%s.%s%s", filenameParam, datePrefix, WILDCARD_CHARACTER)));
-
-    return (files == null || files.length == 0) ? "" : Paths.get(this.dir, files[0]).toString();
-  }
-
-  public synchronized String getDBFilePath(int hours) throws ParseException {
-    Date hoursBeforeFileCreateMs =
-        new Date(this.fileCreateTime.getTime() - ((long) hours * 60 * 60 * 1000));
-    DateFormat df = new SimpleDateFormat("yyyy-MM-dd-HH");
-    String oldDBFilePath = getFilesInDirDB(df.format(hoursBeforeFileCreateMs));
-    LOG.info("RCA: About to delete SQLite file - " + oldDBFilePath);
-    return oldDBFilePath;
-  }
-
-  public synchronized void deleteOldDBFile()
-      throws SQLException, SecurityException, ParseException {
-    String oldDBFilePath = getDBFilePath(this.STORAGE_FILE_RETENTION_COUNT);
-    File dbFile = new File(oldDBFilePath);
-    if (dbFile.exists()) {
-      if (!dbFile.delete()) {
-        LOG.error("Failed to delete File - " + oldDBFilePath);
-      }
-    }
-    oldDBFilePath = getDBFilePath(this.STORAGE_FILE_RETENTION_COUNT + 1);
-    dbFile = new File(oldDBFilePath);
-    if (dbFile.exists()) {
-      if (!dbFile.delete()) {
-        LOG.error("Failed to delete File - " + oldDBFilePath);
-      }
-    }
-  }
-
-  // The database is always rotated when the thread dies. So the tablenames in the tableNames Set is
-  // the
-  // authoritative set for the current set of tables.
-  // TODO: Add the code to rotate the table on exception and periodically
-  //
   @Override
-  public synchronized <T extends ResourceFlowUnit> void write(Node<?> node, T flowUnit) {
+  public synchronized <T extends ResourceFlowUnit> void write(Node<?> node, T flowUnit) throws SQLException, IOException {
     // Write only if there is data to be writen.
     if (flowUnit.isEmpty()) {
       LOG.debug("RCA: Flow unit isEmpty");
       return;
     }
-    String tableName = node.getClass().getSimpleName();
 
-    try {
-      rotateDBIfRequired();
-    } catch (SQLException e) {
-      LOG.error(
-          "RCA: Caught SQLException while creating a new DB connection for file rotation.", e);
-    } catch (ParseException e) {
-      LOG.error("RCA: Caught ParseException while checking for file rotation.", e);
-    } catch (SecurityException e) {
-      LOG.error("RCA: Caught SecurityException while trying to delete old DB file. ", e);
+    Path rotatedFile = fileRotate.tryRotate(System.currentTimeMillis());
+    if (rotatedFile != null) {
+      fileGC.eligibleForGc(rotatedFile.toFile().getName());
+      openNewDBFile();
     }
 
     try {
-      writeFlowUnit(flowUnit, tableName);
+      writeFlowUnit(flowUnit, node.name());
     } catch (SQLException e) {
       LOG.error(
           "RCA: Caught SQLException while writing flowuni.", e);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
@@ -22,12 +22,14 @@ import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framew
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.QueryUtils;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaResponseUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.response.RcaResponse;
+import java.io.IOException;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -52,8 +54,9 @@ class SQLitePersistor extends PersistorBase {
 
   private static int id_test = 1;
 
-  SQLitePersistor(String dir, String filename, String storageFileRetentionCount) throws SQLException {
-    super(dir, filename, DB_URL, storageFileRetentionCount);
+  SQLitePersistor(String dir, String filename, String storageFileRetentionCount,
+                  TimeUnit rotationTime, long rotationPeriod) throws SQLException, IOException {
+    super(dir, filename, DB_URL, storageFileRetentionCount, rotationTime, rotationPeriod);
     create = DSL.using(conn, SQLDialect.SQLITE);
     jooqTableColumns = new HashMap<>();
   }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaTestHelper.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaTestHelper.java
@@ -15,7 +15,11 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -34,13 +38,7 @@ public class RcaTestHelper {
   public static List<String> getAllLinesFromStatsLog() {
     try {
       return Files.readAllLines(Paths.get(getLogFilePath("StatsLog")));
-    } catch (IOException e) {
-      e.printStackTrace();
-    } catch (ParserConfigurationException e) {
-      e.printStackTrace();
-    } catch (SAXException e) {
-      e.printStackTrace();
-    } catch (XPathExpressionException e) {
+    } catch (IOException | ParserConfigurationException | SAXException | XPathExpressionException e) {
       e.printStackTrace();
     }
     return Collections.EMPTY_LIST;
@@ -49,6 +47,25 @@ public class RcaTestHelper {
   public static List<String> getAllLinesWithMatchingString(String pattern) {
     List<String> matches = new ArrayList<>();
     for (String line: getAllLinesFromStatsLog()) {
+      if (line.contains(pattern)) {
+        matches.add(line);
+      }
+    }
+    return matches;
+  }
+
+  public static List<String> getAllLinesFromLog(String logName) {
+    try {
+      return Files.readAllLines(Paths.get(getLogFilePath(logName)));
+    } catch (IOException | ParserConfigurationException | SAXException | XPathExpressionException e) {
+      e.printStackTrace();
+    }
+    return Collections.EMPTY_LIST;
+  }
+
+  public static List<String> getAllLogLinesWithMatchingString(String logName, String pattern) {
+    List<String> matches = new ArrayList<>();
+    for (String line: getAllLinesFromLog(logName)) {
       if (line.contains(pattern)) {
         matches.add(line);
       }
@@ -73,14 +90,18 @@ public class RcaTestHelper {
 
   public static void cleanUpLogs() {
     try {
-      Files.deleteIfExists(Paths.get(getLogFilePath("PerformanceAnalyzerLog")));
-      Files.deleteIfExists(Paths.get(getLogFilePath("StatsLog")));
-    } catch (ParserConfigurationException e) {
+      truncate(Paths.get(getLogFilePath("PerformanceAnalyzerLog")).toFile());
+      truncate(Paths.get(getLogFilePath("StatsLog")).toFile());
+    } catch (ParserConfigurationException | SAXException | XPathExpressionException | IOException e) {
       e.printStackTrace();
-    } catch (SAXException e) {
-      e.printStackTrace();
-    } catch (XPathExpressionException e) {
-      e.printStackTrace();
+    }
+  }
+
+  public static void truncate(File file) {
+    try (FileChannel outChan = new FileOutputStream(file, false).getChannel()) {
+      outChan.truncate(0);
+    } catch (FileNotFoundException e) {
+      System.out.println(file.getName() + " does not exist.");
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/FileGCTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/FileGCTest.java
@@ -69,7 +69,7 @@ public class FileGCTest {
   }
 
   class FileGCTestHelper extends FileGC {
-    FileGCTestHelper() {
+    FileGCTestHelper() throws IOException {
       // Based on these numbers the limit for the time based cleanup is [now - (10 * 3)].
       super(testLocation, baseFilename, TimeUnit.MILLISECONDS, 10, 3);
     }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/FileGCTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/FileGCTest.java
@@ -1,0 +1,213 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaTestHelper;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class FileGCTest {
+  private Path testLocation = null;
+  private final String baseFilename = "rca.test.file";
+
+  @BeforeClass
+  public static void cleanupLogs() {
+    RcaTestHelper.cleanUpLogs();
+  }
+
+  @AfterClass
+  public static void cleanup() throws IOException {
+    cleanupLogs();
+    String cwd = System.getProperty("user.dir");
+    Path tmpPath = Paths.get(cwd, "src", "test", "resources", "tmp");
+    FileUtils.cleanDirectory(tmpPath.toFile());
+  }
+
+  @Before
+  public void init() throws IOException {
+    String cwd = System.getProperty("user.dir");
+    testLocation = Paths.get(cwd, "src", "test", "resources", "tmp", "file_rotate");
+    Files.createDirectories(testLocation);
+    FileUtils.cleanDirectory(testLocation.toFile());
+  }
+
+  @After
+  public void after() throws IOException {
+    FileUtils.cleanDirectory(testLocation.toFile());
+  }
+
+  class FileGCTestHelper extends FileGC {
+    FileGCTestHelper() {
+      // Based on these numbers the limit for the time based cleanup is [now - (10 * 3)].
+      super(testLocation, baseFilename, TimeUnit.MILLISECONDS, 10, 3);
+    }
+
+    @Override
+    protected List<File> cleanupAndGetRemaining(long currentMillis) {
+      return Collections.EMPTY_LIST;
+    }
+
+    public Deque<File> getEligibleForGcList() {
+      return eligibleForGc;
+    }
+  }
+
+  @Test
+  public void testTimeBasedFileCleanup() throws IOException {
+    long currentTime = System.currentTimeMillis();
+    // create files with modified time past the limit.
+    long limit = currentTime - 10 * 3;
+
+    // For these set of files, we are trying to set the file modification time to be before the
+    // limit so that they will be deleted by the time based cleaner.
+    for (int i = 0; i < 5; i++) {
+      String name = baseFilename + "." + i;
+      Path filePath = Paths.get(testLocation.toString(), name);
+      Files.createFile(filePath);
+      Assert.assertTrue(filePath.toFile().setLastModified(limit - (i + 1) * 10));
+    }
+    FileGCTestHelper fileGc = new FileGCTestHelper();
+    String[] files = fileGc.getDbFiles();
+    List<File> afterTimeBasedCleanup = fileGc.timeBasedCleanup(files, System.currentTimeMillis());
+
+    files = fileGc.getDbFiles();
+    Assert.assertEquals("Remaining files: " + files, 0, files.length);
+
+    // we expect all files to be cleaned up.
+    Assert.assertEquals(0, afterTimeBasedCleanup.size());
+  }
+
+  @Test
+  public void testCountBasedCleanup() throws IOException {
+    long currtTime = System.currentTimeMillis();
+    Set<String> set = new HashSet<>();
+    List<String> listByRecency = new ArrayList<>();
+
+    // files that are recent enough that they won't be affected by the time based filter.
+    for (int j = 0; j < 10; j++) {
+      String name = baseFilename + "." + j + j;
+      set.add(name);
+      listByRecency.add(name);
+      Path filePath = Paths.get(testLocation.toString(), name);
+      Files.createFile(filePath);
+      long lastMod = currtTime - j;
+      Assert.assertTrue(filePath.toFile().setLastModified(lastMod));
+    }
+
+    FileGCTestHelper fileGc = new FileGCTestHelper();
+    String[] files = fileGc.getDbFiles();
+
+    List<File> filesList =
+        Arrays.stream(files)
+            .map(f -> Paths.get(testLocation.toString(), f).toFile())
+            .collect(Collectors.toList());
+    List<File> afterCountBasedCleanup = fileGc.countBasedCleanup(filesList);
+
+    Assert.assertEquals(3, afterCountBasedCleanup.size());
+
+    List<String> expectedFiles = listByRecency.subList(0, 3);
+    Collections.reverse(expectedFiles);
+    Assert.assertEquals(expectedFiles.size(), afterCountBasedCleanup.size());
+
+    int i = 0;
+    for (File file : afterCountBasedCleanup) {
+      Assert.assertEquals(expectedFiles.get(i), file.getName());
+      i += 1;
+    }
+  }
+
+  @Test
+  public void eligibleForGc() throws IOException {
+    long currentTime = System.currentTimeMillis();
+    long limit = currentTime - 10 * 3;
+
+    // ALl of these will be deleted because of time based cleanup.
+    for (int i = 0; i < 3; i++) {
+      String name = baseFilename + "." + i;
+      Path filePath = Paths.get(testLocation.toString(), name);
+      Files.createFile(filePath);
+      Assert.assertTrue(filePath.toFile().setLastModified(limit - (i + 1) * 10));
+    }
+
+    long currtTime = System.currentTimeMillis();
+
+    // This file will get deleted because of count based cleaning.
+    String name = baseFilename + "." + 222;
+    Path filePath = Paths.get(testLocation.toString(), name);
+    Files.createFile(filePath);
+    Assert.assertTrue(filePath.toFile().setLastModified(currtTime - 5));
+
+    // These files will stay on.
+    // <basename>.00 -> most recent file
+    // <basename>.22 -> oldest file
+
+    List<String> modifiedTimeBased = new ArrayList<>();
+    for (int j = 0; j < 3; j++) {
+      name = baseFilename + "." + j + j;
+      modifiedTimeBased.add(name);
+      filePath = Paths.get(testLocation.toString(), name);
+      Files.createFile(filePath);
+      long lastMod = currtTime - j;
+      Assert.assertTrue(filePath.toFile().setLastModified(lastMod));
+    }
+    Collections.reverse(modifiedTimeBased);
+
+    System.out.println(System.currentTimeMillis());
+    FileGC fileGC = new FileGC(testLocation, baseFilename, TimeUnit.MILLISECONDS, 10, 3, currtTime);
+
+    int i = 0;
+    for (File file : fileGC.eligibleForGc) {
+      Assert.assertEquals(modifiedTimeBased.get(i), file.getName());
+      i += 1;
+    }
+
+    name = baseFilename + "." + 100;
+    filePath = Paths.get(testLocation.toString(), name);
+    Files.createFile(filePath);
+
+    // This should cause the oldest file to be deleted
+    fileGC.eligibleForGc(name);
+    Assert.assertFalse(
+        Paths.get(testLocation.toString(), modifiedTimeBased.get(0)).toFile().exists());
+
+    modifiedTimeBased.add(name);
+
+    i = 1;
+    for (File file : fileGC.eligibleForGc) {
+      Assert.assertEquals(modifiedTimeBased.get(i), file.getName());
+      i += 1;
+    }
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/FileRotateTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/FileRotateTest.java
@@ -1,0 +1,142 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaTestHelper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class FileRotateTest {
+  private Path testLocation = null;
+  private Path fileToRotate = null;
+  private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd-kk-mm-ss");
+
+  @BeforeClass
+  public static void cleanupLogs() {
+    RcaTestHelper.cleanUpLogs();
+  }
+
+  @AfterClass
+  public static void cleanup() throws IOException {
+    cleanupLogs();
+    String cwd = System.getProperty("user.dir");
+    Path tmpPath = Paths.get(cwd, "src", "test", "resources", "tmp");
+    FileUtils.cleanDirectory(tmpPath.toFile());
+  }
+
+  @Before
+  public void init() throws IOException {
+    String cwd = System.getProperty("user.dir");
+    testLocation = Paths.get(cwd, "src", "test", "resources", "tmp", "file_rotate");
+    Files.createDirectories(testLocation);
+    FileUtils.cleanDirectory(testLocation.toFile());
+    fileToRotate = Paths.get(testLocation.toString(), "fileRotate.test");
+    Files.deleteIfExists(fileToRotate);
+  }
+
+  class TestFileRotate extends FileRotate {
+    TestFileRotate(TimeUnit rotation_time_unit, long rotation_period) {
+      super(fileToRotate, rotation_time_unit, rotation_period, DATE_FORMAT);
+    }
+
+    public void setLastRotated(long value) {
+      lastRotatedMillis = value;
+    }
+
+    @Override
+    public Path rotate(long millis) throws IOException {
+      return super.rotate(millis);
+    }
+
+    @Override
+    public boolean shouldRotate(long currentTimeMillis) {
+      return super.shouldRotate(currentTimeMillis);
+    }
+  }
+
+  @Test
+  public void shouldRotate() throws InterruptedException, IOException {
+    TestFileRotate fileRotate = new TestFileRotate(TimeUnit.MILLISECONDS, 100);
+    Thread.sleep(100);
+    Assert.assertTrue(fileRotate.shouldRotate(System.currentTimeMillis()));
+    fileRotate.setLastRotated(System.currentTimeMillis());
+    Assert.assertFalse(fileRotate.shouldRotate(System.currentTimeMillis()));
+  }
+
+  @Test
+  public void rotate() throws IOException {
+    TestFileRotate fileRotate = new TestFileRotate(TimeUnit.MILLISECONDS, 100);
+    Assert.assertFalse(fileToRotate.toFile().exists());
+    Assert.assertNull(fileRotate.rotate(System.currentTimeMillis()));
+
+    // Let's create a file and try rotating it.
+    long currentMillis = System.currentTimeMillis();
+
+    Files.createFile(fileToRotate);
+    Assert.assertTrue(fileToRotate.toFile().exists());
+    fileRotate.rotate(currentMillis);
+
+    String formatNow = DATE_FORMAT.format(currentMillis);
+    for (String f : testLocation.toFile().list()) {
+      String prefix = fileToRotate.getFileName() + "." + formatNow;
+      Assert.assertTrue(
+          String.format("expected prefix: '%s', found: '%s'", prefix, f), f.startsWith(prefix));
+    }
+
+    Assert.assertFalse(fileToRotate.toFile().exists());
+    Files.createFile(fileToRotate);
+    Assert.assertTrue(fileToRotate.toFile().exists());
+    fileRotate.rotate(currentMillis);
+    List<String> lines =
+        RcaTestHelper.getAllLogLinesWithMatchingString(
+            "PerformanceAnalyzerLog", "FileAlreadyExistsException");
+    Assert.assertEquals(1, lines.size());
+  }
+
+  @Test
+  public void tryRotate() throws IOException {
+    TestFileRotate fileRotate = new TestFileRotate(TimeUnit.MILLISECONDS, 100);
+    long currentMillis = System.currentTimeMillis();
+    fileRotate.setLastRotated(currentMillis - 100);
+
+    Files.createFile(fileToRotate);
+    Assert.assertTrue(fileToRotate.toFile().exists());
+    fileRotate.tryRotate(currentMillis);
+
+    String formatNow = DATE_FORMAT.format(currentMillis);
+    for (String f : testLocation.toFile().list()) {
+      String prefix = fileToRotate.getFileName() + "." + formatNow;
+      Assert.assertTrue(
+              String.format("expected prefix: '%s', found: '%s'", prefix, f), f.startsWith(prefix));
+    }
+    currentMillis = System.currentTimeMillis();
+    fileRotate.setLastRotated(currentMillis);
+    Assert.assertEquals(null, fileRotate.tryRotate(currentMillis));
+
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistorTest.java
@@ -15,13 +15,117 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.JvmEnum;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaTestHelper;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Rca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Resources;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.contexts.ResourceContext;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.WildcardFileFilter;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class SQLitePersistorTest {
+  private Path testLocation = null;
+  private final String baseFilename = "rca.test.file";
+
+  @BeforeClass
+  public static void cleanupLogs() {
+    RcaTestHelper.cleanUpLogs();
+  }
+
+  @AfterClass
+  public static void cleanup() throws IOException {
+    cleanupLogs();
+    String cwd = System.getProperty("user.dir");
+    Path tmpPath = Paths.get(cwd, "src", "test", "resources", "tmp");
+    // FileUtils.cleanDirectory(tmpPath.toFile());
+  }
+
+  @Before
+  public void init() throws IOException {
+    String cwd = System.getProperty("user.dir");
+    testLocation = Paths.get(cwd, "src", "test", "resources", "tmp", "file_rotate");
+    Files.createDirectories(testLocation);
+    FileUtils.cleanDirectory(testLocation.toFile());
+  }
+
+  @After
+  public void after() throws IOException {
+    // FileUtils.cleanDirectory(testLocation.toFile());
+  }
+
+  class TestRca extends Rca<ResourceFlowUnit> {
+    public TestRca() {
+      super(5);
+    }
+
+    @Override
+    public ResourceFlowUnit operate() {
+      return null;
+    }
+
+    @Override
+    public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {}
+  }
 
   @Test
-  public void createTable() {}
+  public void write() throws IOException, SQLException, InterruptedException {
+    ResourceContext context = new ResourceContext(Resources.State.UNHEALTHY);
+    HotResourceSummary summary =
+        new HotResourceSummary(
+            ResourceType.newBuilder().setJVM(JvmEnum.OLD_GEN).build(),
+            70,
+            71,
+            "heap usage in percentage",
+            60);
+    ResourceFlowUnit rfu = new ResourceFlowUnit(System.currentTimeMillis(), context, summary);
 
-  @Test
-  public void insertRow() {}
+    Node rca = new TestRca();
+
+    SQLitePersistor sqlite =
+        new SQLitePersistor(
+            testLocation.toString(), baseFilename, String.valueOf(1), TimeUnit.SECONDS, 1);
+
+
+    // The first write, this should create only one file as there is nothing to rotate.
+    sqlite.write(rca, rfu);
+    Assert.assertEquals(1,
+            testLocation.toFile().list(new WildcardFileFilter(baseFilename + "*")).length);
+    Assert.assertTrue(Paths.get(testLocation.toString(), baseFilename).toFile().exists());
+    Thread.sleep(1000);
+
+    // This should rotate the last file written and create a new one for this write.
+    sqlite.write(rca, rfu);
+    Assert.assertTrue(Paths.get(testLocation.toString(), baseFilename).toFile().exists());
+    Assert.assertEquals(2, testLocation.toFile().list(new WildcardFileFilter(baseFilename + "*")).length);
+
+    // This should delete the last rotated one, rotate the current sqlite and then write the data
+    // in a new file. So the residual count on the directory should still be 2.
+    Thread.sleep(1000);
+    sqlite.write(rca, rfu);
+    Assert.assertTrue(Paths.get(testLocation.toString(), baseFilename).toFile().exists());
+    Assert.assertEquals(2, testLocation.toFile().list(new WildcardFileFilter(baseFilename + "*")).length);
+
+    // A test to see that the string read from the database has the Rca name and the summary name
+    // we expect.
+    String readTableStr = sqlite.readTables();
+    Assert.assertTrue(readTableStr.contains("TestRca"));
+    Assert.assertTrue(readTableStr.contains("HotResourceSummary"));
+  }
 }

--- a/src/test/resources/rca/rca_enabled.conf
+++ b/src/test/resources/rca/rca_enabled.conf
@@ -1,1 +1,1 @@
-true
+false


### PR DESCRIPTION
Description of changes:
There are three parts to it:

- Before this patch, the Rca sqlite files would be created as rca.sqlite. We want to change it to rca.sqlite and add the time stamp only when the file is rotated and no longer a candidate for modification.
- In the code as it stands, we would do a directory scan to identify the old db files that are candidates for deletion. This is performance intensive. This patch adds changes such that a full directory scan is only required at startup and never again.
- Separate out the logic for db file rotation and garbage collection into separate files and out of PersistorBase.
- Add the logic to attempt to write data in case of SQL exception after recreating file.

Tests:

- Added unit tests for test the rotation logic
- added unit tests for the file garbage collection logic
- added unit tests to check that sqlite files are correctly written, rotated and garbage collected. And the data inside them is flushed to disk and hence readable (no corruption under normal circumstances). We were missing these tests before.

Code coverage percentage for this patch:
For the files added it covers more than 80%

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.