### PR TITLE
Exception handling logic change for metrics gather method

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/MetricsDBProvider.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/MetricsDBProvider.java
@@ -58,25 +58,24 @@ public class MetricsDBProvider implements Queryable {
       for (String col : columnNames) {
         row.add(String.valueOf(r.getValue(col)));
       }
-      // LOG.info("RCA: row: \n{}", r);
       retResults.add(row);
     }
     return retResults;
   }
 
+  /**
+   * This queries the MetricsDB to get all the data for the given metric.
+   *
+   * <p>If we query for a metric that does not exist then {@code queryMetrics()} with throw
+   * {@code exception}, which is not handled here. The caller might handle if it wants to.
+   * @param db The MetricsDB file to query
+   * @param metricName The table for the metric that will be queried.
+   * @return Returns the metrics data in a tabular form.
+   */
   @Override
   public List<List<String>> queryMetrics(MetricsDB db, String metricName) {
-    // LOG.info("RCA: About to get the query metric: {}", metricName);
-    try {
-      Result<Record> queryResult = db.queryMetric(metricName);
-      return parseResult(queryResult);
-    } catch (Exception e) {
-      LOG.error("kak: Having issues with the DB man! {}", e.getMessage());
-      e.printStackTrace();
-      return Collections.emptyList();
-    }
-    // LOG.info("RCA: result {}", queryResult);
-
+    Result<Record> queryResult = db.queryMetric(metricName);
+    return parseResult(queryResult);
   }
 
   @Override
@@ -84,19 +83,13 @@ public class MetricsDBProvider implements Queryable {
       final MetricsDB db,
       final String metricName,
       final String dimension,
-      final String aggregation) {
-    try {
-      return parseResult(
+      final String aggregation) throws Exception {
+      Result<Record> queryResult =
           db.queryMetric(
               Collections.singletonList(metricName),
               Collections.singletonList(aggregation),
-              Collections.singletonList(dimension)));
-    } catch (Exception e) {
-      LOG.error("Couldn't query the metrics correctly. {}", e.getMessage());
-      LOG.error("Exception: ", e);
-    }
-
-    return Collections.emptyList();
+              Collections.singletonList(dimension));
+      return parseResult(queryResult);
   }
 
   @Override

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Queryable.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Queryable.java
@@ -25,7 +25,7 @@ public interface Queryable {
   List<List<String>> queryMetrics(MetricsDB db, String metricName);
 
   List<List<String>> queryMetrics(
-      MetricsDB db, String metricName, String dimension, String aggregation);
+      MetricsDB db, String metricName, String dimension, String aggregation) throws Exception;
 
   long getDBTimestamp(MetricsDB db);
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/MetricTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/MetricTest.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.MetricFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.HTTP_RequestDocs;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Queryable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.spec.MetricsDBProviderTestHelper;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MetricTest {
+
+  class MetricX extends HTTP_RequestDocs {
+    public MetricX() {
+      super(5);
+    }
+
+    public void setFlowUnitList(List<MetricFlowUnit> flowUnitList) {
+      setFlowUnits(flowUnitList);
+    }
+  }
+
+  @Test
+  public void gather() throws Exception {
+    Queryable queryable = new MetricsDBProviderTestHelper(false);
+    Metric metric = new MetricX();
+    MetricFlowUnit mfu = metric.gather(queryable);
+    Assert.assertTrue(mfu.isEmpty());
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/FileGCTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/FileGCTest.java
@@ -184,7 +184,6 @@ public class FileGCTest {
     }
     Collections.reverse(modifiedTimeBased);
 
-    System.out.println(System.currentTimeMillis());
     FileGC fileGC = new FileGC(testLocation, baseFilename, TimeUnit.MILLISECONDS, 10, 3, currtTime);
 
     int i = 0;


### PR DESCRIPTION
Metrics gather(), whihc calls the MetricsDB to get the metrics can throw exception if
the queried metric does not exist. We were handling the exception earlier than we should
and hence the gather was not returning an empty flow unit. We were alos missing on logging
the exception at teh right place and unnecessarily logging the entire stack trace which
is not required as this is expected.

*Issue #, if available:*

*Description of changes:*

*Tests:*

*Code coverage percentage for this patch:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
