### PR TITLE
Add parameter "rca?all" in RCA API to dump all RCA SQL tables

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/MetricsRestUtil.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/MetricsRestUtil.java
@@ -55,7 +55,7 @@ public class MetricsRestUtil {
     return outputJson.toString();
   }
 
-  public List<String> parseArrayParam(Map<String, String> params, String name, boolean optional) {
+  public List<String> parseArrayParam(Map<String, String> params, String name, boolean optional) throws InvalidParameterException {
     if (!optional) {
       if (!params.containsKey(name) || params.get(name).isEmpty()) {
         throw new InvalidParameterException(String.format("%s parameter needs to be set", name));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The changes made by adding RCA API removed the function that dump all RCA tables from SQL. This PR is to add that function back and create a new parameter "?all" in rest API endpoint to query all SQL tables for debugging purpose

To query all tables : 
curl --url "localhost:9650/_opendistro/_performanceanalyzer/rca?all" -XGET

*Tests:*
tested on docker

*Code coverage percentage for this patch:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
