### PR TITLE
Modify HighHeapUsageClusterRca to skip non JVM resource flowunit and …

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HighHeapUsageClusterRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HighHeapUsageClusterRca.java
@@ -16,12 +16,14 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.JvmEnum;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Rca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Resources;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.contexts.ResourceContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotClusterSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
@@ -82,13 +84,29 @@ public class HighHeapUsageClusterRca extends Rca<ResourceFlowUnit> {
         .getDataNodesDetails()) {
       ImmutableList<ResourceFlowUnit> nodeStateList = currentMap.get(nodeDetails.getId());
       if (nodeStateList != null) {
-        int unhealthyNodeCnt = 0;
+        int unhealthyOldGenCnt = 0;
+        int unhealthyYoungGenCnt = 0;
         for (ResourceFlowUnit flowUnit : nodeStateList) {
           if (flowUnit.getResourceContext().getState() == Resources.State.UNHEALTHY) {
-            unhealthyNodeCnt++;
+            HotNodeSummary currentNodSummary = (HotNodeSummary) flowUnit.getResourceSummary();
+            for (GenericSummary resourceSummary : currentNodSummary.getNestedSummaryList()) {
+              if (resourceSummary instanceof HotResourceSummary) {
+                if (((HotResourceSummary) resourceSummary).getResourceType().getJVM() == JvmEnum.YOUNG_GEN) {
+                  unhealthyYoungGenCnt++;
+                  break;
+                }
+                else if (((HotResourceSummary) resourceSummary).getResourceType().getJVM() == JvmEnum.OLD_GEN) {
+                  unhealthyOldGenCnt++;
+                  break;
+                }
+              }
+              else {
+                LOG.error("RCA : The summary that hot node RCA carries is not resource type summary. ");
+              }
+            }
           }
         }
-        if (unhealthyNodeCnt >= UNHEALTHY_FLOWUNIT_THRESHOLD) {
+        if (unhealthyYoungGenCnt >= UNHEALTHY_FLOWUNIT_THRESHOLD || unhealthyOldGenCnt >= UNHEALTHY_FLOWUNIT_THRESHOLD) {
           unhealthyNodeList.add(nodeStateList.get(0).getResourceSummary());
         }
       }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/RcaTestHelper.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/RcaTestHelper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.contexts.ResourceContext;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
+import java.util.Collections;
+
+public class RcaTestHelper extends Rca<ResourceFlowUnit> {
+  public RcaTestHelper() {
+    super(5);
+  }
+
+  public void mockFlowUnit(ResourceFlowUnit flowUnit) {
+    this.flowUnits = Collections.singletonList(flowUnit);
+  }
+
+  @Override
+  public ResourceFlowUnit operate() {
+    return null;
+  }
+
+  @Override
+  public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {
+  }
+
+  public static ResourceFlowUnit generateFlowUnit(ResourceType type, String nodeID, Resources.State healthy) {
+    HotResourceSummary resourceSummary = new HotResourceSummary(type,
+        10, 5, "testing", 60);
+    HotNodeSummary nodeSummary = new HotNodeSummary(nodeID, "127.0.0.0");
+    nodeSummary.addNestedSummaryList(resourceSummary);
+    return new ResourceFlowUnit(System.currentTimeMillis(), new ResourceContext(healthy), nodeSummary);
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessorTestHelper.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessorTestHelper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ClusterDetailsEventProcessorTestHelper extends AbstractReaderTests {
+  List<String> nodeDetails;
+
+  public ClusterDetailsEventProcessorTestHelper() throws SQLException, ClassNotFoundException {
+    super();
+    nodeDetails = new ArrayList<>();
+  }
+
+  public void addNodeDetails(String nodeId, String address, boolean isMasterNode) {
+    nodeDetails.add(createNodeDetailsMetrics(nodeId, address, isMasterNode));
+  }
+
+  public void generateClusterDetailsEvent() {
+    if (nodeDetails.isEmpty()) {
+      return;
+    }
+    StringBuilder stringBuilder = new StringBuilder().append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds());
+    nodeDetails.stream().forEach(
+        node -> {
+          stringBuilder.append(System.getProperty("line.separator"))
+              .append(node);
+        }
+    );
+    Event testEvent = new Event("", stringBuilder.toString(), 0);
+    ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
+    clusterDetailsEventProcessor.processEvent(testEvent);
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessorTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessorTests.java
@@ -18,20 +18,14 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
 
 import static org.junit.Assert.assertEquals;
 
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor.NodeDetails;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
 
-import java.sql.SQLException;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Test;
 
-public class ClusterDetailsEventProcessorTests extends AbstractReaderTests {
-
-  public ClusterDetailsEventProcessorTests() throws SQLException, ClassNotFoundException {
-    super();
-  }
+public class ClusterDetailsEventProcessorTests {
 
   @Test
   public void testProcessEvent() throws Exception {
@@ -44,16 +38,15 @@ public class ClusterDetailsEventProcessorTests extends AbstractReaderTests {
     String address2 = "10.212.52.241";
     boolean isMasterNode2 = false;
 
-    StringBuilder stringBuilder = new StringBuilder()
-        .append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds())
-        .append(System.getProperty("line.separator"))
-        .append(createNodeDetailsMetrics(nodeId1, address1, isMasterNode1))
-        .append(System.getProperty("line.separator"))
-        .append(createNodeDetailsMetrics(nodeId2, address2, isMasterNode2));
-
-    Event testEvent = new Event("", stringBuilder.toString(), 0);
-    ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
-    clusterDetailsEventProcessor.processEvent(testEvent);
+    try {
+      ClusterDetailsEventProcessorTestHelper clusterDetailsEventProcessorTestHelper = new ClusterDetailsEventProcessorTestHelper();
+      clusterDetailsEventProcessorTestHelper.addNodeDetails(nodeId1, address1, isMasterNode1);
+      clusterDetailsEventProcessorTestHelper.addNodeDetails(nodeId2, address2, isMasterNode2);
+      clusterDetailsEventProcessorTestHelper.generateClusterDetailsEvent();
+    } catch (Exception e) {
+      Assert.assertTrue("got exception when generating cluster details event", false);
+      return;
+    }
 
     List<NodeDetails> nodes = ClusterDetailsEventProcessor.getNodesDetails();
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/HighHeapUsageClusterRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/HighHeapUsageClusterRcaTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.store.rca;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.JvmEnum;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.RcaTestHelper;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Resources.State;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HighHeapUsageClusterRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(GradleTaskForRca.class)
+public class HighHeapUsageClusterRcaTest {
+
+  @Test
+  public void testOperate() {
+    RcaTestHelper nodeRca = new RcaTestHelper();
+    HighHeapUsageClusterRca clusterRca = new HighHeapUsageClusterRca(1, nodeRca);
+
+    //setup cluster details
+    try {
+      ClusterDetailsEventProcessorTestHelper clusterDetailsEventProcessorTestHelper = new ClusterDetailsEventProcessorTestHelper();
+      clusterDetailsEventProcessorTestHelper.addNodeDetails("node1", "127.0.0.0", false);
+      clusterDetailsEventProcessorTestHelper.addNodeDetails("node2", "127.0.0.1", false);
+      clusterDetailsEventProcessorTestHelper.generateClusterDetailsEvent();
+    } catch (Exception e) {
+      Assert.assertTrue("got exception when generating cluster details event", false);
+      return;
+    }
+
+    // send three young gen flowunits (healthy, unhealthy, unhealthy) to node1
+    // the cluterRca will generate three healthy flowunits
+    nodeRca.mockFlowUnit(RcaTestHelper.generateFlowUnit(buildResourceType(JvmEnum.YOUNG_GEN), "node1", State.HEALTHY));
+    Assert.assertFalse(clusterRca.operate().getResourceContext().isUnhealthy());
+    nodeRca.mockFlowUnit(RcaTestHelper.generateFlowUnit(buildResourceType(JvmEnum.YOUNG_GEN), "node1", State.UNHEALTHY));
+    Assert.assertFalse(clusterRca.operate().getResourceContext().isUnhealthy());
+    nodeRca.mockFlowUnit(RcaTestHelper.generateFlowUnit(buildResourceType(JvmEnum.YOUNG_GEN), "node1", State.UNHEALTHY));
+    Assert.assertFalse(clusterRca.operate().getResourceContext().isUnhealthy());
+
+    // send two young gen flowunits (unhealthy, unhealthy) to node2
+    // the cluterRca will continue generating healthy flowunits
+    nodeRca.mockFlowUnit(RcaTestHelper.generateFlowUnit(buildResourceType(JvmEnum.YOUNG_GEN), "node2", State.UNHEALTHY));
+    Assert.assertFalse(clusterRca.operate().getResourceContext().isUnhealthy());
+    nodeRca.mockFlowUnit(RcaTestHelper.generateFlowUnit(buildResourceType(JvmEnum.YOUNG_GEN), "node2", State.UNHEALTHY));
+    Assert.assertFalse(clusterRca.operate().getResourceContext().isUnhealthy());
+
+    // send two old gen flowunits (unhealthy, unhealthy) to node1
+    // the cluterRca will continue generating healthy flowunits
+    nodeRca.mockFlowUnit(RcaTestHelper.generateFlowUnit(buildResourceType(JvmEnum.OLD_GEN), "node1", State.UNHEALTHY));
+    Assert.assertFalse(clusterRca.operate().getResourceContext().isUnhealthy());
+    nodeRca.mockFlowUnit(RcaTestHelper.generateFlowUnit(buildResourceType(JvmEnum.OLD_GEN), "node1", State.UNHEALTHY));
+    Assert.assertFalse(clusterRca.operate().getResourceContext().isUnhealthy());
+
+    // send one old gen flowunits (unhealthy) to node1
+    // the cluterRca will generate a unhealthy flowunit at the end
+    nodeRca.mockFlowUnit(RcaTestHelper.generateFlowUnit(buildResourceType(JvmEnum.OLD_GEN), "node1", State.UNHEALTHY));
+    Assert.assertTrue(clusterRca.operate().getResourceContext().isUnhealthy());
+
+    // send one young gen flowunits (unhealthy) to node1
+    // flowunit becomes healthy
+    nodeRca.mockFlowUnit(RcaTestHelper.generateFlowUnit(buildResourceType(JvmEnum.YOUNG_GEN), "node1", State.UNHEALTHY));
+    Assert.assertFalse(clusterRca.operate().getResourceContext().isUnhealthy());
+
+    // send one old gen flowunits (unhealthy) to node2
+    // the cluterRca will generate a unhealthy flowunit at the end
+    nodeRca.mockFlowUnit(RcaTestHelper.generateFlowUnit(buildResourceType(JvmEnum.YOUNG_GEN), "node2", State.UNHEALTHY));
+    Assert.assertTrue(clusterRca.operate().getResourceContext().isUnhealthy());
+  }
+
+  private ResourceType buildResourceType(JvmEnum jvmEnum) {
+    return ResourceType.newBuilder().setJVM(jvmEnum).build();
+  }
+}


### PR DESCRIPTION
…add a unit test for this RCA

*Issue #, if available:*

*Description of changes:*
The currently HighHeapUsageClusterRca implementation does not take into consideration that the flowunit from each cluster node can carry different types of resource summaries other than young gen/old gen. Add a checker in the HighHeapUsageClusterRca to skip those resource summaries which JVM heap RCA does not interested in. 

*Tests:*
Created unit test for this RCA.
tested on docker.

*Code coverage percentage for this patch:*
80%

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
