### PR TITLE
Fix Rca metrics format

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/formatter/StatsCollectorFormatter.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/formatter/StatsCollectorFormatter.java
@@ -39,7 +39,7 @@ public class StatsCollectorFormatter implements Formatter {
     formatted.append(sep);
     formatted.append(measurementSet.getName()).append("=").append(value);
     if (!measurementSet.getUnit().isEmpty()) {
-      formatted.append(" ").append("unit|").append(measurementSet.getUnit());
+      formatted.append(" ").append(measurementSet.getUnit());
     }
     formatted.append(" ").append("aggr|").append(aggregationType);
     if (!name.isEmpty()) {


### PR DESCRIPTION
We donot require "unit|" tag while writing rca metric logs