### PR TITLE
Fix null pointer error when no query_parameter is passed in rca api

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryRcaRequestHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryRcaRequestHandler.java
@@ -78,7 +78,7 @@ public class QueryRcaRequestHandler extends MetricsHandler implements HttpHandle
         synchronized (this) {
           String query = exchange.getRequestURI().getQuery();
           //first check if we want to dump all SQL tables for debugging purpose
-          if (query.equals(DUMP_ALL)) {
+          if (query != null && query.equals(DUMP_ALL)) {
             sendResponse(exchange, dumpAllRcaTables(), HttpURLConnection.HTTP_OK);
           }
           else {


### PR DESCRIPTION
Fix null pointer error when no query_parameter is passed in rca api