### PR TITLE
Persist nested summaries only if the flowunit is emitted by the top l…

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/ResourceFlowUnit.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/ResourceFlowUnit.java
@@ -31,19 +31,25 @@ public class ResourceFlowUnit extends GenericFlowUnit {
 
   private ResourceContext resourceContext = null;
   private GenericSummary resourceSummary = null;
-  private boolean persistable = false;
+  // whether summary needs to be persisted as well when persisting this flowunit
+  private boolean persistSummary = false;
 
   public ResourceFlowUnit(long timeStamp) {
     super(timeStamp);
   }
 
   public <S extends GenericSummary> ResourceFlowUnit(long timeStamp, ResourceContext context,
-      S resourceSummary) {
+      S resourceSummary, boolean persistSummary) {
     super(timeStamp);
     this.resourceContext = context;
     this.resourceSummary = resourceSummary;
     this.empty = false;
-    this.persistable = true;
+    this.persistSummary = persistSummary;
+  }
+
+  public <S extends GenericSummary> ResourceFlowUnit(long timeStamp, ResourceContext context,
+      S resourceSummary) {
+    this(timeStamp, context, resourceSummary, false);
   }
 
   //Call generic() only if you want to generate a empty flowunit
@@ -67,12 +73,12 @@ public class ResourceFlowUnit extends GenericFlowUnit {
     this.resourceSummary = summary;
   }
 
-  public void setPersistable(boolean persistable) {
-    this.persistable = persistable;
+  public void setPersistSummary(boolean persistSummary) {
+    this.persistSummary = persistSummary;
   }
 
-  public boolean isPersistable() {
-    return this.persistable;
+  public boolean isSummaryPersistable() {
+    return this.persistSummary;
   }
 
   @Override

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistorBase.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistorBase.java
@@ -223,7 +223,7 @@ public abstract class PersistorBase implements Persistable {
       }
       int lastPrimaryKey = insertRow(tableName, flowUnit.getSqlValue());
 
-      if (flowUnit.hasResourceSummary()) {
+      if (flowUnit.hasResourceSummary() && flowUnit.isSummaryPersistable()) {
         writeSummary(
                 flowUnit.getResourceSummary(),
                 tableName,

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HighHeapUsageClusterRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HighHeapUsageClusterRca.java
@@ -140,7 +140,7 @@ public class HighHeapUsageClusterRca extends Rca<ResourceFlowUnit> {
       } else {
         context = new ResourceContext(Resources.State.HEALTHY);
       }
-      return new ResourceFlowUnit(System.currentTimeMillis(), context, summary);
+      return new ResourceFlowUnit(System.currentTimeMillis(), context, summary, true);
     } else {
       // we return an empty FlowUnit RCA for now. Can change to healthy (or previous known RCA state)
       LOG.debug("Empty FlowUnit returned for {}", this.getClass().getName());

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HotNodeRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HotNodeRca.java
@@ -94,7 +94,7 @@ public class HotNodeRca extends Rca<ResourceFlowUnit> {
       // reset the variables
       counter = 0;
       hasUnhealthyFlowUnit = false;
-      return new ResourceFlowUnit(System.currentTimeMillis(), context, summary);
+      return new ResourceFlowUnit(System.currentTimeMillis(), context, summary, !currentNode.getIsMasterNode());
     } else {
       return new ResourceFlowUnit(System.currentTimeMillis());
     }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistorTest.java
@@ -94,7 +94,7 @@ public class SQLitePersistorTest {
             71,
             "heap usage in percentage",
             60);
-    ResourceFlowUnit rfu = new ResourceFlowUnit(System.currentTimeMillis(), context, summary);
+    ResourceFlowUnit rfu = new ResourceFlowUnit(System.currentTimeMillis(), context, summary, true);
 
     Node rca = new TestRca();
 


### PR DESCRIPTION
…evel RCA of each node

*Issue #, if available:*
#100 

*Description of changes:*
Add a "persistSummary" flag in flowunit so that only the flowunit emitted by the top level RCA can persist its summary. For data node, the top level RCA is HotNodeRca and for elected master, it is those cluster level RCAs. 
This can help to fix two different issues : 
1. summary will no longer be persisted multiple times. Previously each RCA will persist its own summary and the inner most summary will be persisted by multiple flowunits. 
2. The HotNodeSummary table on master can now can only be linked to HotClusterSummary. This is to avoid the HotNodeSummary table being created and linked to the HotNodeRca table first and causes the RCA API to fail. 

*Tests:*
tested on docker

*Code coverage percentage for this patch:*
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
