### PR TITLE
Fix the getIsMasterNode() function called in HotNodeRca

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -232,14 +232,8 @@ public class RcaController {
 
   private void checkUpdateNodeRole(final NodeDetails currentNode) {
     final NodeRole currentNodeRole = NodeRole.valueOf(currentNode.getRole());
-    Boolean isMasterNode = currentNode.getIsMasterNode();
-    if (isMasterNode != null) {
-      currentRole = isMasterNode ? NodeRole.ELECTED_MASTER : currentNodeRole;
-    } else {
-      final String electedMasterHostAddress = RcaControllerHelper.getElectedMasterHostAddress();
-      currentRole = currentNode.getHostAddress().equalsIgnoreCase(electedMasterHostAddress)
-          ? NodeRole.ELECTED_MASTER : currentNodeRole;
-    }
+    boolean isMasterNode = currentNode.getIsMasterNode();
+    currentRole = isMasterNode ? NodeRole.ELECTED_MASTER : currentNodeRole;
   }
 
   /**

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessor.java
@@ -17,6 +17,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaControllerHelper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.util.JsonConverter;
 import com.google.common.collect.ImmutableList;
@@ -166,7 +167,15 @@ public class ClusterDetailsEventProcessor implements EventProcessor {
       return role;
     }
 
-    public Boolean getIsMasterNode() {
+    public boolean getIsMasterNode() {
+      // TODO : this is added to support backward compatibility for _cat/master fix.
+      //  We can remove this later if the writer changes has been adapted by all clusters in fleet.
+      // query cat master api directly to read the node's role in case the ClusterDetailsEvent
+      // received from writer does not have "IS_MASTER_NODE" field.
+      if (isMasterNode == null) {
+        final String electedMasterHostAddress = RcaControllerHelper.getElectedMasterHostAddress();
+        isMasterNode = this.hostAddress.equalsIgnoreCase(electedMasterHostAddress);
+      }
       return isMasterNode;
     }
   }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change the getIsMasterNode() function to return a primitive boolean type to avoid getting null when calling this function. 
Whenever the getIsMasterNode find that it can not read IS_MASTER_NODE field from event string, it will call _cat/master instead to check whether this node is master or not. 

*Tests:*
tested on docker

*Code coverage percentage for this patch:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
