### PR TITLE
Track RCA enabled across clusters

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerApp.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerApp.java
@@ -35,17 +35,22 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.met
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.sys.AllJvmSamplers;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.listener.MisbehavingGraphOperateMethodListener;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.samplers.RcaStateSamplers;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.RcaStatsReporter;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.collectors.SampleAggregator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.emitters.ISampler;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.emitters.PeriodicSamplers;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.listeners.IListener;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ReaderMetricsProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rest.QueryMetricsRequestHandler;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.threads.ThreadProvider;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.threads.exceptions.PAThreadException;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.sun.net.httpserver.HttpServer;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executors;
@@ -55,6 +60,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class PerformanceAnalyzerApp {
+
   private static final int EXCEPTION_QUEUE_LENGTH = 1;
   public static final String QUERY_URL = "/_opendistro/_performanceanalyzer/metrics";
   private static final Logger LOG = LogManager.getLogger(PerformanceAnalyzerApp.class);
@@ -79,15 +85,15 @@ public class PerformanceAnalyzerApp {
           MISBEHAVING_NODES_LISTENER,
           ExceptionsAndErrors.values());
 
-  public static final SampleAggregator JVM_METRICS_AGGREGATOR =
-      new SampleAggregator(JvmMetrics.values());
+  public static final SampleAggregator PERIODIC_SAMPLE_AGGREGATOR =
+      new SampleAggregator(getPeriodicMeasurementSets());
 
   public static final RcaStatsReporter RCA_STATS_REPORTER =
       new RcaStatsReporter(Arrays.asList(RCA_GRAPH_METRICS_AGGREGATOR,
           RCA_RUNTIME_METRICS_AGGREGATOR, ERRORS_AND_EXCEPTIONS_AGGREGATOR,
-          JVM_METRICS_AGGREGATOR));
+          PERIODIC_SAMPLE_AGGREGATOR));
   public static final PeriodicSamplers PERIODIC_SAMPLERS =
-      new PeriodicSamplers(JVM_METRICS_AGGREGATOR, AllJvmSamplers.getJvmSamplers(),
+      new PeriodicSamplers(PERIODIC_SAMPLE_AGGREGATOR, getAllSamplers(),
           (MetricsConfiguration.CONFIG_MAP.get(StatsCollector.class).samplingInterval) / 2,
           TimeUnit.MILLISECONDS);
   public static final BlockingQueue<PAThreadException> exceptionQueue =
@@ -147,6 +153,7 @@ public class PerformanceAnalyzerApp {
 
   /**
    * Handles any exception thrown from the threads which are not handled by the thread itself.
+   *
    * @param exception The exception thrown from the thread.
    */
   private static void handle(PAThreadException exception) {
@@ -225,4 +232,21 @@ public class PerformanceAnalyzerApp {
 
     return new ClientServers(httpServer, netServer, netClient);
   }
+
+  private static List<ISampler> getAllSamplers() {
+    List<ISampler> allSamplers = new ArrayList<>();
+    allSamplers.addAll(AllJvmSamplers.getJvmSamplers());
+    allSamplers.add(RcaStateSamplers.getRcaEnabledSampler());
+
+    return allSamplers;
+  }
+
+  private static MeasurementSet[] getPeriodicMeasurementSets() {
+    List<MeasurementSet> measurementSets = new ArrayList<>();
+    measurementSets.addAll(Arrays.asList(JvmMetrics.values()));
+    measurementSets.add(RcaRuntimeMetrics.RCA_ENABLED);
+
+    return measurementSets.toArray(new MeasurementSet[]{});
+  }
+
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -83,7 +83,7 @@ public class RcaController {
   private boolean rcaEnabledDefaultValue = false;
 
   // This needs to be volatile as the RcaConfPoller writes it but the Nanny reads it.
-  private volatile boolean rcaEnabled = false;
+  private static volatile boolean rcaEnabled = false;
 
   // This needs to be volatile as the NodeRolePoller writes it but the Nanny reads it.
   private volatile NodeRole currentRole = NodeRole.UNKNOWN;
@@ -304,7 +304,7 @@ public class RcaController {
     return RCA_ENABLED_CONF_FILE;
   }
 
-  public boolean isRcaEnabled() {
+  public static boolean isRcaEnabled() {
     return rcaEnabled;
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaRuntimeMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaRuntimeMetrics.java
@@ -43,7 +43,7 @@ public enum RcaRuntimeMetrics implements MeasurementSet {
    * Metric tracking if RCA is enabled or disabled. We write a 0 if RCA is disabled and 1 if it is
    * enabled.
    */
-  RCA_ENABLED("RcaEnabled", "count", Collections.singletonList(Statistics.MAX));
+  RCA_ENABLED("RcaEnabled", "count", Collections.singletonList(Statistics.SAMPLE));
 
   /**
    * What we want to appear as the metric name.

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaRuntimeMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaRuntimeMetrics.java
@@ -43,7 +43,7 @@ public enum RcaRuntimeMetrics implements MeasurementSet {
    * Metric tracking if RCA is enabled or disabled. We write a 0 if RCA is disabled and 1 if it is
    * enabled.
    */
-  RCA_ENABLED("RcaEnabled", "count", Collections.singletonList(Statistics.COUNT));
+  RCA_ENABLED("RcaEnabled", "count", Collections.singletonList(Statistics.MAX));
 
   /**
    * What we want to appear as the metric name.

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaRuntimeMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaRuntimeMetrics.java
@@ -21,11 +21,15 @@ import java.util.Collections;
 import java.util.List;
 
 public enum RcaRuntimeMetrics implements MeasurementSet {
-  /** The number of times the framework was stopped by the operator. */
+  /**
+   * The number of times the framework was stopped by the operator.
+   */
   RCA_STOPPED_BY_OPERATOR(
       "RcaStoppedByOperator", "count", Collections.singletonList(Statistics.COUNT)),
 
-  /** The number of times the framework was restarted by the operator. */
+  /**
+   * The number of times the framework was restarted by the operator.
+   */
   RCA_RESTARTED_BY_OPERATOR(
       "RcaRestartedByOperator", "count", Collections.singletonList(Statistics.COUNT)),
 
@@ -33,9 +37,17 @@ public enum RcaRuntimeMetrics implements MeasurementSet {
    * ES APIs calls are expensive and we want to keep track of how many we are making. This is a
    * named counter and therefore we can get a count per ES API.
    */
-  ES_APIS_CALLED("ESApisCalled", "count", Collections.singletonList(Statistics.NAMED_COUNTERS));
+  ES_APIS_CALLED("ESApisCalled", "count", Collections.singletonList(Statistics.NAMED_COUNTERS)),
 
-  /** What we want to appear as the metric name. */
+  /**
+   * Metric tracking if RCA is enabled or disabled. We write a 0 if RCA is disabled and 1 if it is
+   * enabled.
+   */
+  RCA_ENABLED("RcaEnabled", "count", Collections.singletonList(Statistics.COUNT));
+
+  /**
+   * What we want to appear as the metric name.
+   */
   private String name;
 
   /**

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaEnabledSampler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaEnabledSampler.java
@@ -1,0 +1,25 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.samplers;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaController;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaRuntimeMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.collectors.SampleAggregator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.emitters.ISampler;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor.NodeDetails;
+
+public class RcaEnabledSampler implements ISampler {
+
+  @Override
+  public void sample(SampleAggregator sampleCollector) {
+    sampleCollector.updateStat(RcaRuntimeMetrics.RCA_ENABLED, "", isRcaEnabled());
+  }
+
+  private int isRcaEnabled() {
+    NodeDetails currentNode = ClusterDetailsEventProcessor.getCurrentNodeDetails();
+    if (currentNode != null && currentNode.getIsMasterNode()) {
+      return RcaController.isRcaEnabled() ? 1 : 0;
+    }
+
+    return 0;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaEnabledSampler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaEnabledSampler.java
@@ -1,3 +1,18 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.samplers;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaController;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaStateSamplers.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaStateSamplers.java
@@ -1,0 +1,10 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.samplers;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.emitters.ISampler;
+
+public class RcaStateSamplers {
+
+  public static ISampler getRcaEnabledSampler() {
+    return new RcaEnabledSampler();
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaStateSamplers.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaStateSamplers.java
@@ -1,3 +1,18 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.samplers;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.emitters.ISampler;


### PR DESCRIPTION
*Description of changes:*
This change adds a new metric that helps track how many clusters have RCA enabled on them. The metric is emitted only from the elected master in order to prevent double counting of the metric.

*Tests:*
Validated the metric on a 2 node docker setup.

*Code coverage percentage for this patch:*
Same as before.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
