### PR TITLE
Fix muted nodes causing subscribe storm

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/Metric.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/Metric.java
@@ -107,4 +107,13 @@ public abstract class Metric extends LeafNode<MetricFlowUnit> {
   public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {
     LOG.error("we are not supposed to read metric flowunit from wire.");
   }
+
+  /**
+   * This method specifies what needs to be done when the current node is muted for throwing
+   * exceptions.
+   */
+  @Override
+  public void handleNodeMuted() {
+    setLocalFlowUnit(MetricFlowUnit.generic());
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/Rca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/Rca.java
@@ -61,6 +61,15 @@ public abstract class Rca<T extends ResourceFlowUnit> extends NonLeafNode<T> {
     setLocalFlowUnit(result);
   }
 
+  /**
+   * This method specifies what needs to be done when the current node is muted for throwing
+   * exceptions.
+   */
+  @Override
+  public void handleNodeMuted() {
+    setLocalFlowUnit((T) T.generic());
+  }
+
   @Override
   public void persistFlowUnit(FlowUnitOperationArgWrapper args) {
     long startTime = System.currentTimeMillis();

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/Symptom.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/Symptom.java
@@ -59,6 +59,15 @@ public abstract class Symptom extends NonLeafNode<SymptomFlowUnit> {
   }
 
   /**
+   * This method specifies what needs to be done when the current node is muted for throwing
+   * exceptions.
+   */
+  @Override
+  public void handleNodeMuted() {
+    setLocalFlowUnit(SymptomFlowUnit.generic());
+  }
+
+  /**
    * Persists a flow unit.
    *
    * @param args The arg wrapper.

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Node.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Node.java
@@ -135,6 +135,12 @@ public abstract class Node<T extends GenericFlowUnit> {
 
   public abstract void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args);
 
+  /**
+   * This method specifies what needs to be done when the current node is muted for throwing
+   * exceptions.
+   */
+  public abstract void handleNodeMuted();
+
   public void setEmptyFlowUnitList() {
     flowUnits = Collections.emptyList();
   }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/GraphNodeOperations.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/GraphNodeOperations.java
@@ -27,7 +27,7 @@ public class GraphNodeOperations {
 
   static void readFromLocal(FlowUnitOperationArgWrapper args) {
     if (Stats.getInstance().isNodeMuted(args.getNode().name())) {
-      args.getNode().setFlowUnits(Collections.EMPTY_LIST);
+      args.getNode().handleNodeMuted();
       return;
     }
     args.getNode().generateFlowUnitListFromLocal(args);


### PR DESCRIPTION
*Issue #, if available:*
#114 
*Description of changes:*
This change adds a new handleMuted() method for a node that sets an empty flow unit as the output of the vertex instead of the output being an empty list(no flow units).

*Tests:*
Tested by inducing a fault causing the node to mute and observe subscription requests.

*Code coverage percentage for this patch:*
No change.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
