### PR TITLE
Added unit tests for the rca.net package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,7 @@ jacocoTestReport {
                     exclude: [
                             '**/com/amazon/opendistro/elasticsearch/performanceanalyzer/grpc/**',
                             '**/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/**',
+                            '**/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/requests**'
                     ])
         })
     }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/net/GRPCConnectionManager.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/net/GRPCConnectionManager.java
@@ -18,6 +18,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.net;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.core.Util;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.InterNodeRpcServiceGrpc;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.InterNodeRpcServiceGrpc.InterNodeRpcServiceStub;
+import com.google.common.annotations.VisibleForTesting;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
@@ -35,7 +36,7 @@ import org.apache.logging.log4j.Logger;
  * Class that manages the channel to other hosts in the cluster. It also performs staleness checks,
  * and initiates a new connection if it deems a channel to have gone stale.
  *
- * <p>It also has listens to cluster state changes and manages handling connections to the changed
+ * <p>It also listens to cluster state changes and manages handling connections to the changed
  * hosts.
  */
 public class GRPCConnectionManager {
@@ -49,8 +50,8 @@ public class GRPCConnectionManager {
       new ConcurrentHashMap<>();
 
   /**
-   * Map of remote host to a grpc client object to that host. The client objects are created over
-   * the channels for those hosts and are used to call RPC methods on.
+   * Map of remote host to a grpc client object of that host. The client objects are created over
+   * the channels for those hosts and are used to call RPC methods on the hosts.
    */
   private ConcurrentMap<String, AtomicReference<InterNodeRpcServiceStub>> perHostClientStubMap =
       new ConcurrentHashMap<>();
@@ -62,6 +63,16 @@ public class GRPCConnectionManager {
 
   public GRPCConnectionManager(final boolean shouldUseHttps) {
     this.shouldUseHttps = shouldUseHttps;
+  }
+
+  @VisibleForTesting
+  public ConcurrentMap<String, AtomicReference<ManagedChannel>> getPerHostChannelMap() {
+    return perHostChannelMap;
+  }
+
+  @VisibleForTesting
+  public ConcurrentMap<String, AtomicReference<InterNodeRpcServiceStub>> getPerHostClientStubMap() {
+    return perHostClientStubMap;
   }
 
   /**

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/net/NetServer.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/net/NetServer.java
@@ -85,6 +85,12 @@ public class NetServer extends InterNodeRpcServiceGrpc.InterNodeRpcServiceImplBa
     this.useHttps = useHttps;
   }
 
+  // postStartHook executes after the NetServer has successfully started its Server
+  protected void postStartHook() {}
+
+  // shutdownHook executes after the NetServer has shutdown its Server
+  protected void shutdownHook() {}
+
   /**
    * When an object implementing interface <code>Runnable</code> is used to create a thread,
    * starting the thread causes the object's <code>run</code> method to be called in that separately
@@ -102,16 +108,17 @@ public class NetServer extends InterNodeRpcServiceGrpc.InterNodeRpcServiceImplBa
         port,
         numServerThreads,
         useHttps);
-
     server = useHttps ? buildHttpsServer() : buildHttpServer();
     try {
       server.start();
       LOG.info("gRPC server started successfully!");
+      postStartHook();
       server.awaitTermination();
       LOG.info(" gRPC server terminating..");
     } catch (InterruptedException | IOException e) {
       e.printStackTrace();
       server.shutdownNow();
+      shutdownHook();
     }
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/ReceivedFlowUnitStore.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/ReceivedFlowUnitStore.java
@@ -100,9 +100,12 @@ public class ReceivedFlowUnitStore {
   /**
    * Drains out all the flow units for all nodes.
    */
-  public void drainAll() {
+  public List<FlowUnitMessage> drainAll() {
+    List<FlowUnitMessage> drained = new ArrayList<>();
     for (final String graphNode : flowUnitMap.keySet()) {
-      drainNode(graphNode);
+      ImmutableList<FlowUnitMessage> messages = drainNode(graphNode);
+      drained.addAll(messages);
     }
+    return drained;
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/SubscriptionManager.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/SubscriptionManager.java
@@ -44,13 +44,13 @@ public class SubscriptionManager {
   /**
    * Map of vertex to a set of hosts that are publishing flow units for that vertex.
    */
-  private ConcurrentMap<String, Set<String>> publisherMap = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, Set<String>> publisherMap = new ConcurrentHashMap<>();
 
   /**
    * Map of vertex to a set of hosts that are interested in consuming the flow units for that
    * vertex.
    */
-  private ConcurrentMap<String, Set<String>> subscriberMap = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, Set<String>> subscriberMap = new ConcurrentHashMap<>();
 
   /**
    * The current locus of the node.

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/handler/SubscribeServerHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/handler/SubscribeServerHandler.java
@@ -21,8 +21,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsC
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeResponse;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.CompositeSubscribeRequest;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.SubscriptionManager;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.requests.CompositeSubscribeRequest;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.tasks.SubscriptionRxTask;
 import io.grpc.stub.StreamObserver;
 import java.util.concurrent.ExecutorService;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/requests/CompositeSubscribeRequest.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/requests/CompositeSubscribeRequest.java
@@ -13,7 +13,7 @@
  *  permissions and limitations under the License.
  */
 
-package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net;
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.requests;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeResponse;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/SubscriptionRxTask.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/SubscriptionRxTask.java
@@ -20,8 +20,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeMes
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeResponse;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeResponse.SubscriptionStatus;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.CompositeSubscribeRequest;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.SubscriptionManager;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.requests.CompositeSubscribeRequest;
 import io.grpc.stub.StreamObserver;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/NodeStateManagerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/NodeStateManagerTest.java
@@ -17,6 +17,7 @@ public class NodeStateManagerTest {
   private static final String TEST_NODE_1 = "node1";
   private static final String TEST_HOST_2 = "host2";
   private static final String TEST_HOST_3 = "host3";
+  private static final String TEST_HOST_4 = "host4";
   private static final int MS_IN_S = 1000;
   private static final int TEN_S_IN_MILLIS = 10 * MS_IN_S;
   private static final ClusterDetailsEventProcessor.NodeDetails EMPTY_DETAILS =
@@ -89,7 +90,7 @@ public class NodeStateManagerTest {
 
     ImmutableList<String> hostsToSubscribeTo =
         testNodeStateManager.getStaleOrNotSubscribedNodes(TEST_NODE_1, TEN_S_IN_MILLIS,
-            ImmutableSet.of(TEST_HOST_1, TEST_HOST_2));
+            ImmutableSet.of(TEST_HOST_1, TEST_HOST_2, TEST_HOST_4));
 
     Assert.assertEquals(2, hostsToSubscribeTo.size());
     Assert.assertTrue(hostsToSubscribeTo.contains(TEST_HOST_1));

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/ReceivedFlowUnitStoreTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/ReceivedFlowUnitStoreTest.java
@@ -18,6 +18,10 @@ import org.junit.experimental.categories.Category;
 public class ReceivedFlowUnitStoreTest {
 
   private static final String TEST_NODE = "testNode";
+  private static final String TEST_NODE_2 = "testNode2";
+  private static final long TIMESTAMP_1 = 1L;
+  private static final long TIMESTAMP_2 = 2L;
+  private static final long TIMESTAMP_3 = 3L;
   private static final int Q_SIZE = 1000;
   private static final int NUM_THREADS = 2;
 
@@ -51,6 +55,21 @@ public class ReceivedFlowUnitStoreTest {
     testFlowUnitStore.enqueue(TEST_NODE, buildTestFlowUnitMessage());
 
     Assert.assertEquals(1, testFlowUnitStore.drainNode(TEST_NODE).size());
+  }
+
+  @Test
+  public void testDrainAll() {
+    FlowUnitMessage msg1 = FlowUnitMessage.newBuilder().setTimeStamp(TIMESTAMP_1).build();
+    FlowUnitMessage msg2 = FlowUnitMessage.newBuilder().setTimeStamp(TIMESTAMP_2).build();
+    FlowUnitMessage msg3 = FlowUnitMessage.newBuilder().setTimeStamp(TIMESTAMP_3).build();
+    testFlowUnitStore.enqueue(TEST_NODE, msg1);
+    testFlowUnitStore.enqueue(TEST_NODE, msg2);
+    testFlowUnitStore.enqueue(TEST_NODE_2, msg3);
+    List<FlowUnitMessage> drained = testFlowUnitStore.drainAll();
+    Assert.assertEquals(3, drained.size());
+    Assert.assertTrue(drained.contains(msg1));
+    Assert.assertTrue(drained.contains(msg2));
+    Assert.assertTrue(drained.contains(msg3));
   }
 
   private FlowUnitMessage buildTestFlowUnitMessage() {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/RejectingExecutor.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/RejectingExecutor.java
@@ -1,0 +1,84 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * An executor which throws an {@link RejectedExecutionException} any time it is asked to execute a task
+ * This class is useful for testing certain branches of our net code
+ */
+class RejectingExecutor implements ExecutorService {
+
+    @Override
+    public void shutdown() {}
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return null;
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return false;
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return false;
+    }
+
+    @Override
+    public boolean awaitTermination(long l, TimeUnit timeUnit) throws InterruptedException {
+        return false;
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> callable) {
+        return null;
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable runnable, T t) {
+        return null;
+    }
+
+    @Override
+    public Future<?> submit(Runnable runnable) {
+        return null;
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> collection) throws InterruptedException {
+        return null;
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> collection, long l, TimeUnit timeUnit)
+            throws InterruptedException {
+        return null;
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> collection)
+            throws InterruptedException, ExecutionException {
+        return null;
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> collection, long l, TimeUnit timeUnit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        return null;
+    }
+
+    @Override
+    public void execute(Runnable runnable) {
+        throw new RejectedExecutionException("REJECTED");
+    }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/SubscribeResponseHandlerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/SubscribeResponseHandlerTest.java
@@ -1,0 +1,57 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeResponse;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.GRPCConnectionManager;
+import com.google.common.collect.Sets;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SubscribeResponseHandlerTest {
+    private static final String HOST = "127.0.0.1";
+    private static final String NODE = "TEST";
+
+    private SubscriptionManager subscriptionManager;
+    private NodeStateManager nodeStateManager;
+    private SubscribeResponseHandler uut;
+
+    @Before
+    public void setup() {
+        GRPCConnectionManager grpcConnectionManager = new GRPCConnectionManager(true);
+        subscriptionManager = new SubscriptionManager(grpcConnectionManager);
+        nodeStateManager = new NodeStateManager();
+        uut = new SubscribeResponseHandler(subscriptionManager, nodeStateManager, HOST, NODE);
+    }
+
+    @Test
+    public void testOnNext() {
+        // Test that onNext() properly processes a successful subscription message
+        SubscribeResponse success = SubscribeResponse.newBuilder()
+                .setSubscriptionStatus(SubscribeResponse.SubscriptionStatus.SUCCESS).build();
+        uut.onNext(success);
+        Assert.assertEquals(subscriptionManager.getPublishersForNode(NODE), Sets.newHashSet(HOST));
+        Assert.assertEquals(SubscribeResponse.SubscriptionStatus.SUCCESS,
+                nodeStateManager.getSubscriptionStatus(NODE, HOST));
+
+        // Test that onNext() properly processes a tag mismatch subscription message
+        SubscribeResponse mismatch = SubscribeResponse.newBuilder()
+                .setSubscriptionStatus(SubscribeResponse.SubscriptionStatus.TAG_MISMATCH).build();
+        uut.onNext(mismatch);
+        Assert.assertEquals(SubscribeResponse.SubscriptionStatus.TAG_MISMATCH,
+                nodeStateManager.getSubscriptionStatus(NODE, HOST));
+        SubscribeResponse unknown = SubscribeResponse.newBuilder().build();
+        uut.onNext(unknown); // This line is included for branch coverage
+    }
+
+    @Test
+    public void testOnError() {
+        /* No-op */
+        uut.onError(new Exception("no-op"));
+    }
+
+    @Test
+    public void testOnCompleted() {
+        /* No-op */
+        uut.onCompleted();
+    }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/SubscriptionManagerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/SubscriptionManagerTest.java
@@ -1,0 +1,95 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeResponse;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.GRPCConnectionManager;
+import com.google.common.collect.Sets;
+import java.util.Collections;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+
+public class SubscriptionManagerTest {
+    private GRPCConnectionManager grpcConnectionManager;
+    private SubscriptionManager uut;
+
+    @Before
+    public void setup() {
+        grpcConnectionManager = new GRPCConnectionManager(true);
+        uut = new SubscriptionManager(grpcConnectionManager);
+    }
+
+    @Test
+    public void testAddAndGetPublishers() {
+        String testNode = "testNode";
+        String ip1 = "127.0.0.1";
+        String ip2 = "127.0.0.2";
+        Assert.assertEquals(Collections.emptySet(), uut.getPublishersForNode(testNode));
+        uut.addPublisher(testNode, ip1);
+        Assert.assertEquals(Sets.newHashSet(ip1), uut.getPublishersForNode(testNode));
+        uut.addPublisher(testNode, ip2);
+        Assert.assertEquals(Sets.newHashSet(ip1, ip2), uut.getPublishersForNode(testNode));
+    }
+
+    @Test
+    public void testSubscriptionFlow() {
+        String testNode = "testNode";
+        String ip1 = "127.0.0.1";
+        String ip2 = "127.0.0.2";
+        String locus = "data-node";
+
+        // Test that addSubscriber doesn't work on non-matching loci
+        SubscribeResponse.SubscriptionStatus status = uut.addSubscriber(testNode, ip1, locus);
+        Assert.assertEquals(SubscribeResponse.SubscriptionStatus.TAG_MISMATCH, status);
+        Assert.assertFalse(uut.isNodeSubscribed(testNode));
+
+        // Test that addSubscriber works for matching loci
+        uut.setCurrentLocus(locus);
+        status = uut.addSubscriber(testNode, ip1, locus);
+        Assert.assertEquals(SubscribeResponse.SubscriptionStatus.SUCCESS, status);
+        Assert.assertEquals(Sets.newHashSet(ip1), uut.getSubscribersFor(testNode));
+        Assert.assertTrue(uut.isNodeSubscribed(testNode));
+
+        // Test that addSubscriber works on repeated calls
+        status = uut.addSubscriber(testNode, ip2, locus);
+        Assert.assertEquals(SubscribeResponse.SubscriptionStatus.SUCCESS, status);
+        Assert.assertEquals(Sets.newHashSet(ip1, ip2), uut.getSubscribersFor(testNode));
+        Assert.assertTrue(uut.isNodeSubscribed(testNode));
+
+        // Add host connections to the grpcConnectionManager
+        grpcConnectionManager.getClientStubForHost(ip1);
+        Assert.assertTrue(grpcConnectionManager.getPerHostChannelMap().containsKey(ip1));
+        Assert.assertTrue(grpcConnectionManager.getPerHostClientStubMap().containsKey(ip1));
+        grpcConnectionManager.getClientStubForHost(ip2);
+        Assert.assertTrue(grpcConnectionManager.getPerHostChannelMap().containsKey(ip2));
+        Assert.assertTrue(grpcConnectionManager.getPerHostClientStubMap().containsKey(ip2));
+
+        // Test that unsubscribeAndTerminateConnection always terminates a connection
+        // TODO is this actually the behavior we intended?
+        uut.unsubscribeAndTerminateConnection("nonExistentNode", ip1);
+        Assert.assertFalse(grpcConnectionManager.getPerHostChannelMap().containsKey(ip1));
+        Assert.assertFalse(grpcConnectionManager.getPerHostClientStubMap().containsKey(ip1));
+
+        // Test that unsubscribeAndTerminateConnection properly updates the underlying map
+        grpcConnectionManager.getClientStubForHost(ip2);
+        uut.unsubscribeAndTerminateConnection(testNode, ip2);
+        Assert.assertEquals(Sets.newHashSet(ip1), uut.getSubscribersFor(testNode));
+        Assert.assertTrue(uut.isNodeSubscribed(testNode));
+        Assert.assertFalse(grpcConnectionManager.getPerHostChannelMap().containsKey(ip2));
+        Assert.assertFalse(grpcConnectionManager.getPerHostClientStubMap().containsKey(ip2));
+
+        // Test that unsubscribeAndTerminateConnection doesn't update the underlying map for non existent addresses
+        uut.unsubscribeAndTerminateConnection(testNode, "nonExistentAddress");
+        Assert.assertEquals(Sets.newHashSet(ip1), uut.getSubscribersFor(testNode));
+        Assert.assertTrue(uut.isNodeSubscribed(testNode));
+
+        // Test that unsubscribeAndTerminateConnection removes the node from the map once all of its subscriptions are
+        // terminated
+        uut.unsubscribeAndTerminateConnection(testNode, ip1);
+        Assert.assertEquals(Collections.emptySet(), uut.getSubscribersFor(testNode));
+        Assert.assertFalse(uut.isNodeSubscribed(testNode));
+    }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopperTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopperTest.java
@@ -1,0 +1,205 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.core.Util;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.GRPCConnectionManager;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetClient;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetServer;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.MetricFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.SymptomFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Used;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.DataMsg;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.IntentMsg;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.handler.PublishRequestHandler;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.handler.SubscribeServerHandler;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.util.WaitFor;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(GradleTaskForRca.class)
+public class WireHopperTest {
+    // TestNetServer is a NetServer that clients can check is running or not
+    private static class TestNetServer extends NetServer implements Runnable {
+        public AtomicBoolean isRunning = new AtomicBoolean(false);
+
+        public TestNetServer(final int port, final int numServerThreads, final boolean useHttps) {
+            super(port, numServerThreads, useHttps);
+        }
+
+        @Override
+        protected void postStartHook() {
+            isRunning.set(true);
+        }
+
+        @Override
+        protected void shutdownHook() {
+            isRunning.set(false);
+        }
+    }
+
+    private static final String NODE1 = "NODE1";
+    private static final String NODE2 = "NODE2";
+    private static final String LOCALHOST = "127.0.0.1";
+    private static final String HOST_NOT_IN_CLUSTER = "NOTINCLUSTER";
+    private static final String LOCUS = "data-node";
+    private static final long EVAL_INTERVAL_S = 5L;
+    private static final long TIMESTAMP = 66L;
+    private static final ExecutorService rejectingExecutor = new RejectingExecutor();
+
+    private static NetClient netClient;
+    private static TestNetServer netServer;
+    private static ExecutorService executorService;
+    private static ExecutorService netServerExecutor;
+    private static AtomicReference<ExecutorService> clientExecutor;
+    private static AtomicReference<ExecutorService> serverExecutor;
+    private static GRPCConnectionManager connectionManager;
+
+    private SubscriptionManager subscriptionManager;
+    private NodeStateManager nodeStateManager;
+    private ReceivedFlowUnitStore receivedFlowUnitStore;
+    private WireHopper uut; // Unit under test
+
+    @BeforeClass
+    public static void setupClass() throws Exception {
+        connectionManager = new GRPCConnectionManager(PluginSettings.instance().getHttpsEnabled());
+        netClient = new NetClient(connectionManager);
+        executorService = Executors.newSingleThreadExecutor();
+        clientExecutor = new AtomicReference<>(null);
+        serverExecutor = new AtomicReference<>(Executors.newSingleThreadExecutor());
+        netServer = new TestNetServer(Util.RPC_PORT, 1, false);
+        netServerExecutor = Executors.newSingleThreadExecutor();
+        netServerExecutor.execute(netServer);
+        // Wait for the TestNetServer to start
+        WaitFor.waitFor(() -> netServer.isRunning.get(), 10, TimeUnit.SECONDS);
+        if (!netServer.isRunning.get()) {
+            throw new RuntimeException("Unable to start TestNetServer");
+        }
+    }
+
+    @Before
+    public void setup() {
+        nodeStateManager = new NodeStateManager();
+        receivedFlowUnitStore = new ReceivedFlowUnitStore();
+        subscriptionManager = new SubscriptionManager(connectionManager);
+        clientExecutor.set(null);
+        uut = new WireHopper(nodeStateManager, netClient, subscriptionManager, clientExecutor, receivedFlowUnitStore);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        executorService.shutdown();
+        netServerExecutor.shutdown();
+        netServer.stop();
+        netClient.stop();
+    }
+
+    @Test
+    public void testSendIntent() throws Exception {
+        Node<MetricFlowUnit> node = new Heap_Used(EVAL_INTERVAL_S);
+        netServer.setSubscribeHandler(new SubscribeServerHandler(subscriptionManager, serverExecutor));
+        Map<String, String> rcaConfTags = new HashMap<>();
+        rcaConfTags.put("locus", RcaConsts.RcaTagConstants.LOCUS_DATA_NODE);
+        IntentMsg msg = new IntentMsg(NODE1, node.name(), rcaConfTags);
+        // verify resilience to null executor
+        uut.sendIntent(msg);
+        // verify method generates appropriate task
+        clientExecutor.set(executorService);
+        subscriptionManager.setCurrentLocus(RcaConsts.RcaTagConstants.LOCUS_DATA_NODE);
+        ClusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
+                ClusterDetailsEventProcessorTestHelper.newNodeDetails(NODE1, LOCALHOST, false),
+                ClusterDetailsEventProcessorTestHelper.newNodeDetails(node.name(), LOCALHOST, false)
+        ));
+        uut.sendIntent(msg);
+        WaitFor.waitFor(() -> subscriptionManager.getSubscribersFor(node.name()).size() == 1, 1,
+                TimeUnit.SECONDS);
+        Assert.assertEquals(1, subscriptionManager.getSubscribersFor(node.name()).size());
+        Assert.assertEquals(LOCALHOST, subscriptionManager.getSubscribersFor(node.name()).asList().get(0));
+        // verify resilience to RejectedExecutionException
+        clientExecutor.set(rejectingExecutor);
+        uut.sendIntent(msg);
+    }
+
+    @Test
+    public void testSendData() throws Exception {
+        netServer.setSendDataHandler(new PublishRequestHandler(nodeStateManager, receivedFlowUnitStore, serverExecutor));
+        // verify resilience to null executor
+        GenericFlowUnit flowUnit = new SymptomFlowUnit(TIMESTAMP);
+        DataMsg msg = new DataMsg(NODE1, Lists.newArrayList(NODE2), Collections.singletonList(flowUnit));
+        uut.sendData(msg);
+
+        clientExecutor.set(executorService);
+        Assert.assertEquals(0L, nodeStateManager.getLastReceivedTimestamp(NODE1, LOCALHOST));
+        // setup downstream subscribers
+        subscriptionManager.setCurrentLocus(LOCUS);
+        subscriptionManager.addSubscriber(NODE1, LOCALHOST, LOCUS);
+        // verify sendData works
+        ClusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
+                ClusterDetailsEventProcessorTestHelper.newNodeDetails(NODE1, LOCALHOST, false),
+                ClusterDetailsEventProcessorTestHelper.newNodeDetails(NODE2, LOCALHOST, false)
+        ));
+        uut.sendData(msg);
+        WaitFor.waitFor(() -> nodeStateManager.getLastReceivedTimestamp(NODE1, LOCALHOST) != 0, 1,
+                TimeUnit.SECONDS);
+        List<FlowUnitMessage> receivedMags = receivedFlowUnitStore.drainNode(NODE1);
+        Assert.assertEquals(1L, receivedMags.size());
+
+        // verify resilience to RejectedExecutionException
+        clientExecutor.set(rejectingExecutor);
+        uut.sendData(msg);
+    }
+
+    @Test
+    public void testReadFromWire() throws Exception {
+        netServer.setSubscribeHandler(new SubscribeServerHandler(subscriptionManager, serverExecutor));
+        // Setup mock object responses
+        Node<MetricFlowUnit> node = new Heap_Used(EVAL_INTERVAL_S);
+        node.addTag(RcaConsts.RcaTagConstants.TAG_LOCUS, RcaConsts.RcaTagConstants.LOCUS_DATA_MASTER_NODE);
+        // Verify resilience to null executor
+        uut.readFromWire(node);
+        // Execute test method and verify return value
+        clientExecutor.set(executorService);
+        ClusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(
+                ClusterDetailsEventProcessorTestHelper.newNodeDetails(
+                        node.name(), LOCALHOST, false)));
+        subscriptionManager.setCurrentLocus(RcaConsts.RcaTagConstants.LOCUS_DATA_NODE);
+        subscriptionManager.addPublisher(node.name(), LOCALHOST);
+        subscriptionManager.addPublisher(node.name(), HOST_NOT_IN_CLUSTER);
+        nodeStateManager.updateReceiveTime(LOCALHOST, node.name(), 1L);
+        FlowUnitMessage msg = FlowUnitMessage.newBuilder().setGraphNode(node.name()).build();
+        ImmutableList<FlowUnitMessage> msgList = ImmutableList.<FlowUnitMessage>builder().add(msg).build();
+        receivedFlowUnitStore.enqueue(node.name(), msg);
+        List<FlowUnitMessage> actualMsgList = uut.readFromWire(node);
+        Assert.assertEquals(msgList, actualMsgList);
+        // Verify expected interactions with the subscription manager
+        WaitFor.waitFor(() -> subscriptionManager.getSubscribersFor(node.name()).size() == 1, 1,
+                TimeUnit.SECONDS);
+        Assert.assertEquals(LOCALHOST, subscriptionManager.getSubscribersFor(node.name()).asList().get(0));
+        // Verify resilience to RejectedExecutionException
+        clientExecutor.set(rejectingExecutor);
+        uut.readFromWire(node);
+    }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/SubscriptionRxTaskTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/SubscriptionRxTaskTest.java
@@ -9,8 +9,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeMes
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeResponse;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeResponse.SubscriptionStatus;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.CompositeSubscribeRequest;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.SubscriptionManager;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.requests.CompositeSubscribeRequest;
 import io.grpc.stub.StreamObserver;
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/AbstractReaderTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/AbstractReaderTests.java
@@ -136,7 +136,7 @@ public class AbstractReaderTests extends AbstractTests {
   }
 
   protected static String createNodeDetailsMetrics(String id, String ipAddress, AllMetrics.NodeRole nodeRole,
-                                            boolean isMasterNode) {
+                                                   boolean isMasterNode) {
     StringBuffer value = new StringBuffer();
     value.append(new NodeDetailsStatus(id, ipAddress, nodeRole, isMasterNode).serialize());
     return value.toString();

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/util/WaitFor.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/util/WaitFor.java
@@ -1,0 +1,31 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.util;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * This class allows you to wait at most a specified duration until a condition evaluates to true
+ */
+public class WaitFor {
+    /**
+     * Waits at most the specified time for the given task to evaluate to true
+     * @param task The task which we hope evaluates to true before the time limit
+     * @param maxWait The max amount of time to wait for the task to evaluate for true
+     * @param unit The time unit of the maxWait parameter
+     * @throws Exception If the time limit expires before the task evaluates to true
+     */
+    public static void waitFor(Callable<Boolean> task, long maxWait, TimeUnit unit) throws Exception {
+        long maxWaitMillis = TimeUnit.MILLISECONDS.convert(maxWait, unit);
+        long pollTime = System.currentTimeMillis();
+        long curTime;
+        while (!task.call() && maxWaitMillis >= 0) {
+            curTime = System.currentTimeMillis();
+            maxWaitMillis -= (curTime - pollTime);
+            pollTime = curTime;
+        }
+        if (maxWait < 0) {
+            throw new TimeoutException("WaitFor timed out before task evaluated to true");
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* 51

*Description of changes:* 
- Added unit tests for the rca.net package
- Added ability to check if NetServer is running
- Moved CompositeSubscribeRequest to its own subpackage, and ignored that subpackage from Jacoco coverage
- Added various getters and setters to main classes
- Added a NodeDetails constructor which is incredibly useful for testing
- Added a RejectingExecutor() test class, which is an executor that throws a RejectedExecutionException for all requests (useful for testing)
- Added the WaitFor utility class. This class currently allows you to wait up to N seconds (or whatever time unit) for some condition to evaluate to true.

*Tests:*
- Increased branch coverage of NodeStateManagerTest
- Covered the drainAll() method in ReceivedFlowUnitStoreTest
- Added the SubscribeResponseHandlerTest, SubscriptionManagerTest, WireHopperTest classes 

*Code coverage percentage for this patch:* 99%

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
