### PR TITLE
Added unit tests for rca.samplers and rca.util

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaEnabledSampler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaEnabledSampler.java
@@ -21,20 +21,21 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.collect
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.emitters.ISampler;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor.NodeDetails;
+import com.google.common.annotations.VisibleForTesting;
 
 public class RcaEnabledSampler implements ISampler {
 
   @Override
   public void sample(SampleAggregator sampleCollector) {
-    sampleCollector.updateStat(RcaRuntimeMetrics.RCA_ENABLED, "", isRcaEnabled());
+    sampleCollector.updateStat(RcaRuntimeMetrics.RCA_ENABLED, "", isRcaEnabled() ? 1 : 0);
   }
 
-  private int isRcaEnabled() {
+  @VisibleForTesting
+  boolean isRcaEnabled() {
     NodeDetails currentNode = ClusterDetailsEventProcessor.getCurrentNodeDetails();
     if (currentNode != null && currentNode.getIsMasterNode()) {
-      return RcaController.isRcaEnabled() ? 1 : 0;
+      return RcaController.isRcaEnabled();
     }
-
-    return 0;
+    return false;
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/stats/collectors/SampleAggregator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/stats/collectors/SampleAggregator.java
@@ -37,7 +37,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtils.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtils.java
@@ -2,6 +2,8 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.util;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor.NodeDetails;
+import com.google.common.annotations.VisibleForTesting;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -10,7 +12,9 @@ import java.util.stream.Collectors;
  */
 public class ClusterUtils {
 
-  private static final String EMPTY_STRING = "";
+  @VisibleForTesting
+  static final String EMPTY_STRING = "";
+
 
   /**
    * Get the current host's ip address.

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
@@ -140,11 +140,11 @@ public class RcaControllerTest {
   public void readRcaEnabledFromConf() throws IOException {
     changeRcaRunState(RcaState.STOP);
     Assert.assertTrue(check(new RcaEnabledEval(rcaController), false));
-    Assert.assertFalse(rcaController.isRcaEnabled());
+    Assert.assertFalse(RcaController.isRcaEnabled());
 
     changeRcaRunState(RcaState.RUN);
     Assert.assertTrue(check(new RcaEnabledEval(rcaController), true));
-    Assert.assertTrue(rcaController.isRcaEnabled());
+    Assert.assertTrue(RcaController.isRcaEnabled());
   }
 
   @Test
@@ -290,7 +290,7 @@ public class RcaControllerTest {
 
     @Override
     public boolean evaluateAndCheck(Boolean t) {
-      return rcaController.isRcaEnabled() == t;
+      return RcaController.isRcaEnabled() == t;
     }
   }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/NodeStateManagerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/NodeStateManagerTest.java
@@ -1,25 +1,16 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net;
 
-import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeResponse.SubscriptionStatus;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.util.ClusterUtils;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import java.util.Arrays;
+import com.google.common.collect.Lists;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@Category(GradleTaskForRca.class)
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(ClusterUtils.class)
 public class NodeStateManagerTest {
 
   private static final String TEST_HOST_1 = "host1";
@@ -28,13 +19,14 @@ public class NodeStateManagerTest {
   private static final String TEST_HOST_3 = "host3";
   private static final int MS_IN_S = 1000;
   private static final int TEN_S_IN_MILLIS = 10 * MS_IN_S;
+  private static final ClusterDetailsEventProcessor.NodeDetails EMPTY_DETAILS =
+          ClusterDetailsEventProcessorTestHelper.newNodeDetails("", "", false);
 
   private NodeStateManager testNodeStateManager;
 
   @Before
   public void setUp() {
     this.testNodeStateManager = new NodeStateManager();
-    mockStatic(ClusterUtils.class);
   }
 
   @Test
@@ -62,10 +54,11 @@ public class NodeStateManagerTest {
 
     testNodeStateManager
         .updateSubscriptionState(TEST_NODE_1, TEST_HOST_1, SubscriptionStatus.SUCCESS);
-    when(ClusterUtils.getAllPeerHostAddresses())
-        .thenReturn(Arrays.asList(TEST_HOST_1, TEST_HOST_2));
-    when(ClusterUtils.isHostAddressInCluster(TEST_HOST_1)).thenReturn(true);
-    when(ClusterUtils.isHostAddressInCluster(TEST_HOST_2)).thenReturn(true);
+    ClusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
+            EMPTY_DETAILS,
+            ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, TEST_HOST_1, false),
+            ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, TEST_HOST_2, false)
+    ));
 
     ImmutableList<String> hostsToSubscribeTo =
         testNodeStateManager.getStaleOrNotSubscribedNodes(TEST_NODE_1, TEN_S_IN_MILLIS,
@@ -87,10 +80,12 @@ public class NodeStateManagerTest {
     testNodeStateManager.updateReceiveTime(TEST_HOST_2, TEST_NODE_1, currentTime);
     testNodeStateManager.updateSubscriptionState(TEST_NODE_1, TEST_HOST_2, SubscriptionStatus.SUCCESS);
 
-    when(ClusterUtils.getAllPeerHostAddresses())
-        .thenReturn(Arrays.asList(TEST_HOST_1, TEST_HOST_2, TEST_HOST_3));
-    when(ClusterUtils.isHostAddressInCluster(TEST_HOST_1)).thenReturn(true);
-    when(ClusterUtils.isHostAddressInCluster(TEST_HOST_2)).thenReturn(true);
+    ClusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
+            EMPTY_DETAILS,
+            ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, TEST_HOST_1, false),
+            ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, TEST_HOST_2, false),
+            ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, TEST_HOST_3, false)
+    ));
 
     ImmutableList<String> hostsToSubscribeTo =
         testNodeStateManager.getStaleOrNotSubscribedNodes(TEST_NODE_1, TEN_S_IN_MILLIS,

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaEnabledSamplerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaEnabledSamplerTest.java
@@ -1,0 +1,51 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.samplers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaController;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaRuntimeMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.collectors.SampleAggregator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class RcaEnabledSamplerTest {
+    private RcaEnabledSampler uut;
+
+    @Mock
+    private SampleAggregator sampleAggregator;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        uut = new RcaEnabledSampler();
+    }
+
+    @Test
+    public void testIsRcaEnabled() {
+        assertFalse(uut.isRcaEnabled());
+        ClusterDetailsEventProcessor.NodeDetails details =
+                ClusterDetailsEventProcessorTestHelper.newNodeDetails("", "", false);
+        ClusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(details));
+        assertFalse(uut.isRcaEnabled());
+        details = ClusterDetailsEventProcessorTestHelper.newNodeDetails("", "", true);
+        ClusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(details));
+        assertEquals(RcaController.isRcaEnabled(), uut.isRcaEnabled());
+    }
+
+    @Test
+    public void testSample() {
+        ClusterDetailsEventProcessor.NodeDetails details =
+                ClusterDetailsEventProcessorTestHelper.newNodeDetails("", "", true);
+        uut.sample(sampleAggregator);
+        verify(sampleAggregator, times(1))
+                .updateStat(RcaRuntimeMetrics.RCA_ENABLED, "", RcaController.isRcaEnabled() ? 1 : 0);
+    }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaStateSamplersTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaStateSamplersTest.java
@@ -1,0 +1,21 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.samplers;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaController;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class RcaStateSamplersTest {
+    private RcaStateSamplers uut;
+
+    @Test
+    public void testGetRcaEnabledSampler() {  // done for constructor coverage
+        uut = new RcaStateSamplers();
+        assertSame(uut.getClass(), RcaStateSamplers.class);
+        assertTrue(RcaStateSamplers.getRcaEnabledSampler() instanceof RcaEnabledSampler);
+    }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtilsTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtilsTest.java
@@ -1,0 +1,55 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.util;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
+import com.google.common.collect.Lists;
+import java.util.Collections;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ClusterUtilsTest {
+    private static final String HOST = "127.0.0.1";
+    private static final String HOST2 = "127.0.0.2";
+    private static final ClusterDetailsEventProcessor.NodeDetails EMPTY_DETAILS =
+            ClusterDetailsEventProcessorTestHelper.newNodeDetails("", "", false);
+
+    @Test
+    public void testGetCurrentHostAddress() {
+        ClusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(EMPTY_DETAILS));
+        Assert.assertEquals(ClusterUtils.EMPTY_STRING, ClusterUtils.getCurrentNodeHostAddress());
+        ClusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(
+                ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, HOST, false)
+        ));
+        Assert.assertEquals(HOST, ClusterUtils.getCurrentNodeHostAddress());
+    }
+
+    @Test
+    public void testGetAllPeerHostAddresses() {
+        // method should behave when fed an empty list of peers
+        ClusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(EMPTY_DETAILS));
+        Assert.assertEquals(Collections.emptyList(), ClusterUtils.getAllPeerHostAddresses());
+        // method should not include the current node in the list of peers
+        ClusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
+                ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, HOST, false)
+        ));
+        Assert.assertEquals(Collections.emptyList(), ClusterUtils.getAllPeerHostAddresses());
+        // method should return the appropriate peers when peers exist
+        ClusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
+                ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, HOST, false),
+                ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, HOST2, false)
+        ));
+        Assert.assertEquals(Collections.singletonList(HOST2), ClusterUtils.getAllPeerHostAddresses());
+    }
+
+    @Test
+    public void testIsHostAddressInCluster() {
+        // method should return false when there are no peers
+        Assert.assertFalse(ClusterUtils.isHostAddressInCluster(HOST));
+        // method should properly recognize which hosts are peers and which aren't
+        ClusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
+                ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, HOST, false)
+        ));
+        Assert.assertTrue(ClusterUtils.isHostAddressInCluster(HOST));
+        Assert.assertFalse(ClusterUtils.isHostAddressInCluster(HOST2));
+    }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/AbstractReaderTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/AbstractReaderTests.java
@@ -131,14 +131,21 @@ public class AbstractReaderTests extends AbstractTests {
     return new HeapStatus(name.toString(), collectionCount, collectionTime).serialize();
   }
 
-  protected String createNodeDetailsMetrics(String id, String ipAddress, boolean isMasterNode) {
+  protected static String createNodeDetailsMetrics(String id, String ipAddress, boolean isMasterNode) {
     return createNodeDetailsMetrics(id, ipAddress, AllMetrics.NodeRole.DATA, isMasterNode);
   }
 
-  protected String createNodeDetailsMetrics(String id, String ipAddress, AllMetrics.NodeRole nodeRole, boolean isMasterNode) {
+  protected static String createNodeDetailsMetrics(String id, String ipAddress, AllMetrics.NodeRole nodeRole,
+                                            boolean isMasterNode) {
     StringBuffer value = new StringBuffer();
     value.append(new NodeDetailsStatus(id, ipAddress, nodeRole, isMasterNode).serialize());
     return value.toString();
+  }
+
+  protected static ClusterDetailsEventProcessor.NodeDetails createNodeDetails(String id, String ipAddress,
+                                                                              boolean isMasterNode) {
+    return new ClusterDetailsEventProcessor.NodeDetails(
+            createNodeDetailsMetrics(id, ipAddress, isMasterNode));
   }
 
   static void setFinalStatic(Field field, Object newValue) throws Exception {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessorTestHelper.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessorTestHelper.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
 import java.sql.SQLException;
@@ -31,6 +32,11 @@ public class ClusterDetailsEventProcessorTestHelper extends AbstractReaderTests 
 
   public void addNodeDetails(String nodeId, String address, boolean isMasterNode) {
     nodeDetails.add(createNodeDetailsMetrics(nodeId, address, isMasterNode));
+  }
+
+  public static ClusterDetailsEventProcessor.NodeDetails newNodeDetails(final String nodeId, final String address,
+                                                                        final boolean isMasterNode) {
+    return createNodeDetails(nodeId, address, isMasterNode);
   }
 
   public void generateClusterDetailsEvent() {


### PR DESCRIPTION
*Issue #, if available:* 51

*Description of changes:* 
- Changed visibility of a few variables and methods to allow for testing
- Added ability to create new NodeDetails elements to the ClusterDetailsEventProcessorTestHelper class

*Tests:*
- RcaEnabledSamplerTest: Basic test which verified the construction and sampling behavior of the uut
- Modified NodeStateManagerTest to not rely on mocks
- Added the RcaStateSamplersTest which does basic constructor coverage. We can't ignore this package, so this test is minor, but necessary for improved coverage
- Added the ClusterUtilsTest which verifies ClusterUtils behavior

*Code coverage percentage for this patch:* 93% for rca.samplers
                                                                      89% for rca.util

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
