### PR TITLE
Exclude the rca.framework.api.metrics package from Jacoco

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,9 @@ jacocoTestReport {
                             '**/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/**'
                     ],
                     exclude: [
-                            '**/com/amazon/opendistro/elasticsearch/performanceanalyzer/grpc/**'])
+                            '**/com/amazon/opendistro/elasticsearch/performanceanalyzer/grpc/**',
+                            '**/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/**',
+                    ])
         })
     }
 }


### PR DESCRIPTION
The classes in this package all extend Metric. "Coverage" of these
classes would amount to constructing them. The actual unit that should
be tested is the Metric class itself.

*Issue #, if available:* 51

*Description of changes:* Exclude the rca.framework.api.metrics package from Jacoco

*Tests:*

*Code coverage percentage for this patch:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
