### PR TITLE
Fix FileRotateTest failues

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/FileRotate.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/FileRotate.java
@@ -112,8 +112,8 @@ public class FileRotate {
 
     Path targetFilePath = Paths.get(dir, targetFileName.toString());
     try {
-      lastRotatedMillis = System.currentTimeMillis();
       Files.move(FILE_TO_ROTATE, targetFilePath);
+      lastRotatedMillis = System.currentTimeMillis();
     } catch (FileAlreadyExistsException fae) {
       LOG.error(fae);
     } catch (IOException e) {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaTestHelper.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaTestHelper.java
@@ -25,19 +25,16 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactory;
-import org.w3c.dom.Document;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.FileAppender;
 import org.xml.sax.SAXException;
 
 public class RcaTestHelper {
   public static List<String> getAllLinesFromStatsLog() {
     try {
-      return Files.readAllLines(Paths.get(getLogFilePath("StatsLog")));
+      return Files.readAllLines(Paths.get(getLogFilePath(LogType.StatsLog)));
     } catch (IOException | ParserConfigurationException | SAXException | XPathExpressionException e) {
       e.printStackTrace();
     }
@@ -54,18 +51,18 @@ public class RcaTestHelper {
     return matches;
   }
 
-  public static List<String> getAllLinesFromLog(String logName) {
+  public static List<String> getAllLinesFromLog(LogType logType) {
     try {
-      return Files.readAllLines(Paths.get(getLogFilePath(logName)));
+      return Files.readAllLines(Paths.get(getLogFilePath(logType)));
     } catch (IOException | ParserConfigurationException | SAXException | XPathExpressionException e) {
       e.printStackTrace();
     }
     return Collections.EMPTY_LIST;
   }
 
-  public static List<String> getAllLogLinesWithMatchingString(String logName, String pattern) {
+  public static List<String> getAllLogLinesWithMatchingString(LogType logType, String pattern) {
     List<String> matches = new ArrayList<>();
-    for (String line: getAllLinesFromLog(logName)) {
+    for (String line: getAllLinesFromLog(logType)) {
       if (line.contains(pattern)) {
         matches.add(line);
       }
@@ -73,25 +70,28 @@ public class RcaTestHelper {
     return matches;
   }
 
-  public static String getLogFilePath(String filename)
-      throws ParserConfigurationException, IOException, SAXException, XPathExpressionException {
-    String cwd = System.getProperty("user.dir");
-    String testResourcesPath =
-        Paths.get(Paths.get(cwd, "src", "test", "resources").toString(), "log4j2.xml").toString();
+  public enum LogType {
+    PerformanceAnalyzerLog,
+    StatsLog
+  }
 
-    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-    DocumentBuilder builder = factory.newDocumentBuilder();
-    Document doc = builder.parse(testResourcesPath);
-    XPathFactory xPathfactory = XPathFactory.newInstance();
-    XPath xpath = xPathfactory.newXPath();
-    return xpath.evaluate(
-        String.format("Configuration/Appenders/File[@name='%s']/@fileName", filename), doc);
+  public static String getLogFilePath(LogType logType)
+          throws ParserConfigurationException, IOException, SAXException, XPathExpressionException {
+    System.out.println(LoggerContext.getContext().getRootLogger().getAppenders());
+    org.apache.logging.log4j.core.Logger logger = null;
+    if (logType == LogType.StatsLog) {
+      logger = LoggerContext.getContext().getLogger("stats_log");
+    } else {
+      logger = LoggerContext.getContext().getRootLogger();
+    }
+    FileAppender fileAppender = (FileAppender) logger.getAppenders().get(logType.name());
+    return fileAppender.getFileName();
   }
 
   public static void cleanUpLogs() {
     try {
-      truncate(Paths.get(getLogFilePath("PerformanceAnalyzerLog")).toFile());
-      truncate(Paths.get(getLogFilePath("StatsLog")).toFile());
+      truncate(Paths.get(getLogFilePath(LogType.PerformanceAnalyzerLog)).toFile());
+      truncate(Paths.get(getLogFilePath(LogType.StatsLog)).toFile());
     } catch (ParserConfigurationException | SAXException | XPathExpressionException | IOException e) {
       e.printStackTrace();
     }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/FileGCTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/FileGCTest.java
@@ -39,7 +39,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class FileGCTest {
-  private Path testLocation = null;
+  private static Path testLocation = null;
   private final String baseFilename = "rca.test.file";
 
   @BeforeClass
@@ -51,14 +51,15 @@ public class FileGCTest {
   public static void cleanup() throws IOException {
     cleanupLogs();
     String cwd = System.getProperty("user.dir");
-    Path tmpPath = Paths.get(cwd, "src", "test", "resources", "tmp");
-    FileUtils.cleanDirectory(tmpPath.toFile());
+    if (testLocation != null) {
+      FileUtils.cleanDirectory(testLocation.toFile());
+    }
   }
 
   @Before
   public void init() throws IOException {
     String cwd = System.getProperty("user.dir");
-    testLocation = Paths.get(cwd, "src", "test", "resources", "tmp", "file_rotate");
+    testLocation = Paths.get(cwd, "src", "test", "resources", "tmp", "file_gc");
     Files.createDirectories(testLocation);
     FileUtils.cleanDirectory(testLocation.toFile());
   }
@@ -88,7 +89,7 @@ public class FileGCTest {
   public void testTimeBasedFileCleanup() throws IOException {
     long currentTime = System.currentTimeMillis();
     // create files with modified time past the limit.
-    long limit = currentTime - 10 * 3;
+    long limit = currentTime - 1000;
 
     // For these set of files, we are trying to set the file modification time to be before the
     // limit so that they will be deleted by the time based cleaner.
@@ -96,7 +97,7 @@ public class FileGCTest {
       String name = baseFilename + "." + i;
       Path filePath = Paths.get(testLocation.toString(), name);
       Files.createFile(filePath);
-      Assert.assertTrue(filePath.toFile().setLastModified(limit - (i + 1) * 10));
+      Assert.assertTrue(filePath.toFile().setLastModified(limit - (i + 1) * 1000));
     }
     FileGCTestHelper fileGc = new FileGCTestHelper();
     String[] files = fileGc.getDbFiles();

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -4,10 +4,10 @@
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
         </Console>
-        <File name="PerformanceAnalyzerLog" fileName="/tmp/PerformanceAnalyzer.log" immediateFlush="true" append="true">
+        <File name="PerformanceAnalyzerLog" fileName="${log4j:configParentLocation}/log/PerformanceAnalyzer.log" immediateFlush="true" append="true">
             <PatternLayout pattern="%d{yyy-MM-dd HH:mm:ss.SSS} [PA:Reader] [%t] %-5level %logger{36} - %msg%n"/>
         </File>
-        <File name="StatsLog" fileName="/tmp/performance_analyzer_agent_stats.log" immediateFlush="true" append="true">
+        <File name="StatsLog" fileName="${log4j:configParentLocation}/log/performance_analyzer_agent_stats.log" immediateFlush="true" append="true">
         </File>
     </Appenders>
     <Loggers>


### PR DESCRIPTION
*Issue #, if available:* 51

*Description of changes:* FileRotateTest started failing because we suddenly became unable to read data from the PerformanceAnalyzerLog.log file when our test ran on the Github CI runner. This change modified the logic of the test so that it verifies the same behavior without relying on reading the log file.

*Tests:* FileRotateTest was modified not to rely on reading out log data to verify behavior.

*Code coverage percentage for this patch:* N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
