### PR TITLE
Ignore the rca.stats.eval.impl.vals package from coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,7 @@ jacocoTestReport {
                     exclude: [
                             '**/com/amazon/opendistro/elasticsearch/performanceanalyzer/grpc/**',
                             '**/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/**',
+                            '**/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/stats/eval/impl/vals/**'
                     ])
         })
     }


### PR DESCRIPTION
This package only contains constructors and getters

*Issue #, if available:* 51 

*Description of changes:* Ignore the rca.stats.eval.impl.vals package from coverage

*Tests:*

*Code coverage percentage for this patch:* 100%

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
