### PR TITLE
Lock minimum build coverage to 76%

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,7 @@ jacocoTestCoverageVerification {
     violationRules {
         rule {
             limit {
-                minimum = 0.6
+                minimum = 0.76
             }
         }
     }


### PR DESCRIPTION
*Issue #, if available:* 51

*Description of changes:* Locked Jacoco minimum coverage to 76%. Anything under this amount will fail to build.

*Tests:*

*Code coverage percentage for this patch:* >= 76%

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
