### PR TITLE
Adding final changes for integrating Muting API with scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,29 +59,53 @@ curl --url "localhost:9650/_opendistro/_performanceanalyzer/rca?name=HighHeapUsa
 ```
 The sample RCA response from above api
 ```
-[
-  {
-    "Name": "HighHeapUsageClusterRca",
-    "State": "unhealthy",
-    "NumOfNodes": 6,
-    "NumOfUnhealthyNodes": 1,
-    "TimeStamp": "1579809393944",
-    "Summary": [
-      {
-        "NodeId": "lpgNv3VlSQGfuqMz8CmzUg",
-        "IpAddress": "10.212.48.118",
-        "ResourceContext": [
-          {
-            "ResourceName": "garbage collector",
-            "UnitType": "heap usage in percentage",
-            "Threshold": 0.65,
-            "Actual": 0.0710642990279853
-          }
-        ]
-      }
+{
+    "HighHeapUsageClusterRca": [
+        {
+            "rca_name": "HighHeapUsageClusterRca",
+            "state": "unhealthy",
+            "timestamp": 1587426650942,
+            "HotClusterSummary": [
+                {
+                    "number_of_nodes": 2,
+                    "number_of_unhealthy_nodes": 1,
+                    "HotNodeSummary": [
+                        {
+                            "host_address": "192.168.144.2",
+                            "node_id": "JtlEoRowSI6iNpzpjlbp_Q",
+                            "HotResourceSummary": [
+                                {
+                                    "resource_type": "old gen",
+                                    "threshold": 0.65,
+                                    "value": 0.81827232588145373,
+                                    "avg": NaN,
+                                    "max": NaN,
+                                    "min": NaN,
+                                    "unit_type": "heap usage in percentage",
+                                    "time_period_seconds": 600,
+                                    "TopConsumerSummary": [
+                                        {
+                                            "name": "CACHE_FIELDDATA_SIZE",
+                                            "value": 590702564
+                                        },
+                                        {
+                                            "name": "CACHE_REQUEST_SIZE",
+                                            "value": 28375
+                                        },
+                                        {
+                                            "name": "CACHE_QUERY_SIZE",
+                                            "value": 12687
+                                        }
+                                    ],
+                                }
+                            ]
+                        }
+                    ] 
+                }
+            ]
+        }
     ]
-  }
-]
+}
 ```
 
 ## Building, Deploying, and Running the RCA Framework

--- a/pa_config/rca.conf
+++ b/pa_config/rca.conf
@@ -41,5 +41,7 @@
   // RCA settings
   "high-heap-usage-old-gen-rca": {
     "top-k" : 3
-  }
+  },
+
+  "muted-rcas": ""
 }

--- a/pa_config/rca.conf
+++ b/pa_config/rca.conf
@@ -36,5 +36,10 @@
     // How often the sqlite file be repeated in seconds. This file contains RCAs and therefore rotating it too frequently
     // might not be as fruitful as there might not be any data.
     "rotation-period-seconds": 21600
+  },
+
+  // RCA settings
+  "high-heap-usage-old-gen-rca": {
+    "top-k" : 3
   }
 }

--- a/pa_config/rca_idle_master.conf
+++ b/pa_config/rca_idle_master.conf
@@ -41,5 +41,7 @@
   // RCA settings
   "high-heap-usage-old-gen-rca": {
     "top-k" : 3
-  }
+  },
+
+  "muted-rcas": ""
 }

--- a/pa_config/rca_idle_master.conf
+++ b/pa_config/rca_idle_master.conf
@@ -36,5 +36,10 @@
     // How often the sqlite file be repeated in seconds. This file contains RCAs and therefore rotating it too frequently
     // might not be as fruitful as there might not be any data.
     "rotation-period-seconds": 21600
+  },
+
+  // RCA settings
+  "high-heap-usage-old-gen-rca": {
+    "top-k" : 3
   }
 }

--- a/pa_config/rca_master.conf
+++ b/pa_config/rca_master.conf
@@ -41,5 +41,7 @@
   // RCA settings
   "high-heap-usage-old-gen-rca": {
     "top-k" : 3
-  }
+  },
+
+  "muted-rcas": ""
 }

--- a/pa_config/rca_master.conf
+++ b/pa_config/rca_master.conf
@@ -36,5 +36,10 @@
     // How often the sqlite file be repeated in seconds. This file contains RCAs and therefore rotating it too frequently
     // might not be as fruitful as there might not be any data.
     "rotation-period-seconds": 21600
+  },
+
+  // RCA settings
+  "high-heap-usage-old-gen-rca": {
+    "top-k" : 3
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -56,12 +56,15 @@ import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.SQLException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Scanner;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -85,6 +88,9 @@ public class RcaController {
   // This needs to be volatile as the RcaConfPoller writes it but the Nanny reads it.
   private static volatile boolean rcaEnabled = false;
 
+  // This needs to be volatile as the RcaConfPoller writes it but the Nanny reads it.
+  private static volatile long lastModifiedTimeInMillisInMemory = 0;
+
   // This needs to be volatile as the NodeRolePoller writes it but the Nanny reads it.
   private volatile NodeRole currentRole = NodeRole.UNKNOWN;
 
@@ -99,6 +105,8 @@ public class RcaController {
   private QueryRcaRequestHandler queryRcaRequestHandler;
 
   private SubscriptionManager subscriptionManager;
+
+  private RcaConf rcaConf;
 
   private final String RCA_ENABLED_CONF_LOCATION;
   private final long rcaStateCheckIntervalMillis;
@@ -135,7 +143,7 @@ public class RcaController {
   }
 
   private void start() {
-    final RcaConf rcaConf = RcaControllerHelper.pickRcaConfForRole(currentRole);
+    rcaConf = RcaControllerHelper.pickRcaConfForRole(currentRole);
     try {
       subscriptionManager.setCurrentLocus(rcaConf.getTagMap().get("locus"));
       List<ConnectedComponent> connectedComponents = RcaUtil.getAnalysisGraphComponents(rcaConf);
@@ -215,8 +223,8 @@ public class RcaController {
             checkUpdateNodeRole(nodeDetails);
           }
         }
-
         updateRcaState();
+
         long duration = System.currentTimeMillis() - startTime;
         if (duration < rcaStateCheckIntervalMillis) {
           Thread.sleep(rcaStateCheckIntervalMillis - duration);
@@ -253,6 +261,51 @@ public class RcaController {
             rcaEnabled = rcaEnabledDefaultValue;
           }
         });
+
+    // If RCA is enabled, update Analysis graph with Muted RCAs value
+    if (rcaEnabled) {
+      LOG.debug("Updating Analysis Graph with Muted RCAs");
+      readAndUpdateMutesRcas();
+    }
+  }
+
+  /**
+   * Reads the mutedRCAList value from the rca.conf file, performs validation on the param value
+   * provided and on successful validation, updates the AnalysisGraph with muted RCA value.
+   *
+   * <p>In case all the RCAs in param value are incorrect, return without any update.
+   */
+  private void readAndUpdateMutesRcas() {
+    // If the rca config file has been updated since the lastModifiedTimeInMillisInMemory in memory,
+    // refresh the `muted-rcas` value from rca config file.
+    long lastModifiedTimeInMillisOnDisk = rcaConf.getLastModifiedTime();
+    if (lastModifiedTimeInMillisOnDisk > lastModifiedTimeInMillisInMemory) {
+      try {
+        Set<String> rcasForMute = new HashSet<>(rcaConf.getMutedRcaList());
+        LOG.info("RCAs provided for muting : {}", rcasForMute);
+
+        Set<String> graphNodeNames = new HashSet<>();
+        RcaUtil.getAnalysisGraphComponents(rcaConf).forEach(
+                connectedComponent -> connectedComponent.addNodeNames(graphNodeNames));
+
+        // Update rcasForMute to retain only valid RCAs
+        rcasForMute.retainAll(graphNodeNames);
+
+        // If rcasForMute post validation is empty but rcaConf.getMutedRcaList() is not empty
+        // all the input RCAs are incorrect, return.
+        if (rcasForMute.isEmpty() && !rcaConf.getMutedRcaList().isEmpty()) {
+          LOG.error("Incorrect RCA(s): {}, cannot be muted. Valid RCAs: {}",
+                  rcaConf.getMutedRcaList(), graphNodeNames);
+          return;
+        }
+
+        LOG.info("Updating the muted RCA Graph to : {}", rcasForMute);
+        Stats.getInstance().updateMutedGraphNodes(rcasForMute);
+      } catch (Exception e) {
+        LOG.error("Couldn't read/update the muted RCAs.", e);
+      }
+    }
+    lastModifiedTimeInMillisInMemory = lastModifiedTimeInMillisOnDisk;
   }
 
   /**
@@ -286,7 +339,6 @@ public class RcaController {
       }
     }
   }
-
 
   private void removeRcaRequestHandler() {
     try {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/configs/HighHeapUsageOldGenRcaConfig.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/configs/HighHeapUsageOldGenRcaConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.configs;
+
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * config object to store rca config settings in rca.conf
+ */
+public class HighHeapUsageOldGenRcaConfig {
+
+  private static final Logger LOG = LogManager.getLogger(HighHeapUsageOldGenRcaConfig.class);
+  private int topK;
+  public static final int DEFAULT_TOP_K = 3;
+  private static final String TOP_K_RCA_CONF = "top-k";
+
+  public HighHeapUsageOldGenRcaConfig(final Map<String, String> settings) {
+    this.topK = DEFAULT_TOP_K;
+    parseConfig(settings);
+  }
+
+  private void parseConfig(final Map<String, String> settings) {
+    if (settings != null && settings.containsKey(TOP_K_RCA_CONF)) {
+      try {
+        topK = Integer.parseInt(settings.get(TOP_K_RCA_CONF));
+      }
+      catch (NumberFormatException ne) {
+        LOG.error("rca.conf contains invalid top-k number");
+      }
+    }
+  }
+
+  public int getTopK() {
+    return topK;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/Metric.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/Metric.java
@@ -75,7 +75,9 @@ public abstract class Metric extends LeafNode<MetricFlowUnit> {
     } catch (DataAccessException dex) {
       // This can happen if the RCA started querying for metrics before the Reader obtained them.
       // This is not an error.
-      LOG.info("Looking for metric {}, when it does not exist.", name);
+      // And node stats metrics can be enabled/disabled on writer side so we might end up being here
+      // if RCA is trying to read node stats which are not enabled yet.
+      LOG.warn("Looking for metric {}, when it does not exist.", name);
     } catch (Exception e) {
       PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
           ExceptionsAndErrors.EXCEPTION_IN_GATHER, name(), 1);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/ConfJsonWrapper.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/ConfJsonWrapper.java
@@ -19,6 +19,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.configs.HighH
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +39,7 @@ class ConfJsonWrapper {
   private final int networkQueueLength;
   private final int perVertexBufferLength;
   private final HighHeapUsageOldGenRcaConfig highHeapUsageOldGenRcaConfig;
+  private final List<String> mutedRcaList;
 
   String getRcaStoreLoc() {
     return rcaStoreLoc;
@@ -79,6 +81,10 @@ class ConfJsonWrapper {
     return perVertexBufferLength;
   }
 
+  List<String> getMutedRcaList() {
+    return mutedRcaList;
+  }
+
   public void setDatastoreRcaLogDirectory(String rcaLogLocation) {
     this.datastore.put(RcaConsts.DATASTORE_LOC_KEY, rcaLogLocation);
   }
@@ -98,7 +104,8 @@ class ConfJsonWrapper {
       @JsonProperty("analysis-graph-implementor") String analysisGraphEntryPoint,
       @JsonProperty("network-queue-length") int networkQueueLength,
       @JsonProperty("max-flow-units-per-vertex-buffer") int perVertexBufferLength,
-      @JsonProperty("high-heap-usage-old-gen-rca") Map<String, String> highHeapUsageOldGenRcaSettings) {
+      @JsonProperty("high-heap-usage-old-gen-rca") Map<String, String> highHeapUsageOldGenRcaSettings,
+      @JsonProperty("muted-rcas") String mutedRcas) {
     this.creationTime = System.currentTimeMillis();
     this.rcaStoreLoc = rcaStoreLoc;
     this.thresholdStoreLoc = thresholdStoreLoc;
@@ -111,5 +118,16 @@ class ConfJsonWrapper {
     this.networkQueueLength = networkQueueLength;
     this.perVertexBufferLength = perVertexBufferLength;
     this.highHeapUsageOldGenRcaConfig = new HighHeapUsageOldGenRcaConfig(highHeapUsageOldGenRcaSettings);
+
+    if (mutedRcas.isEmpty()) {
+      this.mutedRcaList = Collections.emptyList();
+    } else {
+      // Split the string on a delimiter defined as: zero or more whitespace,
+      // a literal comma, zero or more whitespace
+      this.mutedRcaList = Arrays.asList(mutedRcas.split("\\s*,\\s*"));
+      this.mutedRcaList.stream().forEach(
+              mutedRca -> mutedRca.trim()
+      );
+    }
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/ConfJsonWrapper.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/ConfJsonWrapper.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.configs.HighHeapUsageOldGenRcaConfig;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -36,6 +37,7 @@ class ConfJsonWrapper {
   private final String analysisGraphEntryPoint;
   private final int networkQueueLength;
   private final int perVertexBufferLength;
+  private final HighHeapUsageOldGenRcaConfig highHeapUsageOldGenRcaConfig;
 
   String getRcaStoreLoc() {
     return rcaStoreLoc;
@@ -81,6 +83,10 @@ class ConfJsonWrapper {
     this.datastore.put(RcaConsts.DATASTORE_LOC_KEY, rcaLogLocation);
   }
 
+  HighHeapUsageOldGenRcaConfig getHighHeapUsageOldGenRcaConfig() {
+    return highHeapUsageOldGenRcaConfig;
+  }
+
   ConfJsonWrapper(
       @JsonProperty("rca-store-location") String rcaStoreLoc,
       @JsonProperty("threshold-store-location") String thresholdStoreLoc,
@@ -91,7 +97,8 @@ class ConfJsonWrapper {
       @JsonProperty("datastore") Map<String, String> datastore,
       @JsonProperty("analysis-graph-implementor") String analysisGraphEntryPoint,
       @JsonProperty("network-queue-length") int networkQueueLength,
-      @JsonProperty("max-flow-units-per-vertex-buffer") int perVertexBufferLength) {
+      @JsonProperty("max-flow-units-per-vertex-buffer") int perVertexBufferLength,
+      @JsonProperty("high-heap-usage-old-gen-rca") Map<String, String> highHeapUsageOldGenRcaSettings) {
     this.creationTime = System.currentTimeMillis();
     this.rcaStoreLoc = rcaStoreLoc;
     this.thresholdStoreLoc = thresholdStoreLoc;
@@ -103,5 +110,6 @@ class ConfJsonWrapper {
     this.analysisGraphEntryPoint = analysisGraphEntryPoint;
     this.networkQueueLength = networkQueueLength;
     this.perVertexBufferLength = perVertexBufferLength;
+    this.highHeapUsageOldGenRcaConfig = new HighHeapUsageOldGenRcaConfig(highHeapUsageOldGenRcaSettings);
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/ConnectedComponent.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/ConnectedComponent.java
@@ -114,4 +114,11 @@ public class ConnectedComponent {
     }
     return dependencyOrderedNodes;
   }
+
+  public void addNodeNames(Set<String> graphNodeNames) {
+    getAllNodes().forEach(node -> {
+      graphNodeNames.add(node.name());
+    });
+  }
+
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Node.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Node.java
@@ -177,4 +177,14 @@ public abstract class Node<T extends GenericFlowUnit> {
   public void setLocalFlowUnit(T localFlowUnit) {
     this.localFlowUnit = localFlowUnit;
   }
+
+  /**
+   * callback function to parse local rca.conf file and set RCA thresholds accordingly
+   * The default callback function does nothing because we assume most of the RCA vertices
+   * does not read threshold settings from external config
+   * @param conf RcaConf object
+   */
+  public void readRcaConf(RcaConf conf) {
+    return;
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/RcaConf.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/RcaConf.java
@@ -19,6 +19,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyz
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.configs.HighHeapUsageOldGenRcaConfig;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
@@ -29,6 +30,7 @@ import org.apache.logging.log4j.Logger;
 
 public class RcaConf {
   protected String configFileLoc;
+  protected long lastModifiedTime;
   protected ConfJsonWrapper conf;
 
   protected static RcaConf instance;
@@ -39,8 +41,11 @@ public class RcaConf {
     JsonFactory factory = new JsonFactory();
     factory.enable(JsonParser.Feature.ALLOW_COMMENTS);
     ObjectMapper mapper = new ObjectMapper(factory);
+    mapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
     try {
-      this.conf = mapper.readValue(new File(this.configFileLoc), ConfJsonWrapper.class);
+      File configFile = new File(this.configFileLoc);
+      this.lastModifiedTime = configFile.lastModified();
+      this.conf = mapper.readValue(configFile, ConfJsonWrapper.class);
     } catch (IOException e) {
       LOG.error(e.getMessage());
     }
@@ -85,6 +90,11 @@ public class RcaConf {
     return configFileLoc;
   }
 
+  // Returns the last modified time of Rca Conf file
+  public long getLastModifiedTime() {
+    return lastModifiedTime;
+  }
+
   public String getAnalysisGraphEntryPoint() {
     return conf.getAnalysisGraphEntryPoint();
   }
@@ -99,5 +109,9 @@ public class RcaConf {
 
   public HighHeapUsageOldGenRcaConfig getHighHeapUsageOldGenRcaConfig() {
     return conf.getHighHeapUsageOldGenRcaConfig();
+  }
+
+  public List<String> getMutedRcaList() {
+    return conf.getMutedRcaList();
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/RcaConf.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/RcaConf.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.configs.HighHeapUsageOldGenRcaConfig;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -94,5 +95,9 @@ public class RcaConf {
 
   public int getPerVertexBufferLength() {
     return conf.getPerVertexBufferLength();
+  }
+
+  public HighHeapUsageOldGenRcaConfig getHighHeapUsageOldGenRcaConfig() {
+    return conf.getHighHeapUsageOldGenRcaConfig();
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Stats.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Stats.java
@@ -93,12 +93,26 @@ public class Stats {
     return new ArrayList<>(graphs.values());
   }
 
+  public boolean updateMutedGraphNodes(Set<String> nodeNames) {
+    // Add all the rcaNodes if the mutedGraphNodes is empty
+    // else, retain the ones provided in param value
+    if (mutedGraphNodes.isEmpty()) {
+      return mutedGraphNodes.addAll(nodeNames);
+    } else {
+      return mutedGraphNodes.retainAll(nodeNames);
+    }
+  }
+
   public boolean addToMutedGraphNodes(String nodeName) {
     return mutedGraphNodes.add(nodeName);
   }
 
   public boolean isNodeMuted(String nodeName) {
     return mutedGraphNodes.contains(nodeName);
+  }
+
+  public Set<String> getMutedGraphNodes() {
+    return mutedGraphNodes;
   }
 
   public int getMutedGraphNodesCount() {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCASchedulerTask.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCASchedulerTask.java
@@ -194,6 +194,9 @@ public class RCASchedulerTask implements Runnable {
           // This node will be executed locally, so add it to the set to keep track of this.
           locallyExecutableSet.add(node);
 
+          // read rca.conf to set threshold if needed.
+          node.readRcaConf(conf);
+
           // Now we gather all the remote dependencies if there are any and request an intent to
           // consume their data.
           CreatedTasklets newTasklets =

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HighHeapUsageClusterRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HighHeapUsageClusterRca.java
@@ -86,20 +86,19 @@ public class HighHeapUsageClusterRca extends Rca<ResourceFlowUnit> {
         .getDataNodesDetails()) {
       ImmutableList<ResourceFlowUnit> nodeStateList = currentMap.get(nodeDetails.getId());
       if (nodeStateList != null) {
-        int unhealthyOldGenCnt = 0;
-        int unhealthyYoungGenCnt = 0;
+        List<HotResourceSummary> oldGenSummaries = new ArrayList<>();
+        List<HotResourceSummary> youngGenSummaries = new ArrayList<>();
         for (ResourceFlowUnit flowUnit : nodeStateList) {
           if (flowUnit.getResourceContext().getState() == Resources.State.UNHEALTHY) {
             HotNodeSummary currentNodSummary = (HotNodeSummary) flowUnit.getResourceSummary();
-            for (GenericSummary resourceSummary : currentNodSummary.getNestedSummaryList()) {
-              if (resourceSummary instanceof HotResourceSummary) {
-                if (((HotResourceSummary) resourceSummary).getResourceType().getJVM() == JvmEnum.YOUNG_GEN) {
-                  unhealthyYoungGenCnt++;
-                  break;
+            for (GenericSummary genericSummary : currentNodSummary.getNestedSummaryList()) {
+              if (genericSummary instanceof HotResourceSummary) {
+                HotResourceSummary resourceSummary = (HotResourceSummary) genericSummary;
+                if (resourceSummary.getResourceType().getJVM() == JvmEnum.YOUNG_GEN) {
+                  youngGenSummaries.add(resourceSummary);
                 }
-                else if (((HotResourceSummary) resourceSummary).getResourceType().getJVM() == JvmEnum.OLD_GEN) {
-                  unhealthyOldGenCnt++;
-                  break;
+                else if (resourceSummary.getResourceType().getJVM() == JvmEnum.OLD_GEN) {
+                  oldGenSummaries.add(resourceSummary);
                 }
               }
               else {
@@ -108,8 +107,17 @@ public class HighHeapUsageClusterRca extends Rca<ResourceFlowUnit> {
             }
           }
         }
-        if (unhealthyYoungGenCnt >= UNHEALTHY_FLOWUNIT_THRESHOLD || unhealthyOldGenCnt >= UNHEALTHY_FLOWUNIT_THRESHOLD) {
-          unhealthyNodeList.add(nodeStateList.get(0).getResourceSummary());
+        // youngGenSummaries can have multiple elements but we will only consider it as unhealthy if
+        // three consecutive summaries are all unhealthy and we will then pick the first element as the summary for output.
+        if (youngGenSummaries.size() >= UNHEALTHY_FLOWUNIT_THRESHOLD || oldGenSummaries.size() >= UNHEALTHY_FLOWUNIT_THRESHOLD) {
+          HotNodeSummary nodeSummary = new HotNodeSummary(nodeDetails.getId(), nodeDetails.getHostAddress());
+          if (youngGenSummaries.size() >= UNHEALTHY_FLOWUNIT_THRESHOLD) {
+            nodeSummary.addNestedSummaryList(youngGenSummaries.get(0));
+          }
+          if (oldGenSummaries.size() >= UNHEALTHY_FLOWUNIT_THRESHOLD) {
+            nodeSummary.addNestedSummaryList(oldGenSummaries.get(0));
+          }
+          unhealthyNodeList.add(nodeSummary);
         }
       }
     }
@@ -170,15 +178,13 @@ public class HighHeapUsageClusterRca extends Rca<ResourceFlowUnit> {
     }
   }
 
+  /**
+   * This is a cluster level RCA vertex which by definition can not be serialize/de-serialized
+   * over gRPC.
+   */
   @Override
   public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {
-    final List<FlowUnitMessage> flowUnitMessages =
-        args.getWireHopper().readFromWire(args.getNode());
-    List<ResourceFlowUnit> flowUnitList = new ArrayList<>();
-    LOG.debug("rca: Executing fromWire: {}", this.getClass().getSimpleName());
-    for (FlowUnitMessage flowUnitMessage : flowUnitMessages) {
-      flowUnitList.add(ResourceFlowUnit.buildFlowUnitFromWrapper(flowUnitMessage));
-    }
-    setFlowUnits(flowUnitList);
+    throw new IllegalArgumentException(name() + "'s generateFlowUnitListFromWire() should not "
+        + "be required.");
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotheap/HighHeapUsageOldGenRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotheap/HighHeapUsageOldGenRca.java
@@ -20,10 +20,10 @@ import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.Al
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.HeapDimension.MEM_TYPE;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.JvmEnum;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceType;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.configs.HighHeapUsageOldGenRcaConfig;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Rca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Resources;
@@ -34,6 +34,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.persist.SQLParsingUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.TopConsumerSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaVerticesMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import java.time.Clock;
@@ -56,6 +58,14 @@ import org.apache.logging.log4j.Logger;
  * least one full GC during the entire sliding window and then compare the usage with the threshold.
  * To git rid of false positive from sampling, we keep the sliding window big enough to keep at
  * least a couple of such minimum samples to make the min value more accurate.
+ <p>
+ * This RCA read the following node stats from metric and sort them to get the list of top consumers
+ * cache :
+ * Cache_FieldData_Size / Cache_Request_Size / Cache_Query_Size
+ * Lucene memory :
+ * Segments_Memory / Terms_Memory / StoredFields_Memory / TermVectors_Memory / Norms_Memory
+ * Points_Memory / DocValues_Memory / IndexWriter_Memory / Bitset_Memory / VersionMap_Memory
+ </p>
  */
 public class HighHeapUsageOldGenRca extends Rca<ResourceFlowUnit> {
 
@@ -65,6 +75,8 @@ public class HighHeapUsageOldGenRca extends Rca<ResourceFlowUnit> {
   private final Metric heap_Used;
   private final Metric heap_Max;
   private final Metric gc_event;
+  //list of node stat aggregator to collect node stats
+  private final List<NodeStatAggregator> nodeStatAggregators;
   private final ResourceType resourceType;
   // the amount of RCA period this RCA needs to run before sending out a flowunit
   private final int rcaPeriod;
@@ -80,11 +92,12 @@ public class HighHeapUsageOldGenRca extends Rca<ResourceFlowUnit> {
   // minimum
   private static final double OLD_GEN_GC_THRESHOLD = 1;
   private static final double CONVERT_BYTES_TO_MEGABYTES = Math.pow(1024, 3);
+  private int topK;
   protected Clock clock;
 
 
   public <M extends Metric> HighHeapUsageOldGenRca(final int rcaPeriod, final double lowerBoundThreshold,
-      final M heap_Used, final M gc_event, final M heap_Max) {
+      final M heap_Used, final M gc_event, final M heap_Max, final List<Metric> consumers) {
     super(5);
     this.clock = Clock.systemUTC();
     this.heap_Used = heap_Used;
@@ -99,11 +112,18 @@ public class HighHeapUsageOldGenRca extends Rca<ResourceFlowUnit> {
     gcEventSlidingWindow = new SlidingWindow<>(SLIDING_WINDOW_SIZE_IN_MINS, TimeUnit.MINUTES);
     minOldGenSlidingWindow = new MinOldGenSlidingWindow(SLIDING_WINDOW_SIZE_IN_MINS,
         TimeUnit.MINUTES);
+    this.nodeStatAggregators = new ArrayList<>();
+    for (Metric consumerMetric : consumers) {
+      if (consumerMetric != null) {
+        this.nodeStatAggregators.add(new NodeStatAggregator(consumerMetric));
+      }
+    }
+    this.topK = HighHeapUsageOldGenRcaConfig.DEFAULT_TOP_K;
   }
 
   public <M extends Metric> HighHeapUsageOldGenRca(final int rcaPeriod,
-      final M heap_Used, final M gc_event, final M heap_Max) {
-    this(rcaPeriod, 1.0, heap_Used, gc_event, heap_Max);
+      final M heap_Used, final M gc_event, final M heap_Max, final List<Metric> consumers) {
+    this(rcaPeriod, 1.0, heap_Used, gc_event, heap_Max, consumers);
   }
 
   @Override
@@ -153,15 +173,20 @@ public class HighHeapUsageOldGenRca extends Rca<ResourceFlowUnit> {
       }
     }
 
+    long currTimeStamp = this.clock.millis();
     if (!Double.isNaN(oldGenHeapUsed)) {
       LOG.debug(
           "oldGenHeapUsed = {}, oldGenGCEvent = {}, maxOldGenHeapSize = {}",
           oldGenHeapUsed,
           oldGenGCEvent,
           maxOldGenHeapSize);
-      long currTimeStamp = this.clock.millis();
       gcEventSlidingWindow.next(new SlidingWindowData(currTimeStamp, oldGenGCEvent));
       minOldGenSlidingWindow.next(new SlidingWindowData(currTimeStamp, oldGenHeapUsed));
+    }
+
+    //collect node stats from metrics
+    for (NodeStatAggregator nodeStatAggregator : this.nodeStatAggregators) {
+      nodeStatAggregator.collect(currTimeStamp);
     }
 
     if (counter == this.rcaPeriod) {
@@ -191,6 +216,7 @@ public class HighHeapUsageOldGenRca extends Rca<ResourceFlowUnit> {
           && currentMinOldGenUsage / maxOldGenHeapSize > OLD_GEN_USED_THRESHOLD_IN_PERCENTAGE * this.lowerBoundThreshold) {
         summary = new HotResourceSummary(this.resourceType,
             OLD_GEN_USED_THRESHOLD_IN_PERCENTAGE, currentMinOldGenUsage / maxOldGenHeapSize, SLIDING_WINDOW_SIZE_IN_MINS * 60);
+        addTopConsumers(summary);
       }
 
       LOG.debug("High Heap Usage RCA Context = " + context.toString());
@@ -200,6 +226,22 @@ public class HighHeapUsageOldGenRca extends Rca<ResourceFlowUnit> {
       // state)
       LOG.debug("Empty FlowUnit returned for High Heap Usage RCA");
       return new ResourceFlowUnit(this.clock.millis());
+    }
+  }
+
+  //add top k consumers to summary
+  private void addTopConsumers(HotResourceSummary summary) {
+    this.nodeStatAggregators.sort(
+        (NodeStatAggregator n1, NodeStatAggregator n2) -> Integer.compare(n2.getSum(), n1.getSum())
+    );
+    for (NodeStatAggregator aggregator : this.nodeStatAggregators) {
+      if (aggregator.isEmpty()) {
+        continue;
+      }
+      if (summary.getNestedSummaryList().size() >= topK) {
+        break;
+      }
+      summary.addNestedSummaryList(new TopConsumerSummary(aggregator.getName(), aggregator.getSum()));
     }
   }
 
@@ -236,11 +278,22 @@ public class HighHeapUsageOldGenRca extends Rca<ResourceFlowUnit> {
   }
 
   /**
+   * read top k value from rca.conf
+   * @param conf RcaConf object
+   */
+  @Override
+  public void readRcaConf(RcaConf conf) {
+    HighHeapUsageOldGenRcaConfig configObj = conf.getHighHeapUsageOldGenRcaConfig();
+    topK = configObj.getTopK();
+  }
+
+  /**
    * This is a local node RCA which by definition can not be serialize/de-serialized
    * over gRPC.
    */
   @Override
   public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {
-    LOG.error("RCA: {} should not be send over from network", this.getClass().getSimpleName());
+    throw new IllegalArgumentException(name() + "'s generateFlowUnitListFromWire() should not "
+        + "be required.");
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotheap/NodeStatAggregator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotheap/NodeStatAggregator.java
@@ -1,0 +1,129 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotheap;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.MetricFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotshard.IndexShardKey;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jooq.Record;
+import org.jooq.Result;
+
+/**
+ * We've seen huge performance impact if collecting node stats across all shards on data node.
+ * So Performance Analyzer writer will only try to collect node stats from a small portion of
+ * shards at a time to reduce performance impact. This class on reader side will allow us to
+ * keep track of node stat from all previous batches and calculate its sum.
+ */
+public class NodeStatAggregator {
+
+  private static final Logger LOG = LogManager.getLogger(NodeStatAggregator.class);
+  private Metric nodeStatMetric;
+  private int sum;
+  private final HashMap<IndexShardKey, NodeStatValue> shardKeyMap;
+  private long lastPurgeTimestamp;
+  //purge the hash table every 30 mins
+  private static final int PURGE_HASH_TABLE_INTERVAL_IN_MINS = 30;
+
+
+  public NodeStatAggregator(Metric nodeStatMetric) {
+    this.nodeStatMetric = nodeStatMetric;
+    this.sum = 0;
+    this.lastPurgeTimestamp = 0L;
+    this.shardKeyMap = new HashMap<>();
+  }
+
+  /**
+   * Whether this NodeStatAggregator contains valid node stats from writer
+   * This is to avoid reading stale data when the node stats has already been
+   * disabled from writer side
+   * @return if it has valid node stats
+   */
+  public boolean isEmpty() {
+    return shardKeyMap.isEmpty();
+  }
+
+  /**
+   * get the name of node stat metric.
+   * i.e. Norms_Memory, Cache_FieldData_Size, etc.
+   * @return name of node stat metric
+   */
+  public String getName() {
+    return nodeStatMetric.name();
+  }
+
+  /**
+   * get the sum of node stat metric across all shards on this node
+   * @return sum of node stat metric
+   */
+  public int getSum() {
+    return this.sum;
+  }
+
+  /**
+   * call this method to collect node stats of each shard from node stat metric
+   * and calculate its sum.
+   * @param timestamp current timestamp when collecting from metricDB
+   */
+  public void collect(final long timestamp) {
+    for (MetricFlowUnit metric : nodeStatMetric.getFlowUnits()) {
+      if (metric.isEmpty()) {
+        continue;
+      }
+      Result<Record> result = metric.getData();
+      for (Record record : result) {
+        try {
+          IndexShardKey shardKey = IndexShardKey.buildIndexShardKey(record);
+          Integer value = record.getValue(MetricsDB.MAX, Integer.class);
+          NodeStatValue oldNodeStatValue = shardKeyMap.getOrDefault(shardKey, new NodeStatValue(0, 0));
+          shardKeyMap.put(shardKey, new NodeStatValue(value, timestamp));
+          this.sum += (value - oldNodeStatValue.getValue());
+        }
+        catch (Exception e) {
+          LOG.error("Fail to parse node stats {}", this.getName());
+        }
+      }
+    }
+    //purge the hashtable
+    if (TimeUnit.MILLISECONDS.toMinutes(timestamp - this.lastPurgeTimestamp) > PURGE_HASH_TABLE_INTERVAL_IN_MINS) {
+      purgeHashTable(timestamp);
+    }
+  }
+
+  // shards can be deleted from ES while still remains in this hashtable
+  // or we might disable the Node Stats collector on writer to stop sending node stats to reader
+  // in either case, we need to write a function to clean up this hashtable on reader periodically
+  // to remove node stats of inactive shards
+  private void purgeHashTable(final long timestamp) {
+    Iterator<IndexShardKey> iterator = this.shardKeyMap.keySet().iterator();
+    while (iterator.hasNext()) {
+      IndexShardKey key = iterator.next();
+      long timestampDiff = timestamp - this.shardKeyMap.get(key).getTimestamp();
+      if (TimeUnit.MILLISECONDS.toMinutes(timestampDiff) > PURGE_HASH_TABLE_INTERVAL_IN_MINS) {
+        this.sum -= this.shardKeyMap.get(key).getValue();
+        iterator.remove();
+      }
+    }
+  }
+
+  private static class NodeStatValue {
+    private int value;
+    private long timestamp;
+
+    public NodeStatValue(int value, long timestamp) {
+      this.value = value;
+      this.timestamp = timestamp;
+    }
+
+    public int getValue() {
+      return this.value;
+    }
+
+    public long getTimestamp() {
+      return this.timestamp;
+    }
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotshard/IndexShardKey.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotshard/IndexShardKey.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotshard;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CommonDimension;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jooq.Record;
+import org.jooq.exception.DataTypeException;
+
+public class IndexShardKey {
+
+  private static final Logger LOG = LogManager.getLogger(IndexShardKey.class);
+  private final String indexName;
+  private final int shardId;
+
+  public IndexShardKey(String indexName, int shardId) {
+    this.indexName = indexName;
+    this.shardId = shardId;
+  }
+
+  public String getIndexName() {
+    return this.indexName;
+  }
+
+  public int getShardId() {
+    return this.shardId;
+  }
+
+  public static IndexShardKey buildIndexShardKey(Record record) throws IllegalArgumentException {
+    if (record == null) {
+      throw new IllegalArgumentException("record is null");
+    }
+    try {
+      String indexName = record.getValue(CommonDimension.INDEX_NAME.toString(), String.class);
+      Integer shardId = record.getValue(CommonDimension.SHARD_ID.toString(), Integer.class);
+      return new IndexShardKey(indexName, shardId);
+    }
+    catch (DataTypeException de) {
+      LOG.error("Fail to read field from SQL record, message {}", de.getMessage());
+      throw new IllegalArgumentException("failed to read field from record");
+    }
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj != null && obj instanceof IndexShardKey) {
+      IndexShardKey key = (IndexShardKey)obj;
+      return indexName.equals(key.indexName) && shardId == key.shardId;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return indexName.hashCode() * 31 + shardId;
+  }
+
+  @Override
+  public String toString() {
+    return "[" + this.indexName + "][" + this.shardId + "]";
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
@@ -1,11 +1,16 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca;
 
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaTestHelper.updateConfFileForMutedRcas;
+
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.ClientServers;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerThreads;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.GRPCConnectionManager;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Stats;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.RCAScheduler;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.RcaSchedulerState;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
@@ -15,6 +20,8 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -46,7 +53,7 @@ public class RcaControllerTest {
   private ThreadProvider threadProvider;
 
   @Before
-  public void setUp() throws IOException {
+  public void setUp() throws Exception {
     threadProvider = new ThreadProvider();
     String cwd = System.getProperty("user.dir");
     rcaEnabledFileLoc = Paths.get(cwd, "src", "test", "resources", "rca");
@@ -101,6 +108,14 @@ public class RcaControllerTest {
         );
 
     setMyIp(masterIP, AllMetrics.NodeRole.UNKNOWN);
+
+    // since we are using 2 rca.conf files here for testing, 'rca_muted.conf' for testing Muted RCAs
+    // and 'rca.conf' for remainging tests, use reflection to access the private rcaConf class variable.
+    String rcaConfPath = Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca.conf").toString();
+    Field field = rcaController.getClass().getDeclaredField("rcaConf");
+    field.setAccessible(true);
+    field.set(rcaController, new RcaConf(rcaConfPath));
+
     controllerThread =
         threadProvider.createThreadForRunnable(() -> rcaController.run(),
             PerformanceAnalyzerThreads.RCA_CONTROLLER);
@@ -145,6 +160,68 @@ public class RcaControllerTest {
     changeRcaRunState(RcaState.RUN);
     Assert.assertTrue(check(new RcaEnabledEval(rcaController), true));
     Assert.assertTrue(RcaController.isRcaEnabled());
+  }
+
+  @Test
+  public void readAndUpdateMutesRcas() throws Exception {
+    String rcaConfPath = Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca_muted.conf").toString();
+    Method readAndUpdateMutesRcas = rcaController.getClass()
+            .getDeclaredMethod("readAndUpdateMutesRcas", null);
+    readAndUpdateMutesRcas.setAccessible(true);
+
+    Field field = rcaController.getClass().getDeclaredField("rcaConf");
+    field.setAccessible(true);
+
+    // 1. Muted Graph : "CPU_Utilization, Heap_AllocRate", updating RCA Config with "CPU_Utilization, Heap_AllocRate"
+    // Muted Graph should have "CPU_Utilization, Heap_AllocRate"
+    updateConfFileForMutedRcas(rcaConfPath, "CPU_Utilization, Heap_AllocRate");
+    field.set(rcaController, new RcaConf(rcaConfPath));
+    readAndUpdateMutesRcas.invoke(rcaController);
+    Assert.assertEquals(2,Stats.getInstance().getMutedGraphNodes().size());
+    Assert.assertTrue(Stats.getInstance().isNodeMuted("CPU_Utilization"));
+    Assert.assertTrue(Stats.getInstance().isNodeMuted("Heap_AllocRate"));
+
+    // 2. Muted Graph : "CPU_Utilization, Heap_AllocRate", updating RCA Config with ""
+    // Muted Graph should have no nodes
+    updateConfFileForMutedRcas(rcaConfPath, "");
+    field.set(rcaController, new RcaConf(rcaConfPath));
+    readAndUpdateMutesRcas.invoke(rcaController);
+    Assert.assertTrue(Stats.getInstance().getMutedGraphNodes().isEmpty());
+
+    // 3. Muted Graph : "", updating RCA Config with ""
+    // Muted Graph should have no nodes
+    updateConfFileForMutedRcas(rcaConfPath, "");
+    field.set(rcaController, new RcaConf(rcaConfPath));
+    readAndUpdateMutesRcas.invoke(rcaController);
+    Assert.assertTrue(Stats.getInstance().getMutedGraphNodes().isEmpty());
+
+    // 4. On RCA Config, "muted-rcas" : "CPU_Utilization, Heap_AllocRate", Updating RCA Config with "Paging_MajfltRate"
+    // Muted Graph should retain only "Paging_MajfltRate"
+    updateConfFileForMutedRcas(rcaConfPath, "Paging_MajfltRate");
+    field.set(rcaController, new RcaConf(rcaConfPath));
+    readAndUpdateMutesRcas.invoke(rcaController);
+    Assert.assertEquals(1, Stats.getInstance().getMutedGraphNodes().size());
+    Assert.assertTrue(Stats.getInstance().isNodeMuted("Paging_MajfltRate"));
+
+    // 5. On RCA Config, "muted-rcas" : "Paging_MajfltRate", Updating RCA Config with "Paging_MajfltRate_Check"
+    // Muted Graph should have no nodes
+    updateConfFileForMutedRcas(rcaConfPath, "Paging_MajfltRate_Check");
+    field.set(rcaController, new RcaConf(rcaConfPath));
+    readAndUpdateMutesRcas.invoke(rcaController);
+    Assert.assertEquals(0, Stats.getInstance().getMutedGraphNodes().size());
+
+    updateConfFileForMutedRcas(rcaConfPath, "CPU_Utilization, Heap_AllocRate");
+    // 6. On RCA Config, "muted-rcas" : "CPU_Utilization, Heap_AllocRate"
+    // Updating RCA Config with "Paging_MajfltRate_Check, Paging_MajfltRate"
+    // Muted Graph should have "Paging_MajfltRate"
+    updateConfFileForMutedRcas(rcaConfPath, "Paging_MajfltRate_Check, Paging_MajfltRate");
+    field.set(rcaController, new RcaConf(rcaConfPath));
+    readAndUpdateMutesRcas.invoke(rcaController);
+    Assert.assertEquals(1, Stats.getInstance().getMutedGraphNodes().size());
+    Assert.assertTrue(Stats.getInstance().isNodeMuted("Paging_MajfltRate"));
+
+    // Re-set the 'rcaConf' variable to track 'rca.conf' for remaining tests
+    field.set(rcaController, new RcaConf(Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca.conf").toString()));
   }
 
   @Test

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaTestHelper.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaTestHelper.java
@@ -20,16 +20,26 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Scanner;
+
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.FileAppender;
 import org.jooq.tools.json.JSONObject;
@@ -129,4 +139,20 @@ public class RcaTestHelper {
       e.printStackTrace();
     }
   }
+
+  public static void updateConfFileForMutedRcas(String rcaConfPath, String mutedRcas) throws Exception {
+
+    // create the config json Object from rca config file
+    Scanner scanner = new Scanner(new FileInputStream(rcaConfPath), StandardCharsets.UTF_8.name());
+    String jsonText = scanner.useDelimiter("\\A").next();
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.enable(JsonParser.Feature.ALLOW_COMMENTS);
+    mapper.enable(SerializationFeature.INDENT_OUTPUT);
+    JsonNode configObject = mapper.readTree(jsonText);
+
+    // update the `MUTED_RCAS_CONFIG` value in config Object
+    ((ObjectNode) configObject).put("muted-rcas", mutedRcas);
+    mapper.writeValue(new FileOutputStream(rcaConfPath), configObject);
+  }
+
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/configs/HighHeapUsageOldGenRcaConfigTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/configs/HighHeapUsageOldGenRcaConfigTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.configs;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HighHeapUsageOldGenRcaConfigTest {
+
+  private static final String TOP_K_RCA_CONF = "top-k";
+
+  @Test
+  public void testHighHeapUsageOldGenRcaConfig() {
+    HighHeapUsageOldGenRcaConfig config = new HighHeapUsageOldGenRcaConfig(null);
+    Assert.assertEquals(HighHeapUsageOldGenRcaConfig.DEFAULT_TOP_K, config.getTopK());
+
+    Map<String, String> settings = new HashMap<>();
+    settings.put(TOP_K_RCA_CONF, "5");
+    config = new HighHeapUsageOldGenRcaConfig(settings);
+    Assert.assertEquals(5, config.getTopK());
+
+    settings.put(TOP_K_RCA_CONF, "5.8");
+    config = new HighHeapUsageOldGenRcaConfig(settings);
+    Assert.assertEquals(HighHeapUsageOldGenRcaConfig.DEFAULT_TOP_K, config.getTopK());
+
+    settings.clear();
+    settings.put("test", "2");
+    config = new HighHeapUsageOldGenRcaConfig(settings);
+    Assert.assertEquals(HighHeapUsageOldGenRcaConfig.DEFAULT_TOP_K, config.getTopK());
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/MetricTestHelper.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/MetricTestHelper.java
@@ -37,6 +37,11 @@ public class MetricTestHelper extends Metric {
     context = DSL.using(new MockConnection(Mock.of(0)));
   }
 
+  public MetricTestHelper(long evaluationIntervalSeconds, String name) {
+    super(name, evaluationIntervalSeconds);
+    context = DSL.using(new MockConnection(Mock.of(0)));
+  }
+
   public void createTestFlowUnits(final List<String> fieldName, final List<String> row) {
     List<String[]> stringData = new ArrayList<>();
     stringData.add(fieldName.toArray(new String[0]));

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/spec/RcaSpecTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/spec/RcaSpecTests.java
@@ -113,7 +113,7 @@ public class RcaSpecTests {
   // @Test(expected = RuntimeException.class)
   public void testAddToFlowFieldBeforeAddingAsDependency() {
     Metric heapUsed = new Heap_Used(5);
-    HighHeapUsageOldGenRca highHeapUsageOldGenRca = new HighHeapUsageOldGenRca(1, heapUsed, null, null);
+    HighHeapUsageOldGenRca highHeapUsageOldGenRca = new HighHeapUsageOldGenRca(1, heapUsed, null, null, null);
     highHeapUsageOldGenRca.addAllUpstreams(Collections.singletonList(heapUsed));
   }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotheap/HighHeapUsageOldGenRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotheap/HighHeapUsageOldGenRcaTest.java
@@ -13,32 +13,42 @@
  *  permissions and limitations under the License.
  */
 
-package com.amazon.opendistro.elasticsearch.performanceanalyzer.store.rca;
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.store.rca.hotheap;
 
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCType.OLD_GEN;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCType.TOT_FULL_GC;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.HeapDimension.MEM_TYPE;
 import static java.time.Instant.ofEpochMilli;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CommonDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.MetricTestHelper;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.TopConsumerSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HighHeapUsageClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotheap.HighHeapUsageOldGenRca;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(GradleTaskForRca.class)
 public class HighHeapUsageOldGenRcaTest {
   private static final double CONVERT_MEGABYTES_TO_BYTES = Math.pow(1024, 2);
   private MetricTestHelper heap_Used;
   private MetricTestHelper gc_event;
   private MetricTestHelper heap_Max;
+  private List<Metric> node_stats;
   private HighHeapUsageOldGenRcaX oldGenRcaX;
   private List<String> columnName;
 
@@ -55,7 +65,26 @@ public class HighHeapUsageOldGenRcaTest {
     heap_Used = new MetricTestHelper(5);
     gc_event = new MetricTestHelper(5);
     heap_Max = new MetricTestHelper(5);
-    oldGenRcaX = new HighHeapUsageOldGenRcaX(1, heap_Used, gc_event, heap_Max);
+
+    List<String> nodeStatColumnName = Arrays.asList(CommonDimension.INDEX_NAME.toString(),
+        CommonDimension.SHARD_ID.toString(), MetricsDB.MAX);
+    MetricTestHelper nodeStat1 = new MetricTestHelper(5, "node_stat_1");
+    MetricTestHelper nodeStat2 = new MetricTestHelper(5, "node_stat_2");
+    MetricTestHelper nodeStat3 = new MetricTestHelper(5, "node_stat_3");
+    MetricTestHelper nodeStat4 = new MetricTestHelper(5, "node_stat_4");
+    nodeStat1.createTestFlowUnits(nodeStatColumnName, Arrays.asList("index1", "1", "5"));
+    nodeStat2.createTestFlowUnits(nodeStatColumnName, Arrays.asList("index1", "2", "2"));
+    nodeStat3.createTestFlowUnits(nodeStatColumnName, Arrays.asList("index1", "1", "8"));
+    nodeStat4.createTestFlowUnits(nodeStatColumnName, Arrays.asList("index1", "1", "1"));
+
+    node_stats = new ArrayList<Metric>() {{
+      add(nodeStat1);
+      add(nodeStat2);
+      add(nodeStat3);
+      add(nodeStat4);
+    }};
+
+    oldGenRcaX = new HighHeapUsageOldGenRcaX(1, heap_Used, gc_event, heap_Max, node_stats);
     columnName = Arrays.asList(MEM_TYPE.toString(), MetricsDB.MAX);
     // set max heap size to 100MB
     heap_Max.createTestFlowUnits(columnName, Arrays.asList(OLD_GEN.toString(), String.valueOf(100 * CONVERT_MEGABYTES_TO_BYTES)));
@@ -65,6 +94,8 @@ public class HighHeapUsageOldGenRcaTest {
   public void testHighHeapOldGenRca() {
     ResourceFlowUnit flowUnit;
     Clock constantClock = Clock.fixed(ofEpochMilli(0), ZoneId.systemDefault());
+
+
 
     //ts = 0, heap = 50Mb, full gc = 0
     mockFlowUnits(50, 0);
@@ -101,12 +132,30 @@ public class HighHeapUsageOldGenRcaTest {
     oldGenRcaX.setClock(Clock.offset(constantClock, Duration.ofMinutes(20)));
     flowUnit = oldGenRcaX.operate();
     Assert.assertTrue(flowUnit.getResourceContext().isUnhealthy());
+
+    Assert.assertTrue(flowUnit.hasResourceSummary());
+    Assert.assertTrue(flowUnit.getResourceSummary() instanceof HotResourceSummary);
+    HotResourceSummary resourceSummary = (HotResourceSummary) flowUnit.getResourceSummary();
+    Assert.assertEquals(3, resourceSummary.getNestedSummaryList().size());
+    for (int i = 0; i < 3; i++) {
+      Assert.assertTrue(resourceSummary.getNestedSummaryList().get(i) instanceof TopConsumerSummary);
+      TopConsumerSummary consumerSummary = (TopConsumerSummary) resourceSummary.getNestedSummaryList().get(i);
+      if (i == 0) {
+        Assert.assertEquals("node_stat_3", consumerSummary.getName());
+      }
+      if (i == 1) {
+        Assert.assertEquals("node_stat_1", consumerSummary.getName());
+      }
+      if (i == 2) {
+        Assert.assertEquals("node_stat_2", consumerSummary.getName());
+      }
+    }
   }
 
   private static class HighHeapUsageOldGenRcaX extends HighHeapUsageOldGenRca {
     public <M extends Metric> HighHeapUsageOldGenRcaX(final int rcaPeriod,
-        final M heap_Used, final M gc_event, final M heap_Max) {
-      super(rcaPeriod, heap_Used, gc_event, heap_Max);
+        final M heap_Used, final M gc_event, final M heap_Max, final List<Metric> node_stats) {
+      super(rcaPeriod, heap_Used, gc_event, heap_Max, node_stats);
     }
 
     public void setClock(Clock testClock) {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotheap/HighHeapUsageYoungGenRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotheap/HighHeapUsageYoungGenRcaTest.java
@@ -13,7 +13,7 @@
  *  permissions and limitations under the License.
  */
 
-package com.amazon.opendistro.elasticsearch.performanceanalyzer.store.rca;
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.store.rca.hotheap;
 
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCType.OLD_GEN;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCType.TOT_YOUNG_GC;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotheap/NodeStatAggregatorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotheap/NodeStatAggregatorTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.store.rca.hotheap;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CommonDimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.MetricTestHelper;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotheap.NodeStatAggregator;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(GradleTaskForRca.class)
+public class NodeStatAggregatorTest {
+
+  private MetricTestHelper nodeStat;
+  private NodeStatAggregator nodeStatAggregator;
+
+  @Before
+  public void setup() {
+    this.nodeStat = new MetricTestHelper(5);
+    this.nodeStatAggregator = new NodeStatAggregator(nodeStat);
+  }
+
+  @Test
+  public void testCollect() {
+    List<String> columnName = Arrays.asList(CommonDimension.INDEX_NAME.toString(), CommonDimension.SHARD_ID.toString(), MetricsDB.MAX);
+
+    nodeStat.createTestFlowUnits(columnName, Arrays.asList("index1", "1", "5"));
+    nodeStatAggregator.collect(0);
+    Assert.assertEquals(5, nodeStatAggregator.getSum());
+
+    nodeStat.createTestFlowUnits(columnName, Arrays.asList("index1", "2", "3"));
+    nodeStatAggregator.collect(TimeUnit.MINUTES.toMillis(3));
+    Assert.assertEquals(8, nodeStatAggregator.getSum());
+
+    nodeStat.createTestFlowUnits(columnName, Arrays.asList("index2", "1", "10"));
+    nodeStatAggregator.collect(TimeUnit.MINUTES.toMillis(8));
+    Assert.assertEquals(18, nodeStatAggregator.getSum());
+
+    nodeStat.createTestFlowUnits(columnName, Arrays.asList("index1", "2", "1"));
+    nodeStatAggregator.collect(TimeUnit.MINUTES.toMillis(12));
+    Assert.assertEquals(16, nodeStatAggregator.getSum());
+
+    //purge the hash after 30min
+    nodeStat.createTestFlowUnits(columnName, Arrays.asList("index2", "2", "10"));
+    nodeStatAggregator.collect(TimeUnit.MINUTES.toMillis(32));
+    Assert.assertEquals(21, nodeStatAggregator.getSum());
+  }
+}

--- a/src/test/resources/rca/rca.conf
+++ b/src/test/resources/rca/rca.conf
@@ -41,5 +41,7 @@
     // How often the sqlite file be repeated in seconds. This file contains RCAs and therefore rotating it too frequently
     // might not be as fruitful as there might not be any data.
     "rotation-period-seconds": 21600
-  }
+  },
+
+    "muted-rcas": ""
 }

--- a/src/test/resources/rca/rca_elected_master.conf
+++ b/src/test/resources/rca/rca_elected_master.conf
@@ -41,5 +41,7 @@
     // How often the sqlite file be repeated in seconds. This file contains RCAs and therefore rotating it too frequently
     // might not be as fruitful as there might not be any data.
     "rotation-period-seconds": 21600
-  }
+  },
+
+  "muted-rcas": ""
 }

--- a/src/test/resources/rca/rca_muted.conf
+++ b/src/test/resources/rca/rca_muted.conf
@@ -1,6 +1,7 @@
+// Conf for testing muted RCAs
 {
   "analysis-graph-implementor":
-    "com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.AnalysisGraphTest",
+  "com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.AnalysisGraphTest",
   // it can be file:// or s3://
   "rca-store-location": "s3://sifi-store/rcas/",
 
@@ -37,11 +38,11 @@
     "type": "sqlite",
     "location-dir": "/tmp",
     "filename": "rca.sqlite",
-
+    "storage-file-retention-count": 5,
     // How often the sqlite file be repeated in seconds. This file contains RCAs and therefore rotating it too frequently
     // might not be as fruitful as there might not be any data.
     "rotation-period-seconds": 21600
   },
 
-  "muted-rcas": ""
+  "muted-rcas": "CPU_Utilization, Heap_AllocRate"
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The RcaController thread will check the muted_rcas.conf file and update the Analysis Graph for muted RCAs. Plugged into existing code to disable reading metrics if node is Muted.
- Added UTs
- Incoporated PR Feedback

The API behavior : The API will be invoked with full list of RCAs that are expected to be muted. The input will be provided as a comma separated string, similar to `"CPU_Utilization, Heap_AllocRate"`. The API implementation takes care of validating the RCA names provided in the input and any leading/trailing spaces.
1. If API is invoked with at least 1 valid RCA, the muted RCA Graph is updated to retain only this valid RCA(s).
1. If API is invoked with an empty string, the muted RCA Graph is updated and all previous existing RCAs in the graph are removed.
2. If API is invoked with an all invalid RCAs, no action is taken. 


*Tests:* UT, Dev Stack Testing

*Code coverage percentage for this patch:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
