### PR TITLE
Muting API

### DIFF
--- a/pa_config/rca.conf
+++ b/pa_config/rca.conf
@@ -41,5 +41,7 @@
   // RCA settings
   "high-heap-usage-old-gen-rca": {
     "top-k" : 3
-  }
+  },
+
+  "muted-rcas": ""
 }

--- a/pa_config/rca_idle_master.conf
+++ b/pa_config/rca_idle_master.conf
@@ -41,5 +41,7 @@
   // RCA settings
   "high-heap-usage-old-gen-rca": {
     "top-k" : 3
-  }
+  },
+
+  "muted-rcas": ""
 }

--- a/pa_config/rca_master.conf
+++ b/pa_config/rca_master.conf
@@ -41,5 +41,7 @@
   // RCA settings
   "high-heap-usage-old-gen-rca": {
     "top-k" : 3
-  }
+  },
+
+  "muted-rcas": ""
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -286,7 +286,7 @@ public class RcaController {
 
         Set<String> graphNodeNames = new HashSet<>();
         RcaUtil.getAnalysisGraphComponents(rcaConf).forEach(
-                connectedComponent -> connectedComponent.addNodeNames(graphNodeNames));
+                connectedComponent -> graphNodeNames.addAll(connectedComponent.getNodeNames()));
 
         // Update rcasForMute to retain only valid RCAs
         rcasForMute.retainAll(graphNodeNames);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -284,18 +284,14 @@ public class RcaController {
         Set<String> rcasForMute = new HashSet<>(rcaConf.getMutedRcaList());
         LOG.info("RCAs provided for muting : {}", rcasForMute);
 
-        Set<String> graphNodeNames = new HashSet<>();
-        RcaUtil.getAnalysisGraphComponents(rcaConf).forEach(
-                connectedComponent -> graphNodeNames.addAll(connectedComponent.getNodeNames()));
-
         // Update rcasForMute to retain only valid RCAs
-        rcasForMute.retainAll(graphNodeNames);
+        rcasForMute.retainAll(ConnectedComponent.getNodeNames());
 
         // If rcasForMute post validation is empty but rcaConf.getMutedRcaList() is not empty
         // all the input RCAs are incorrect, return.
         if (rcasForMute.isEmpty() && !rcaConf.getMutedRcaList().isEmpty()) {
-          LOG.error("Incorrect RCA(s): {}, cannot be muted. Valid RCAs: {}",
-                  rcaConf.getMutedRcaList(), graphNodeNames);
+          LOG.error("Incorrect RCA(s): {}, cannot be muted. Valid RCAs: {}, Muted RCAs: {}",
+                  rcaConf.getMutedRcaList(), ConnectedComponent.getNodeNames(), Stats.getInstance().getMutedGraphNodes());
           return;
         }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -56,12 +56,15 @@ import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.SQLException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Scanner;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -85,6 +88,9 @@ public class RcaController {
   // This needs to be volatile as the RcaConfPoller writes it but the Nanny reads it.
   private static volatile boolean rcaEnabled = false;
 
+  // This needs to be volatile as the RcaConfPoller writes it but the Nanny reads it.
+  private static volatile long lastModifiedTimeInMillisInMemory = 0;
+
   // This needs to be volatile as the NodeRolePoller writes it but the Nanny reads it.
   private volatile NodeRole currentRole = NodeRole.UNKNOWN;
 
@@ -99,6 +105,8 @@ public class RcaController {
   private QueryRcaRequestHandler queryRcaRequestHandler;
 
   private SubscriptionManager subscriptionManager;
+
+  private RcaConf rcaConf;
 
   private final String RCA_ENABLED_CONF_LOCATION;
   private final long rcaStateCheckIntervalMillis;
@@ -135,7 +143,7 @@ public class RcaController {
   }
 
   private void start() {
-    final RcaConf rcaConf = RcaControllerHelper.pickRcaConfForRole(currentRole);
+    rcaConf = RcaControllerHelper.pickRcaConfForRole(currentRole);
     try {
       subscriptionManager.setCurrentLocus(rcaConf.getTagMap().get("locus"));
       List<ConnectedComponent> connectedComponents = RcaUtil.getAnalysisGraphComponents(rcaConf);
@@ -215,8 +223,8 @@ public class RcaController {
             checkUpdateNodeRole(nodeDetails);
           }
         }
-
         updateRcaState();
+
         long duration = System.currentTimeMillis() - startTime;
         if (duration < rcaStateCheckIntervalMillis) {
           Thread.sleep(rcaStateCheckIntervalMillis - duration);
@@ -253,6 +261,51 @@ public class RcaController {
             rcaEnabled = rcaEnabledDefaultValue;
           }
         });
+
+    // If RCA is enabled, update Analysis graph with Muted RCAs value
+    if (rcaEnabled) {
+      LOG.debug("Updating Analysis Graph with Muted RCAs");
+      readAndUpdateMutesRcas();
+    }
+  }
+
+  /**
+   * Reads the mutedRCAList value from the rca.conf file, performs validation on the param value
+   * provided and on successful validation, updates the AnalysisGraph with muted RCA value.
+   *
+   * <p>In case all the RCAs in param value are incorrect, return without any update.
+   */
+  private void readAndUpdateMutesRcas() {
+    // If the rca config file has been updated since the lastModifiedTimeInMillisInMemory in memory,
+    // refresh the `muted-rcas` value from rca config file.
+    long lastModifiedTimeInMillisOnDisk = rcaConf.getLastModifiedTime();
+    if (lastModifiedTimeInMillisOnDisk > lastModifiedTimeInMillisInMemory) {
+      try {
+        Set<String> rcasForMute = new HashSet<>(rcaConf.getMutedRcaList());
+        LOG.info("RCAs provided for muting : {}", rcasForMute);
+
+        Set<String> graphNodeNames = new HashSet<>();
+        RcaUtil.getAnalysisGraphComponents(rcaConf).forEach(
+                connectedComponent -> connectedComponent.addNodeNames(graphNodeNames));
+
+        // Update rcasForMute to retain only valid RCAs
+        rcasForMute.retainAll(graphNodeNames);
+
+        // If rcasForMute post validation is empty but rcaConf.getMutedRcaList() is not empty
+        // all the input RCAs are incorrect, return.
+        if (rcasForMute.isEmpty() && !rcaConf.getMutedRcaList().isEmpty()) {
+          LOG.error("Incorrect RCA(s): {}, cannot be muted. Valid RCAs: {}",
+                  rcaConf.getMutedRcaList(), graphNodeNames);
+          return;
+        }
+
+        LOG.info("Updating the muted RCA Graph to : {}", rcasForMute);
+        Stats.getInstance().updateMutedGraphNodes(rcasForMute);
+      } catch (Exception e) {
+        LOG.error("Couldn't read/update the muted RCAs.", e);
+      }
+    }
+    lastModifiedTimeInMillisInMemory = lastModifiedTimeInMillisOnDisk;
   }
 
   /**
@@ -286,7 +339,6 @@ public class RcaController {
       }
     }
   }
-
 
   private void removeRcaRequestHandler() {
     try {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/ConfJsonWrapper.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/ConfJsonWrapper.java
@@ -19,6 +19,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.configs.HighH
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +39,7 @@ class ConfJsonWrapper {
   private final int networkQueueLength;
   private final int perVertexBufferLength;
   private final HighHeapUsageOldGenRcaConfig highHeapUsageOldGenRcaConfig;
+  private final List<String> mutedRcaList;
 
   String getRcaStoreLoc() {
     return rcaStoreLoc;
@@ -79,6 +81,10 @@ class ConfJsonWrapper {
     return perVertexBufferLength;
   }
 
+  List<String> getMutedRcaList() {
+    return mutedRcaList;
+  }
+
   public void setDatastoreRcaLogDirectory(String rcaLogLocation) {
     this.datastore.put(RcaConsts.DATASTORE_LOC_KEY, rcaLogLocation);
   }
@@ -98,7 +104,8 @@ class ConfJsonWrapper {
       @JsonProperty("analysis-graph-implementor") String analysisGraphEntryPoint,
       @JsonProperty("network-queue-length") int networkQueueLength,
       @JsonProperty("max-flow-units-per-vertex-buffer") int perVertexBufferLength,
-      @JsonProperty("high-heap-usage-old-gen-rca") Map<String, String> highHeapUsageOldGenRcaSettings) {
+      @JsonProperty("high-heap-usage-old-gen-rca") Map<String, String> highHeapUsageOldGenRcaSettings,
+      @JsonProperty("muted-rcas") String mutedRcas) {
     this.creationTime = System.currentTimeMillis();
     this.rcaStoreLoc = rcaStoreLoc;
     this.thresholdStoreLoc = thresholdStoreLoc;
@@ -111,5 +118,16 @@ class ConfJsonWrapper {
     this.networkQueueLength = networkQueueLength;
     this.perVertexBufferLength = perVertexBufferLength;
     this.highHeapUsageOldGenRcaConfig = new HighHeapUsageOldGenRcaConfig(highHeapUsageOldGenRcaSettings);
+
+    if (mutedRcas.isEmpty()) {
+      this.mutedRcaList = Collections.emptyList();
+    } else {
+      // Split the string on a delimiter defined as: zero or more whitespace,
+      // a literal comma, zero or more whitespace
+      this.mutedRcaList = Arrays.asList(mutedRcas.split("\\s*,\\s*"));
+      this.mutedRcaList.stream().forEach(
+              mutedRca -> mutedRca.trim()
+      );
+    }
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/ConnectedComponent.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/ConnectedComponent.java
@@ -29,12 +29,11 @@ public class ConnectedComponent {
 
   /* The elements in the inner list can be executed in parallel. Two inner lists have to be executed in order. */
   private List<List<Node<?>>> dependencyOrderedNodes;
-  private Set<String> nodeNames;
+  private static Set<String> nodeNames = new HashSet<>();
   private int graphId;
 
   public Set<Node<?>> getAllNodes() {
     Set<Node<?>> traversed = new HashSet<>();
-    nodeNames = new HashSet<>();
     Deque<Node<?>> inline = new ArrayDeque<>(leafNodes);
     while (!inline.isEmpty()) {
       Node<?> currNode = inline.poll();
@@ -118,8 +117,7 @@ public class ConnectedComponent {
     return dependencyOrderedNodes;
   }
 
-  public Set<String> getNodeNames() {
-    getAllNodes();
+  public static Set<String> getNodeNames() {
     return nodeNames;
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/ConnectedComponent.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/ConnectedComponent.java
@@ -29,10 +29,12 @@ public class ConnectedComponent {
 
   /* The elements in the inner list can be executed in parallel. Two inner lists have to be executed in order. */
   private List<List<Node<?>>> dependencyOrderedNodes;
+  private Set<String> nodeNames;
   private int graphId;
 
   public Set<Node<?>> getAllNodes() {
     Set<Node<?>> traversed = new HashSet<>();
+    nodeNames = new HashSet<>();
     Deque<Node<?>> inline = new ArrayDeque<>(leafNodes);
     while (!inline.isEmpty()) {
       Node<?> currNode = inline.poll();
@@ -40,6 +42,7 @@ public class ConnectedComponent {
         continue;
       }
       traversed.add(currNode);
+      nodeNames.add(currNode.name());
       List<Node<?>> currNodesDownstream = currNode.getDownStreams();
       if (currNodesDownstream.size() > 0) {
         inline.addAll(currNodesDownstream);
@@ -115,10 +118,9 @@ public class ConnectedComponent {
     return dependencyOrderedNodes;
   }
 
-  public void addNodeNames(Set<String> graphNodeNames) {
-    getAllNodes().forEach(node -> {
-      graphNodeNames.add(node.name());
-    });
+  public Set<String> getNodeNames() {
+    getAllNodes();
+    return nodeNames;
   }
 
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/ConnectedComponent.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/ConnectedComponent.java
@@ -114,4 +114,11 @@ public class ConnectedComponent {
     }
     return dependencyOrderedNodes;
   }
+
+  public void addNodeNames(Set<String> graphNodeNames) {
+    getAllNodes().forEach(node -> {
+      graphNodeNames.add(node.name());
+    });
+  }
+
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/RcaConf.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/RcaConf.java
@@ -19,6 +19,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyz
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.configs.HighHeapUsageOldGenRcaConfig;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
@@ -29,6 +30,7 @@ import org.apache.logging.log4j.Logger;
 
 public class RcaConf {
   protected String configFileLoc;
+  protected long lastModifiedTime;
   protected ConfJsonWrapper conf;
 
   protected static RcaConf instance;
@@ -39,8 +41,11 @@ public class RcaConf {
     JsonFactory factory = new JsonFactory();
     factory.enable(JsonParser.Feature.ALLOW_COMMENTS);
     ObjectMapper mapper = new ObjectMapper(factory);
+    mapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
     try {
-      this.conf = mapper.readValue(new File(this.configFileLoc), ConfJsonWrapper.class);
+      File configFile = new File(this.configFileLoc);
+      this.lastModifiedTime = configFile.lastModified();
+      this.conf = mapper.readValue(configFile, ConfJsonWrapper.class);
     } catch (IOException e) {
       LOG.error(e.getMessage());
     }
@@ -85,6 +90,11 @@ public class RcaConf {
     return configFileLoc;
   }
 
+  // Returns the last modified time of Rca Conf file
+  public long getLastModifiedTime() {
+    return lastModifiedTime;
+  }
+
   public String getAnalysisGraphEntryPoint() {
     return conf.getAnalysisGraphEntryPoint();
   }
@@ -99,5 +109,9 @@ public class RcaConf {
 
   public HighHeapUsageOldGenRcaConfig getHighHeapUsageOldGenRcaConfig() {
     return conf.getHighHeapUsageOldGenRcaConfig();
+  }
+
+  public List<String> getMutedRcaList() {
+    return conf.getMutedRcaList();
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Stats.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Stats.java
@@ -93,12 +93,26 @@ public class Stats {
     return new ArrayList<>(graphs.values());
   }
 
+  public boolean updateMutedGraphNodes(Set<String> nodeNames) {
+    // Add all the rcaNodes if the mutedGraphNodes is empty
+    // else, retain the ones provided in param value
+    if (mutedGraphNodes.isEmpty()) {
+      return mutedGraphNodes.addAll(nodeNames);
+    } else {
+      return mutedGraphNodes.retainAll(nodeNames);
+    }
+  }
+
   public boolean addToMutedGraphNodes(String nodeName) {
     return mutedGraphNodes.add(nodeName);
   }
 
   public boolean isNodeMuted(String nodeName) {
     return mutedGraphNodes.contains(nodeName);
+  }
+
+  public Set<String> getMutedGraphNodes() {
+    return mutedGraphNodes;
   }
 
   public int getMutedGraphNodesCount() {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
@@ -204,11 +204,12 @@ public class RcaControllerTest {
     Assert.assertTrue(Stats.getInstance().isNodeMuted("Paging_MajfltRate"));
 
     // 5. On RCA Config, "muted-rcas" : "Paging_MajfltRate", Updating RCA Config with "Paging_MajfltRate_Check"
-    // Muted Graph should have no nodes
+    // Muted Graph should still have "Paging_MajfltRate"
     updateConfFileForMutedRcas(rcaConfPath, "Paging_MajfltRate_Check");
     field.set(rcaController, new RcaConf(rcaConfPath));
     readAndUpdateMutesRcas.invoke(rcaController);
-    Assert.assertEquals(0, Stats.getInstance().getMutedGraphNodes().size());
+    Assert.assertEquals(1, Stats.getInstance().getMutedGraphNodes().size());
+    Assert.assertTrue(Stats.getInstance().isNodeMuted("Paging_MajfltRate"));
 
     updateConfFileForMutedRcas(rcaConfPath, "CPU_Utilization, Heap_AllocRate");
     // 6. On RCA Config, "muted-rcas" : "CPU_Utilization, Heap_AllocRate"

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
@@ -1,11 +1,16 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca;
 
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaTestHelper.updateConfFileForMutedRcas;
+
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.ClientServers;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerThreads;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.GRPCConnectionManager;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Stats;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.RCAScheduler;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.RcaSchedulerState;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
@@ -15,6 +20,8 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -46,7 +53,7 @@ public class RcaControllerTest {
   private ThreadProvider threadProvider;
 
   @Before
-  public void setUp() throws IOException {
+  public void setUp() throws Exception {
     threadProvider = new ThreadProvider();
     String cwd = System.getProperty("user.dir");
     rcaEnabledFileLoc = Paths.get(cwd, "src", "test", "resources", "rca");
@@ -101,6 +108,14 @@ public class RcaControllerTest {
         );
 
     setMyIp(masterIP, AllMetrics.NodeRole.UNKNOWN);
+
+    // since we are using 2 rca.conf files here for testing, 'rca_muted.conf' for testing Muted RCAs
+    // and 'rca.conf' for remainging tests, use reflection to access the private rcaConf class variable.
+    String rcaConfPath = Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca.conf").toString();
+    Field field = rcaController.getClass().getDeclaredField("rcaConf");
+    field.setAccessible(true);
+    field.set(rcaController, new RcaConf(rcaConfPath));
+
     controllerThread =
         threadProvider.createThreadForRunnable(() -> rcaController.run(),
             PerformanceAnalyzerThreads.RCA_CONTROLLER);
@@ -145,6 +160,68 @@ public class RcaControllerTest {
     changeRcaRunState(RcaState.RUN);
     Assert.assertTrue(check(new RcaEnabledEval(rcaController), true));
     Assert.assertTrue(RcaController.isRcaEnabled());
+  }
+
+  @Test
+  public void readAndUpdateMutesRcas() throws Exception {
+    String rcaConfPath = Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca_muted.conf").toString();
+    Method readAndUpdateMutesRcas = rcaController.getClass()
+            .getDeclaredMethod("readAndUpdateMutesRcas", null);
+    readAndUpdateMutesRcas.setAccessible(true);
+
+    Field field = rcaController.getClass().getDeclaredField("rcaConf");
+    field.setAccessible(true);
+
+    // 1. Muted Graph : "CPU_Utilization, Heap_AllocRate", updating RCA Config with "CPU_Utilization, Heap_AllocRate"
+    // Muted Graph should have "CPU_Utilization, Heap_AllocRate"
+    updateConfFileForMutedRcas(rcaConfPath, "CPU_Utilization, Heap_AllocRate");
+    field.set(rcaController, new RcaConf(rcaConfPath));
+    readAndUpdateMutesRcas.invoke(rcaController);
+    Assert.assertEquals(2,Stats.getInstance().getMutedGraphNodes().size());
+    Assert.assertTrue(Stats.getInstance().isNodeMuted("CPU_Utilization"));
+    Assert.assertTrue(Stats.getInstance().isNodeMuted("Heap_AllocRate"));
+
+    // 2. Muted Graph : "CPU_Utilization, Heap_AllocRate", updating RCA Config with ""
+    // Muted Graph should have no nodes
+    updateConfFileForMutedRcas(rcaConfPath, "");
+    field.set(rcaController, new RcaConf(rcaConfPath));
+    readAndUpdateMutesRcas.invoke(rcaController);
+    Assert.assertTrue(Stats.getInstance().getMutedGraphNodes().isEmpty());
+
+    // 3. Muted Graph : "", updating RCA Config with ""
+    // Muted Graph should have no nodes
+    updateConfFileForMutedRcas(rcaConfPath, "");
+    field.set(rcaController, new RcaConf(rcaConfPath));
+    readAndUpdateMutesRcas.invoke(rcaController);
+    Assert.assertTrue(Stats.getInstance().getMutedGraphNodes().isEmpty());
+
+    // 4. On RCA Config, "muted-rcas" : "CPU_Utilization, Heap_AllocRate", Updating RCA Config with "Paging_MajfltRate"
+    // Muted Graph should retain only "Paging_MajfltRate"
+    updateConfFileForMutedRcas(rcaConfPath, "Paging_MajfltRate");
+    field.set(rcaController, new RcaConf(rcaConfPath));
+    readAndUpdateMutesRcas.invoke(rcaController);
+    Assert.assertEquals(1, Stats.getInstance().getMutedGraphNodes().size());
+    Assert.assertTrue(Stats.getInstance().isNodeMuted("Paging_MajfltRate"));
+
+    // 5. On RCA Config, "muted-rcas" : "Paging_MajfltRate", Updating RCA Config with "Paging_MajfltRate_Check"
+    // Muted Graph should have no nodes
+    updateConfFileForMutedRcas(rcaConfPath, "Paging_MajfltRate_Check");
+    field.set(rcaController, new RcaConf(rcaConfPath));
+    readAndUpdateMutesRcas.invoke(rcaController);
+    Assert.assertEquals(0, Stats.getInstance().getMutedGraphNodes().size());
+
+    updateConfFileForMutedRcas(rcaConfPath, "CPU_Utilization, Heap_AllocRate");
+    // 6. On RCA Config, "muted-rcas" : "CPU_Utilization, Heap_AllocRate"
+    // Updating RCA Config with "Paging_MajfltRate_Check, Paging_MajfltRate"
+    // Muted Graph should have "Paging_MajfltRate"
+    updateConfFileForMutedRcas(rcaConfPath, "Paging_MajfltRate_Check, Paging_MajfltRate");
+    field.set(rcaController, new RcaConf(rcaConfPath));
+    readAndUpdateMutesRcas.invoke(rcaController);
+    Assert.assertEquals(1, Stats.getInstance().getMutedGraphNodes().size());
+    Assert.assertTrue(Stats.getInstance().isNodeMuted("Paging_MajfltRate"));
+
+    // Re-set the 'rcaConf' variable to track 'rca.conf' for remaining tests
+    field.set(rcaController, new RcaConf(Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca.conf").toString()));
   }
 
   @Test

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaTestHelper.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaTestHelper.java
@@ -20,16 +20,26 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Scanner;
+
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.FileAppender;
 import org.jooq.tools.json.JSONObject;
@@ -129,4 +139,20 @@ public class RcaTestHelper {
       e.printStackTrace();
     }
   }
+
+  public static void updateConfFileForMutedRcas(String rcaConfPath, String mutedRcas) throws Exception {
+
+    // create the config json Object from rca config file
+    Scanner scanner = new Scanner(new FileInputStream(rcaConfPath), StandardCharsets.UTF_8.name());
+    String jsonText = scanner.useDelimiter("\\A").next();
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.enable(JsonParser.Feature.ALLOW_COMMENTS);
+    mapper.enable(SerializationFeature.INDENT_OUTPUT);
+    JsonNode configObject = mapper.readTree(jsonText);
+
+    // update the `MUTED_RCAS_CONFIG` value in config Object
+    ((ObjectNode) configObject).put("muted-rcas", mutedRcas);
+    mapper.writeValue(new FileOutputStream(rcaConfPath), configObject);
+  }
+
 }

--- a/src/test/resources/rca/rca.conf
+++ b/src/test/resources/rca/rca.conf
@@ -41,5 +41,7 @@
     // How often the sqlite file be repeated in seconds. This file contains RCAs and therefore rotating it too frequently
     // might not be as fruitful as there might not be any data.
     "rotation-period-seconds": 21600
-  }
+  },
+
+    "muted-rcas": ""
 }

--- a/src/test/resources/rca/rca_elected_master.conf
+++ b/src/test/resources/rca/rca_elected_master.conf
@@ -41,5 +41,7 @@
     // How often the sqlite file be repeated in seconds. This file contains RCAs and therefore rotating it too frequently
     // might not be as fruitful as there might not be any data.
     "rotation-period-seconds": 21600
-  }
+  },
+
+  "muted-rcas": ""
 }

--- a/src/test/resources/rca/rca_muted.conf
+++ b/src/test/resources/rca/rca_muted.conf
@@ -1,6 +1,7 @@
+// Conf for testing muted RCAs
 {
   "analysis-graph-implementor":
-    "com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.AnalysisGraphTest",
+  "com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.AnalysisGraphTest",
   // it can be file:// or s3://
   "rca-store-location": "s3://sifi-store/rcas/",
 
@@ -37,11 +38,11 @@
     "type": "sqlite",
     "location-dir": "/tmp",
     "filename": "rca.sqlite",
-
+    "storage-file-retention-count": 5,
     // How often the sqlite file be repeated in seconds. This file contains RCAs and therefore rotating it too frequently
     // might not be as fruitful as there might not be any data.
     "rotation-period-seconds": 21600
   },
 
-  "muted-rcas": ""
+  "muted-rcas": "CPU_Utilization, Heap_AllocRate"
 }


### PR DESCRIPTION
Description of changes: The RcaController thread will check the muted_rcas.conf file and update the Analysis Graph for muted RCAs. Plugged into existing code to disable reading metrics if node is Muted.

    Added UTs
    Incoporated PR Feedback

The API behavior : The API will be invoked with full list of RCAs that are expected to be muted. The input will be provided as a comma separated string, similar to "CPU_Utilization, Heap_AllocRate". The API implementation takes care of validating the RCA names provided in the input and any leading/trailing spaces.

    If API is invoked with at least 1 valid RCA, the muted RCA Graph is updated to retain only this valid RCA(s).
    If API is invoked with an empty string, the muted RCA Graph is updated and all previous existing RCAs in the graph are removed.
    If API is invoked with an all invalid RCAs, no action is taken.

Tests: UT, Dev Stack Testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
