### PR TITLE
Add temperature profile along heap allocation rate dimension

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/temperature/ClusterTemperatureFlowUnit.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/temperature/ClusterTemperatureFlowUnit.java
@@ -21,17 +21,18 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.ClusterTemperatureSummary;
 
 public class ClusterTemperatureFlowUnit extends ResourceFlowUnit {
-    private final ClusterTemperatureSummary clusterTemperatureSummary;
 
-    public ClusterTemperatureFlowUnit(long timeStamp, ResourceContext context,
-                                      ClusterTemperatureSummary resourceSummary) {
-        super(timeStamp, context, resourceSummary, true);
-        clusterTemperatureSummary = resourceSummary;
-    }
+  private final ClusterTemperatureSummary clusterTemperatureSummary;
 
-    @Override
-    public FlowUnitMessage buildFlowUnitMessage(String graphNode, String esNode) {
-        throw new IllegalStateException(this.getClass().getSimpleName() + " should not be passed "
-                + "over the wire.");
-    }
+  public ClusterTemperatureFlowUnit(long timeStamp, ResourceContext context,
+      ClusterTemperatureSummary resourceSummary) {
+    super(timeStamp, context, resourceSummary, true);
+    clusterTemperatureSummary = resourceSummary;
+  }
+
+  @Override
+  public FlowUnitMessage buildFlowUnitMessage(String graphNode, String esNode) {
+    throw new IllegalStateException(this.getClass().getSimpleName() + " should not be passed "
+        + "over the wire.");
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/temperature/CompactNodeTemperatureFlowUnit.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/temperature/CompactNodeTemperatureFlowUnit.java
@@ -28,39 +28,45 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
  * shards, it would be sending too many bytes over the wire.
  */
 public class CompactNodeTemperatureFlowUnit extends ResourceFlowUnit {
-    private final CompactNodeSummary compactNodeTemperatureSummary;
 
-    public CompactNodeTemperatureFlowUnit(long timeStamp, ResourceContext context,
-                                          CompactNodeSummary resourceSummary,
-                                          boolean persistSummary) {
-        super(timeStamp, context, resourceSummary, persistSummary);
-        this.compactNodeTemperatureSummary = resourceSummary;
-    }
+  private final CompactNodeSummary compactNodeTemperatureSummary;
 
-    public CompactNodeTemperatureFlowUnit(long timeStamp) {
-        super(timeStamp);
-        compactNodeTemperatureSummary = null;
-    }
+  public CompactNodeTemperatureFlowUnit(long timeStamp, ResourceContext context,
+      CompactNodeSummary resourceSummary,
+      boolean persistSummary) {
+    super(timeStamp, context, resourceSummary, persistSummary);
+    this.compactNodeTemperatureSummary = resourceSummary;
+  }
 
-    @Override
-    public FlowUnitMessage buildFlowUnitMessage(String graphNode, String esNode) {
-        FlowUnitMessage.Builder builder = FlowUnitMessage.newBuilder();
-        builder.setGraphNode(graphNode);
-        builder.setEsNode(esNode);
-        builder.setTimeStamp(System.currentTimeMillis());
-        compactNodeTemperatureSummary.buildSummaryMessageAndAddToFlowUnit(builder);
-        return builder.build();
-    }
+  public CompactNodeTemperatureFlowUnit(long timeStamp) {
+    super(timeStamp);
+    compactNodeTemperatureSummary = null;
+  }
 
-    public static CompactNodeTemperatureFlowUnit buildFlowUnitFromWrapper(final FlowUnitMessage message) {
-        CompactNodeSummary compactNodeTemperatureSummary =
-                CompactNodeSummary.buildNodeTemperatureProfileFromMessage(message.getNodeTemperatureSummary());
-        return new CompactNodeTemperatureFlowUnit(message.getTimeStamp(), new ResourceContext(Resources.State.UNKNOWN),
-                compactNodeTemperatureSummary, false);
-    }
+  public static CompactNodeTemperatureFlowUnit buildFlowUnitFromWrapper(
+      final FlowUnitMessage message) {
+    CompactNodeSummary compactNodeTemperatureSummary =
+        CompactNodeSummary
+            .buildNodeTemperatureProfileFromMessage(message.getNodeTemperatureSummary());
+    return new CompactNodeTemperatureFlowUnit(message.getTimeStamp(),
+        new ResourceContext(Resources.State.UNKNOWN),
+        compactNodeTemperatureSummary, false);
+  }
 
-    public CompactNodeSummary getCompactNodeTemperatureSummary() {
-        return compactNodeTemperatureSummary;
+  @Override
+  public FlowUnitMessage buildFlowUnitMessage(String graphNode, String esNode) {
+    FlowUnitMessage.Builder builder = FlowUnitMessage.newBuilder();
+    builder.setGraphNode(graphNode);
+    builder.setEsNode(esNode);
+    builder.setTimeStamp(System.currentTimeMillis());
+    if (compactNodeTemperatureSummary != null) {
+      compactNodeTemperatureSummary.buildSummaryMessageAndAddToFlowUnit(builder);
     }
+    return builder.build();
+  }
+
+  public CompactNodeSummary getCompactNodeTemperatureSummary() {
+    return compactNodeTemperatureSummary;
+  }
 
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/temperature/DimensionalTemperatureFlowUnit.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/temperature/DimensionalTemperatureFlowUnit.java
@@ -21,33 +21,34 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.NodeLevelDimensionalSummary;
 
 /**
- * This is the FlowUnit wrapper over the summary of the given node across all the tracked
- * dimension. The graph nodes, between which this FlowUnit is passed are local to an
- * Elasticsearch node (or in other words, are not transferred over the wire). Therefore, the
- * protobuf message generation is not really required.
+ * This is the FlowUnit wrapper over the summary of the given node across all the tracked dimension.
+ * The graph nodes, between which this FlowUnit is passed are local to an Elasticsearch node (or in
+ * other words, are not transferred over the wire). Therefore, the protobuf message generation is
+ * not really required.
  */
 public class DimensionalTemperatureFlowUnit extends ResourceFlowUnit {
-    private final NodeLevelDimensionalSummary nodeDimensionProfile;
 
-    public DimensionalTemperatureFlowUnit(long timeStamp,
-                                          final NodeLevelDimensionalSummary nodeDimensionProfile) {
-        super(timeStamp, ResourceContext.generic(), nodeDimensionProfile, true);
-        this.nodeDimensionProfile = nodeDimensionProfile;
-    }
+  private final NodeLevelDimensionalSummary nodeDimensionProfile;
 
-    public DimensionalTemperatureFlowUnit(long timestamp) {
-        super(timestamp);
-        nodeDimensionProfile = null;
-    }
+  public DimensionalTemperatureFlowUnit(long timeStamp,
+      final NodeLevelDimensionalSummary nodeDimensionProfile) {
+    super(timeStamp, ResourceContext.generic(), nodeDimensionProfile, true);
+    this.nodeDimensionProfile = nodeDimensionProfile;
+  }
 
-    // A dimension flow unit never leaves a node. So, we don't need to generate protobuf messages.
-    @Override
-    public FlowUnitMessage buildFlowUnitMessage(String graphNode, String esNode) {
-        throw new IllegalStateException(this.getClass().getSimpleName() + " should not be passed "
-                + "over the wire.");
-    }
+  public DimensionalTemperatureFlowUnit(long timestamp) {
+    super(timestamp);
+    nodeDimensionProfile = null;
+  }
 
-    public NodeLevelDimensionalSummary getNodeDimensionProfile() {
-        return nodeDimensionProfile;
-    }
+  // A dimension flow unit never leaves a node. So, we don't need to generate protobuf messages.
+  @Override
+  public FlowUnitMessage buildFlowUnitMessage(String graphNode, String esNode) {
+    throw new IllegalStateException(this.getClass().getSimpleName() + " should not be passed "
+        + "over the wire.");
+  }
+
+  public NodeLevelDimensionalSummary getNodeDimensionProfile() {
+    return nodeDimensionProfile;
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/ClusterDimensionalSummary.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/ClusterDimensionalSummary.java
@@ -39,432 +39,434 @@ import org.jooq.SelectJoinStep;
 import org.jooq.impl.DSL;
 
 /**
- * This is the temperature summary at a cluster level. This categorizes all the nodes in the
- * cluster in 4 regions: hot, warm, luke-warm and cold for all the tracked dimensions. This
- * object is created on the elected master. One such object is created per tracked dimension.
+ * This is the temperature summary at a cluster level. This categorizes all the nodes in the cluster
+ * in 4 regions: hot, warm, luke-warm and cold for all the tracked dimensions. This object is
+ * created on the elected master. One such object is created per tracked dimension.
  */
 public class ClusterDimensionalSummary extends GenericSummary {
-    /**
-     * The name of the table in which this summary is persisted.
-     */
-    public static final String TABLE_NAME =
-            ClusterDimensionalSummary.class.getSimpleName();
+
+  /**
+   * The name of the table in which this summary is persisted.
+   */
+  public static final String TABLE_NAME =
+      ClusterDimensionalSummary.class.getSimpleName();
+
+  /**
+   * The name of the table in which Zonal categorizations of the nodes are persisted.
+   */
+  public static final String ZONE_PROFILE_TABLE_NAME =
+      ZoneSummary.class.getSimpleName();
+
+  private static final String DIM_KEY = "dimension";
+  private static final String MEAN_KEY = "mean";
+  private static final String TOTAL_KEY = "total";
+  private static final String NUM_NODES_KEY = "numNodes";
+
+  /**
+   * This determines which dimension for which this profile is.
+   */
+  private final TemperatureVector.Dimension profileForDimension;
+  /**
+   * The zonal details go here. This is a wrapper over all nodes that belong to this zone. A zone
+   * can be empty, i.e. have to nodes that belong to it.
+   */
+  private final ZoneSummary[] zoneProfiles;
+  /**
+   * This is the mean temperature for this dimension over all the nodes in the cluster.
+   */
+  private TemperatureVector.NormalizedValue meanTemperature;
+  /**
+   * meanTemperature is a normalized value. The total tells us if this is something that one should
+   * be concerned about.
+   */
+  private double totalUsage;
+  /**
+   * The number of nodes in the cluster.
+   */
+  private int numberOfNodes;
+
+  public ClusterDimensionalSummary(TemperatureVector.Dimension profileForDimension) {
+    this.profileForDimension = profileForDimension;
+
+    this.zoneProfiles = new ZoneSummary[HeatZoneAssigner.Zone.values().length];
+    for (int i = 0; i < this.zoneProfiles.length; i++) {
+      this.zoneProfiles[i] = new ZoneSummary(HeatZoneAssigner.Zone.values()[i]);
+    }
+  }
+
+  /**
+   * This determines the SQLite schema. It gives us the name and type of columns.
+   *
+   * @return A list of columns for this table.
+   */
+  public static List<Field<?>> getCols() {
+    List<Field<?>> schema = new ArrayList<>();
+    schema.add(DSL.field(DSL.name(DIM_KEY), String.class));
+    schema.add(DSL.field(DSL.name(MEAN_KEY), Short.class));
+    schema.add(DSL.field(DSL.name(TOTAL_KEY), Double.class));
+    schema.add(DSL.field(DSL.name(NUM_NODES_KEY), Integer.class));
+
+    return schema;
+  }
+
+  /**
+   * The columns are: ClusterDimensionTemperatureSummary_ID | dimension | mean | total | numNodes |
+   * ClusterTemperatureSummary_ID
+   *
+   * <p>The build is used to create a summary object from a row of the table.
+   *
+   * @param record  A database row
+   * @param context The SQL query context that is used to get the data for the inner objects.
+   * @return Returns the summary object
+   */
+  public static ClusterDimensionalSummary build(Record record, DSLContext context) {
+    String dimensionName = record.get(DIM_KEY, String.class);
+
+    TemperatureVector.NormalizedValue meanTemp =
+        new TemperatureVector.NormalizedValue(record.get(MEAN_KEY, Short.class));
+    double total = record.get(TOTAL_KEY, Double.class);
+    int numNodes = record.get(NUM_NODES_KEY, Integer.class);
+    int dimSummaryId = record.get(SQLiteQueryUtils.getPrimaryKeyColumnName(TABLE_NAME),
+        Integer.class);
+
+    ClusterDimensionalSummary summary =
+        new ClusterDimensionalSummary(TemperatureVector.Dimension.valueOf(dimensionName));
+    summary.setTotalUsage(total);
+    summary.setMeanTemperature(meanTemp);
+    summary.setNumberOfNodes(numNodes);
+
+    Field<Integer> foreignKeyForDimensionalTable = DSL.field(
+        SQLiteQueryUtils.getPrimaryKeyColumnName(TABLE_NAME), Integer.class);
+
+    SelectJoinStep<Record> rcaQuery = SQLiteQueryUtils
+        .buildSummaryQuery(context, ZONE_PROFILE_TABLE_NAME, dimSummaryId,
+            foreignKeyForDimensionalTable);
+
+    Result<Record> recordList = rcaQuery.fetch();
+    for (Record zoneSummary : recordList) {
+      buildZoneProfile(zoneSummary, summary, context);
+    }
+    return summary;
+  }
+
+  /**
+   * The columns are : ClusterZoneProfileSummary_ID | zone | min | max |
+   * ClusterDimensionalTemperatureSummary_ID
+   *
+   * @param record  A database row
+   * @param summary The summary object constructed from the database row
+   */
+  private static void buildZoneProfile(Record record,
+      ClusterDimensionalSummary summary,
+      DSLContext context) {
+    String zoneName = record.get(ZoneSummary.ZONE_KEY, String.class);
+
+    ZoneSummary zone =
+        summary.zoneProfiles[HeatZoneAssigner.Zone.valueOf(zoneName).ordinal()];
+
+    String allNodesStr = record.get(ZoneSummary.ALL_NODES_KEY, String.class);
+
+    if (!allNodesStr.isEmpty()) {
+      JsonArray json = new JsonParser().parse(allNodesStr).getAsJsonArray();
+
+      for (int i = 0; i < json.getAsJsonArray().size(); i++) {
+        JsonObject obj = json.get(i).getAsJsonObject();
+        String hostIp =
+            obj.get(HotNodeSummary.SQL_SCHEMA_CONSTANTS.HOST_IP_ADDRESS_COL_NAME).getAsString();
+        String nodeId =
+            obj.get(HotNodeSummary.SQL_SCHEMA_CONSTANTS.NODE_ID_COL_NAME).getAsString();
+
+        CompactClusterLevelNodeSummary nodeSummary =
+            new CompactClusterLevelNodeSummary(nodeId, hostIp);
+        zone.addNode(nodeSummary);
+      }
+    }
+  }
+
+  public int getNumberOfNodes() {
+    return numberOfNodes;
+  }
+
+  public void setNumberOfNodes(int numberOfNodes) {
+    this.numberOfNodes = numberOfNodes;
+  }
+
+  public void addNodeToZone(CompactClusterLevelNodeSummary nodeSummary) {
+    HeatZoneAssigner.Zone zone =
+        HeatZoneAssigner.assign(nodeSummary.getTemperatureForDimension(profileForDimension),
+            meanTemperature,
+            CpuUtilDimensionTemperatureRca.THRESHOLD_NORMALIZED_VAL_FOR_HEAT_ZONE_ASSIGNMENT);
+    ZoneSummary profile = zoneProfiles[zone.ordinal()];
+    profile.addNode(nodeSummary);
+    numberOfNodes += 1;
+  }
+
+  public TemperatureVector.NormalizedValue getMeanTemperature() {
+    return meanTemperature;
+  }
+
+  public void setMeanTemperature(TemperatureVector.NormalizedValue meanTemperature) {
+    this.meanTemperature = meanTemperature;
+  }
+
+  public TemperatureVector.Dimension getProfileForDimension() {
+    return profileForDimension;
+  }
+
+  public double getTotalUsage() {
+    return totalUsage;
+  }
+
+  public void setTotalUsage(double totalUsage) {
+    this.totalUsage = totalUsage;
+  }
+
+  public List<GenericSummary> getNestedSummaryList() {
+    List<GenericSummary> zoneSummaries = new ArrayList<>();
+    for (ZoneSummary zone : zoneProfiles) {
+      zoneSummaries.add(zone);
+    }
+    return zoneSummaries;
+  }
+
+  /**
+   * Should not be called as its not passed across network boundaries.
+   */
+  @Override
+  public <T extends GeneratedMessageV3> T buildSummaryMessage() {
+    throw new IllegalArgumentException("This should not be called.");
+  }
+
+  /**
+   * Should not be called as its not passed across network boundaries.
+   */
+  @Override
+  public void buildSummaryMessageAndAddToFlowUnit(FlowUnitMessage.Builder messageBuilder) {
+    throw new IllegalArgumentException("This should not be called.");
+  }
+
+  @Override
+  public String getTableName() {
+    return TABLE_NAME;
+  }
+
+  @Override
+  public List<Field<?>> getSqlSchema() {
+    return getCols();
+  }
+
+  /**
+   * Serializes the summary information into a row that can be persisted into a table.
+   *
+   * @return a list of values.
+   */
+  @Override
+  public List<Object> getSqlValue() {
+    List<Object> row = new ArrayList<>();
+    row.add(getProfileForDimension().NAME);
+    row.add(getMeanTemperature().getPOINTS());
+    row.add(getTotalUsage());
+    row.add(getNumberOfNodes());
+    return row;
+  }
+
+  /**
+   * This serializes the object and all its inner classes into a JSON object as a response to a REST
+   * call.
+   *
+   * @return A JsonObject.
+   */
+  @Override
+  public JsonElement toJson() {
+    JsonObject summaryObj = new JsonObject();
+    summaryObj.addProperty(DIM_KEY, getProfileForDimension().NAME);
+    summaryObj.addProperty(MEAN_KEY, getMeanTemperature().getPOINTS());
+    summaryObj.addProperty(TOTAL_KEY, getTotalUsage());
+    summaryObj.addProperty(NUM_NODES_KEY, getNumberOfNodes());
+
+    JsonArray arr = new JsonArray();
+    for (ZoneSummary zone : zoneProfiles) {
+      arr.add(zone.toJson());
+    }
+
+    summaryObj.add(ZONE_PROFILE_TABLE_NAME, arr);
+    return summaryObj;
+  }
+
+  /**
+   * A summary object to encapsulate all the details about a temperature zone.
+   */
+  public class ZoneSummary extends GenericSummary {
+
+    private static final String ZONE_KEY = "zone";
+    private static final String MIN_KEY = "min";
+    private static final String MAX_KEY = "max";
+    private static final String ALL_NODES_KEY = "all_nodes";
 
     /**
-     * The name of the table in which Zonal categorizations of the nodes are persisted.
+     * This is the zone for which details are stored here.
      */
-    public static final String ZONE_PROFILE_TABLE_NAME =
-            ZoneSummary.class.getSimpleName();
-
-    private static final String DIM_KEY = "dimension";
-    private static final String MEAN_KEY = "mean";
-    private static final String TOTAL_KEY = "total";
-    private static final String NUM_NODES_KEY = "numNodes";
+    private final HeatZoneAssigner.Zone myZone;
 
     /**
-     * This determines which dimension for which this profile is.
+     * The list of nodes that are part of this zone for a given dimension.
      */
-    private final TemperatureVector.Dimension profileForDimension;
+    List<CompactClusterLevelNodeSummary> nodeProfileSummaries;
 
     /**
-     * This is the mean temperature for this dimension over all the nodes in the cluster.
+     * The EsNode with the minimum temperature value.
      */
-    private TemperatureVector.NormalizedValue meanTemperature;
+    CompactClusterLevelNodeSummary minNode;
 
     /**
-     * meanTemperature is a normalized value. The total tells us if this is something that one
-     * should be concerned about.
+     * The ES node with the maximum temperature value.
      */
-    private double totalUsage;
+    CompactClusterLevelNodeSummary maxNode;
+
+    ZoneSummary(HeatZoneAssigner.Zone myZone) {
+      this.myZone = myZone;
+      nodeProfileSummaries = new ArrayList<>();
+    }
 
     /**
-     * The number of nodes in the cluster.
+     * Adds a node to this zone.
+     *
+     * <p>It also compares the temperature for this node with the nodes gathered so far to
+     * update the min and the max nodes.
+     *
+     * @param node The node to be added.
      */
-    private int numberOfNodes;
-
-    /**
-     * The zonal details go here. This is a wrapper over all nodes that belong to this zone. A
-     * zone can be empty, i.e. have to nodes that belong to it.
-     */
-    private final ZoneSummary[] zoneProfiles;
-
-    public ClusterDimensionalSummary(TemperatureVector.Dimension profileForDimension) {
-        this.profileForDimension = profileForDimension;
-
-        this.zoneProfiles = new ZoneSummary[HeatZoneAssigner.Zone.values().length];
-        for (int i = 0; i < this.zoneProfiles.length; i++) {
-            this.zoneProfiles[i] = new ZoneSummary(HeatZoneAssigner.Zone.values()[i]);
+    void addNode(@Nonnull final CompactClusterLevelNodeSummary node) {
+      nodeProfileSummaries.add(node);
+      if (minNode == null) {
+        minNode = node;
+      } else {
+        if (getMinTemperature().isGreaterThan(
+            node.getTemperatureForDimension(profileForDimension))) {
+          minNode = node;
         }
+      }
+
+      if (maxNode == null) {
+        maxNode = node;
+      } else {
+        if (node.getTemperatureForDimension(profileForDimension).isGreaterThan(
+            getMaxTemperature())) {
+          maxNode = node;
+        }
+      }
     }
 
-    public void setMeanTemperature(TemperatureVector.NormalizedValue meanTemperature) {
-        this.meanTemperature = meanTemperature;
+    @Nullable
+    TemperatureVector.NormalizedValue getMinTemperature() {
+      if (minNode != null) {
+        return minNode.getTemperatureForDimension(profileForDimension);
+      }
+      return null;
     }
 
-    public void setTotalUsage(double totalUsage) {
-        this.totalUsage = totalUsage;
+    @Nullable
+    TemperatureVector.NormalizedValue getMaxTemperature() {
+      if (maxNode != null) {
+        return maxNode.getTemperatureForDimension(profileForDimension);
+      }
+      return null;
     }
 
-    public int getNumberOfNodes() {
-        return numberOfNodes;
-    }
-
-    public void setNumberOfNodes(int numberOfNodes) {
-        this.numberOfNodes = numberOfNodes;
-    }
-
-    public void addNodeToZone(CompactClusterLevelNodeSummary nodeSummary) {
-        HeatZoneAssigner.Zone zone =
-                HeatZoneAssigner.assign(nodeSummary.getTemperatureForDimension(profileForDimension),
-                        meanTemperature,
-                        CpuUtilDimensionTemperatureRca.THRESHOLD_NORMALIZED_VAL_FOR_HEAT_ZONE_ASSIGNMENT);
-        ZoneSummary profile = zoneProfiles[zone.ordinal()];
-        profile.addNode(nodeSummary);
-        numberOfNodes += 1;
-    }
-
-    public TemperatureVector.NormalizedValue getMeanTemperature() {
-        return meanTemperature;
-    }
-
-    public TemperatureVector.Dimension getProfileForDimension() {
-        return profileForDimension;
-    }
-
-    public double getTotalUsage() {
-        return totalUsage;
-    }
-
-    /**
-     * Should not be called as its not passed across network boundaries.
-     */
     @Override
     public <T extends GeneratedMessageV3> T buildSummaryMessage() {
-        throw new IllegalArgumentException("This should not be called.");
+      throw new IllegalArgumentException("");
     }
 
-    /**
-     * Should not be called as its not passed across network boundaries.
-     */
     @Override
     public void buildSummaryMessageAndAddToFlowUnit(FlowUnitMessage.Builder messageBuilder) {
-        throw new IllegalArgumentException("This should not be called.");
+      throw new IllegalArgumentException("");
     }
 
     @Override
     public String getTableName() {
-        return TABLE_NAME;
-    }
-
-    public List<GenericSummary> getNestedSummaryList() {
-        List<GenericSummary> zoneSummaries = new ArrayList<>();
-        for (ZoneSummary zone : zoneProfiles) {
-            zoneSummaries.add(zone);
-        }
-        return zoneSummaries;
-    }
-
-    /**
-     * This determines the SQLite schema. It gives us the name and type of columns.
-     * @return A list of columns for this table.
-     */
-    public static List<Field<?>> getCols() {
-        List<Field<?>> schema = new ArrayList<>();
-        schema.add(DSL.field(DSL.name(DIM_KEY), String.class));
-        schema.add(DSL.field(DSL.name(MEAN_KEY), Short.class));
-        schema.add(DSL.field(DSL.name(TOTAL_KEY), Double.class));
-        schema.add(DSL.field(DSL.name(NUM_NODES_KEY), Integer.class));
-
-        return schema;
+      return ZONE_PROFILE_TABLE_NAME;
     }
 
     @Override
     public List<Field<?>> getSqlSchema() {
-        return getCols();
+      return getColumns();
     }
 
-    /**
-     * Serializes the summary information into a row that can be persisted into a table.
-     * @return a list of values.
-     */
     @Override
     public List<Object> getSqlValue() {
-        List<Object> row = new ArrayList<>();
-        row.add(getProfileForDimension().NAME);
-        row.add(getMeanTemperature().getPOINTS());
-        row.add(getTotalUsage());
-        row.add(getNumberOfNodes());
-        return row;
+      List<Object> values = new ArrayList<>();
+      values.add(myZone.name());
+      values.add(minNode == null ? "" : minNode.getHostAddress());
+      values.add(maxNode == null ? "" : maxNode.getHostAddress());
+
+      JsonArray allNodes = getAllNodesJson();
+      String allNodesStr = getAllNodesString(allNodes);
+      values.add(allNodesStr);
+
+      return values;
     }
 
-    /**
-     * This serializes the object and all its inner classes into a JSON object as a response to a
-     * REST call.
-     * @return A JsonObject.
-     */
     @Override
     public JsonElement toJson() {
-        JsonObject summaryObj = new JsonObject();
-        summaryObj.addProperty(DIM_KEY, getProfileForDimension().NAME);
-        summaryObj.addProperty(MEAN_KEY, getMeanTemperature().getPOINTS());
-        summaryObj.addProperty(TOTAL_KEY, getTotalUsage());
-        summaryObj.addProperty(NUM_NODES_KEY, getNumberOfNodes());
+      JsonObject summaryObj = new JsonObject();
+      summaryObj.addProperty(ZONE_KEY, myZone.name());
 
-        JsonArray arr = new JsonArray();
-        for (ZoneSummary zone : zoneProfiles) {
-            arr.add(zone.toJson());
-        }
+      if (minNode == maxNode) {
+        summaryObj.add(MIN_KEY, null);
+        summaryObj.add(MAX_KEY, null);
+      } else {
+        summaryObj.add(MIN_KEY, minNode == null ? null : getNodeJson(minNode));
+        summaryObj.add(MAX_KEY, maxNode == null ? null : getNodeJson(maxNode));
+      }
+      summaryObj.add(ALL_NODES_KEY, getAllNodesJson());
 
-        summaryObj.add(ZONE_PROFILE_TABLE_NAME, arr);
-        return summaryObj;
+      return summaryObj;
     }
 
-    /**
-     * The columns are:
-     * ClusterDimensionTemperatureSummary_ID | dimension | mean | total | numNodes |
-     * ClusterTemperatureSummary_ID
-     *
-     * <p>The build is used to create a summary object from a row of the table.
-     *
-     * @param record A database row
-     * @param context The SQL query context that is used to get the data for the inner objects.
-     * @return Returns the summary object
-     */
-    public static ClusterDimensionalSummary build(Record record, DSLContext context) {
-        String dimensionName = record.get(DIM_KEY, String.class);
-
-        TemperatureVector.NormalizedValue meanTemp =
-                new TemperatureVector.NormalizedValue(record.get(MEAN_KEY, Short.class));
-        double total = record.get(TOTAL_KEY, Double.class);
-        int numNodes = record.get(NUM_NODES_KEY, Integer.class);
-        int dimSummaryId = record.get(SQLiteQueryUtils.getPrimaryKeyColumnName(TABLE_NAME),
-                Integer.class);
-
-        ClusterDimensionalSummary summary =
-                new ClusterDimensionalSummary(TemperatureVector.Dimension.valueOf(dimensionName));
-        summary.setTotalUsage(total);
-        summary.setMeanTemperature(meanTemp);
-        summary.setNumberOfNodes(numNodes);
-
-        Field<Integer> foreignKeyForDimensionalTable = DSL.field(
-                SQLiteQueryUtils.getPrimaryKeyColumnName(TABLE_NAME), Integer.class);
-
-        SelectJoinStep<Record> rcaQuery = SQLiteQueryUtils
-                .buildSummaryQuery(context, ZONE_PROFILE_TABLE_NAME, dimSummaryId, foreignKeyForDimensionalTable);
-
-        Result<Record> recordList = rcaQuery.fetch();
-        for (Record zoneSummary : recordList) {
-            buildZoneProfile(zoneSummary, summary, context);
-        }
-        return summary;
+    private List<Field<?>> getColumns() {
+      List<Field<?>> schema = new ArrayList<>();
+      schema.add(DSL.field(DSL.name(ZONE_KEY), String.class));
+      schema.add(DSL.field(DSL.name(MIN_KEY), String.class));
+      schema.add(DSL.field(DSL.name(MAX_KEY), String.class));
+      schema.add(DSL.field(DSL.name(ALL_NODES_KEY), String.class));
+      return schema;
     }
 
-    /**
-     * The columns are :
-     * ClusterZoneProfileSummary_ID | zone | min | max | ClusterDimensionalTemperatureSummary_ID
-     *
-     * @param record A database row
-     * @param summary The summary object constructed from the database row
-     */
-    private static void buildZoneProfile(Record record,
-                                         ClusterDimensionalSummary summary,
-                                         DSLContext context) {
-        String zoneName = record.get(ZoneSummary.ZONE_KEY, String.class);
+    private JsonObject getNodeJson(CompactClusterLevelNodeSummary nodeSummary) {
+      JsonObject jsonObject = new JsonObject();
 
-        ZoneSummary zone =
-                summary.zoneProfiles[HeatZoneAssigner.Zone.valueOf(zoneName).ordinal()];
+      jsonObject.addProperty(HotNodeSummary.SQL_SCHEMA_CONSTANTS.HOST_IP_ADDRESS_COL_NAME,
+          nodeSummary.getHostAddress());
+      jsonObject.addProperty(HotNodeSummary.SQL_SCHEMA_CONSTANTS.NODE_ID_COL_NAME,
+          nodeSummary.getNodeId());
 
-        String allNodesStr = record.get(ZoneSummary.ALL_NODES_KEY, String.class);
-
-        if (!allNodesStr.isEmpty()) {
-            JsonArray json = new JsonParser().parse(allNodesStr).getAsJsonArray();
-
-            for (int i = 0; i < json.getAsJsonArray().size(); i++) {
-                JsonObject obj = json.get(i).getAsJsonObject();
-                String hostIp =
-                        obj.get(HotNodeSummary.SQL_SCHEMA_CONSTANTS.HOST_IP_ADDRESS_COL_NAME).getAsString();
-                String nodeId =
-                        obj.get(HotNodeSummary.SQL_SCHEMA_CONSTANTS.NODE_ID_COL_NAME).getAsString();
-
-                CompactClusterLevelNodeSummary nodeSummary =
-                        new CompactClusterLevelNodeSummary(nodeId, hostIp);
-                zone.addNode(nodeSummary);
-            }
-        }
+      return jsonObject;
     }
 
-    /**
-     * A summary object to encapsulate all the details about a temperature zone.
-     */
-    public class ZoneSummary extends GenericSummary {
-        private static final String ZONE_KEY = "zone";
-        private static final String MIN_KEY = "min";
-        private static final String MAX_KEY = "max";
-        private static final String ALL_NODES_KEY = "all_nodes";
-
-        /**
-         * This is the zone for which details are stored here.
-         */
-        private final HeatZoneAssigner.Zone myZone;
-
-        /**
-         * The list of nodes that are part of this zone for a given dimension.
-         */
-        List<CompactClusterLevelNodeSummary> nodeProfileSummaries;
-
-        /**
-         * The EsNode with the minimum temperature value.
-         */
-        CompactClusterLevelNodeSummary minNode;
-
-        /**
-         * The ES node with the maximum temperature value.
-         */
-        CompactClusterLevelNodeSummary maxNode;
-
-        ZoneSummary(HeatZoneAssigner.Zone myZone) {
-            this.myZone = myZone;
-            nodeProfileSummaries = new ArrayList<>();
-        }
-
-        /**
-         * Adds a node to this zone.
-         *
-         * <p>It also compares the temperature for this node with the nodes gathered so far to
-         * update the min and the max nodes.
-         * @param node The node to be added.
-         */
-        void addNode(@Nonnull final CompactClusterLevelNodeSummary node) {
-            nodeProfileSummaries.add(node);
-            if (minNode == null) {
-                minNode = node;
-            } else {
-                if (getMinTemperature().isGreaterThan(
-                        node.getTemperatureForDimension(profileForDimension))) {
-                    minNode = node;
-                }
-            }
-
-            if (maxNode == null) {
-                maxNode = node;
-            } else {
-                if (node.getTemperatureForDimension(profileForDimension).isGreaterThan(
-                        getMaxTemperature())) {
-                    maxNode = node;
-                }
-            }
-        }
-
-        @Nullable
-        TemperatureVector.NormalizedValue getMinTemperature() {
-            if (minNode != null) {
-                return minNode.getTemperatureForDimension(profileForDimension);
-            }
-            return null;
-        }
-
-        @Nullable
-        TemperatureVector.NormalizedValue getMaxTemperature() {
-            if (maxNode != null) {
-                return maxNode.getTemperatureForDimension(profileForDimension);
-            }
-            return null;
-        }
-
-        @Override
-        public <T extends GeneratedMessageV3> T buildSummaryMessage() {
-            throw new IllegalArgumentException("");
-        }
-
-        @Override
-        public void buildSummaryMessageAndAddToFlowUnit(FlowUnitMessage.Builder messageBuilder) {
-            throw new IllegalArgumentException("");
-        }
-
-        @Override
-        public String getTableName() {
-            return ZONE_PROFILE_TABLE_NAME;
-        }
-
-        private List<Field<?>> getColumns() {
-            List<Field<?>> schema = new ArrayList<>();
-            schema.add(DSL.field(DSL.name(ZONE_KEY), String.class));
-            schema.add(DSL.field(DSL.name(MIN_KEY), String.class));
-            schema.add(DSL.field(DSL.name(MAX_KEY), String.class));
-            schema.add(DSL.field(DSL.name(ALL_NODES_KEY), String.class));
-            return schema;
-        }
-
-        @Override
-        public List<Field<?>> getSqlSchema() {
-            return getColumns();
-        }
-
-        private JsonObject getNodeJson(CompactClusterLevelNodeSummary nodeSummary) {
-            JsonObject jsonObject = new JsonObject();
-
-            jsonObject.addProperty(HotNodeSummary.SQL_SCHEMA_CONSTANTS.HOST_IP_ADDRESS_COL_NAME,
-                    nodeSummary.getHostAddress());
-            jsonObject.addProperty(HotNodeSummary.SQL_SCHEMA_CONSTANTS.NODE_ID_COL_NAME,
-                    nodeSummary.getNodeId());
-
-            return jsonObject;
-        }
-
-        private JsonArray getAllNodesJson() {
-            JsonArray jsonArray = new JsonArray();
-            for (CompactClusterLevelNodeSummary nodeSummary : nodeProfileSummaries) {
-                jsonArray.add(getNodeJson(nodeSummary));
-            }
-            return jsonArray;
-        }
-
-        private String getAllNodesString(final JsonArray json) {
-            // The gson API throws an error while converting JSON to string if the Json array has
-            // more than one element.
-            StringBuilder sb = new StringBuilder();
-
-            String delim = "[";
-            for (JsonElement elem : json) {
-                JsonObject obj = elem.getAsJsonObject();
-                sb.append(delim).append(obj);
-                delim = ",";
-            }
-            if (sb.length() > 0) {
-                sb.append("]");
-            }
-            return sb.toString();
-        }
-
-        @Override
-        public List<Object> getSqlValue() {
-            List<Object> values = new ArrayList<>();
-            values.add(myZone.name());
-            values.add(minNode == null ? "" : minNode.getHostAddress());
-            values.add(maxNode == null ? "" : maxNode.getHostAddress());
-
-            JsonArray allNodes = getAllNodesJson();
-            String allNodesStr = getAllNodesString(allNodes);
-            values.add(allNodesStr);
-
-            return values;
-        }
-
-        @Override
-        public JsonElement toJson() {
-            JsonObject summaryObj = new JsonObject();
-            summaryObj.addProperty(ZONE_KEY, myZone.name());
-
-            if (minNode == maxNode) {
-                summaryObj.add(MIN_KEY, null);
-                summaryObj.add(MAX_KEY, null);
-            } else {
-                summaryObj.add(MIN_KEY, minNode == null ? null : getNodeJson(minNode));
-                summaryObj.add(MAX_KEY, maxNode == null ? null : getNodeJson(maxNode));
-            }
-            summaryObj.add(ALL_NODES_KEY, getAllNodesJson());
-
-            return summaryObj;
-        }
+    private JsonArray getAllNodesJson() {
+      JsonArray jsonArray = new JsonArray();
+      for (CompactClusterLevelNodeSummary nodeSummary : nodeProfileSummaries) {
+        jsonArray.add(getNodeJson(nodeSummary));
+      }
+      return jsonArray;
     }
+
+    private String getAllNodesString(final JsonArray json) {
+      // The gson API throws an error while converting JSON to string if the Json array has
+      // more than one element.
+      StringBuilder sb = new StringBuilder();
+
+      String delim = "[";
+      for (JsonElement elem : json) {
+        JsonObject obj = elem.getAsJsonObject();
+        sb.append(delim).append(obj);
+        delim = ",";
+      }
+      if (sb.length() > 0) {
+        sb.append("]");
+      }
+      return sb.toString();
+    }
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/ClusterTemperatureSummary.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/ClusterTemperatureSummary.java
@@ -38,183 +38,186 @@ import org.jooq.impl.DSL;
  * tracked dimensions.
  */
 public class ClusterTemperatureSummary extends GenericSummary {
-    public static final String TABLE_NAME = ClusterTemperatureSummary.class.getSimpleName();
-    public static final String NUM_NODES = "num_nodes";
 
-    private final ClusterDimensionalSummary[] nodeDimensionalTemperatureSummaries;
+  public static final String TABLE_NAME = ClusterTemperatureSummary.class.getSimpleName();
+  public static final String NUM_NODES = "num_nodes";
 
-    /**
-     * This is the summary of all the nodes in the cluster.
-     */
-    private final CompactClusterLevelNodeSummary[] nodes;
+  private final ClusterDimensionalSummary[] nodeDimensionalTemperatureSummaries;
 
-    private int numberOfNodes;
+  /**
+   * This is the summary of all the nodes in the cluster.
+   */
+  private final CompactClusterLevelNodeSummary[] nodes;
 
-    public ClusterTemperatureSummary(int numberOfNodes) {
-        this.numberOfNodes = numberOfNodes;
-        this.nodeDimensionalTemperatureSummaries =
-                new ClusterDimensionalSummary[TemperatureVector.Dimension.values().length];
-        this.nodes = new CompactClusterLevelNodeSummary[this.numberOfNodes];
+  private int numberOfNodes;
+
+  public ClusterTemperatureSummary(int numberOfNodes) {
+    this.numberOfNodes = numberOfNodes;
+    this.nodeDimensionalTemperatureSummaries =
+        new ClusterDimensionalSummary[TemperatureVector.Dimension.values().length];
+    this.nodes = new CompactClusterLevelNodeSummary[this.numberOfNodes];
+  }
+
+  private static List<Field<?>> getColumns() {
+    List<Field<?>> schema = new ArrayList<>();
+    schema.add(DSL.field(DSL.name(NUM_NODES), Short.class));
+    return schema;
+  }
+
+  /**
+   * The ClusterTemperatureSummary is stored in the SQLite file as three columns:
+   * ClusterTemperatureSummary_ID | num_nodes | RCA_ID
+   *
+   * <p>where column 1 is the primary key of this table. The RCA_ID ties this instance of summary
+   * to an an instance of ClusterTemperatureRCA.
+   *
+   * @param records The table of records. It should only contain one row for a given RCA_ID.
+   * @param context The Database connection context.
+   * @return The Summary object with other nested objects.
+   */
+  public static ClusterTemperatureSummary buildSummaryFromDatabase(Result<Record> records,
+      DSLContext context) {
+    int numNodes = -1;
+
+    if (records.size() > 1) {
+      throw new IllegalArgumentException("Only 1 ClusterTemperatureSummary expected." + records);
     }
 
-    public void createClusterDimensionalTemperature(TemperatureVector.Dimension dimension,
-                                                    TemperatureVector.NormalizedValue mean,
-                                                    double totalUsage) {
-        ClusterDimensionalSummary summary = new ClusterDimensionalSummary(dimension);
-        summary.setMeanTemperature(mean);
-        summary.setTotalUsage(totalUsage);
-        nodeDimensionalTemperatureSummaries[dimension.ordinal()] = summary;
+    Record record = records.get(0);
+    for (Field<?> field : getColumns()) {
+      numNodes = record.get(field, Integer.class);
+    }
+    ClusterTemperatureSummary summary = new ClusterTemperatureSummary(numNodes);
+
+    String dimensionalTablename = ClusterDimensionalSummary.TABLE_NAME;
+    int clusterTemperatureID =
+        record.get(SQLiteQueryUtils.getPrimaryKeyColumnName(TABLE_NAME), Integer.class);
+
+    Field<Integer> foreignKeyForDimensionalTable = DSL.field(
+        SQLiteQueryUtils.getPrimaryKeyColumnName(TABLE_NAME), Integer.class);
+
+    SelectJoinStep<Record> rcaQuery = SQLiteQueryUtils
+        .buildSummaryQuery(context, dimensionalTablename, clusterTemperatureID,
+            foreignKeyForDimensionalTable);
+
+    Result<Record> recordList = rcaQuery.fetch();
+
+    for (Record record1 : recordList) {
+      ClusterDimensionalSummary dimSummary =
+          ClusterDimensionalSummary.build(record1, context);
+
+      summary.nodeDimensionalTemperatureSummaries[dimSummary.getProfileForDimension()
+                                                            .ordinal()] = dimSummary;
     }
 
-    // The String key is the node ID.
-    public void addNodesSummaries(Map<String, CompactClusterLevelNodeSummary> nodeTemperatureSummaries) {
-        int i = 0;
-        for (CompactClusterLevelNodeSummary nodeTemperatureSummaryVal :
-                nodeTemperatureSummaries.values()) {
-            for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
-                nodeDimensionalTemperatureSummaries[dimension.ordinal()].addNodeToZone(nodeTemperatureSummaryVal);
-            }
-            nodes[i] = nodeTemperatureSummaryVal;
-            i++;
-        }
+    rcaQuery = SQLiteQueryUtils
+        .buildSummaryQuery(context, CompactClusterLevelNodeSummary.class.getSimpleName(),
+            clusterTemperatureID,
+            foreignKeyForDimensionalTable);
+
+    recordList = rcaQuery.fetch();
+    List<CompactClusterLevelNodeSummary> nodeSummaries = new ArrayList<>();
+    for (Record record1 : recordList) {
+      CompactClusterLevelNodeSummary nodeSummary = CompactClusterLevelNodeSummary.build(record1);
+      nodeSummaries.add(nodeSummary);
+    }
+    summary.addNodeSummaries(nodeSummaries);
+    return summary;
+  }
+
+  public void createClusterDimensionalTemperature(TemperatureVector.Dimension dimension,
+      TemperatureVector.NormalizedValue mean,
+      double totalUsage) {
+    ClusterDimensionalSummary summary = new ClusterDimensionalSummary(dimension);
+    summary.setMeanTemperature(mean);
+    summary.setTotalUsage(totalUsage);
+    nodeDimensionalTemperatureSummaries[dimension.ordinal()] = summary;
+  }
+
+  // The String key is the node ID.
+  public void addNodesSummaries(
+      Map<String, CompactClusterLevelNodeSummary> nodeTemperatureSummaries) {
+    int i = 0;
+    for (CompactClusterLevelNodeSummary nodeTemperatureSummaryVal :
+        nodeTemperatureSummaries.values()) {
+      for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
+        nodeDimensionalTemperatureSummaries[dimension.ordinal()]
+            .addNodeToZone(nodeTemperatureSummaryVal);
+      }
+      nodes[i] = nodeTemperatureSummaryVal;
+      i++;
+    }
+  }
+
+  public void addNodeSummaries(List<CompactClusterLevelNodeSummary> nodeSummaries) {
+    int i = 0;
+    for (CompactClusterLevelNodeSummary nodeSummary : nodeSummaries) {
+      nodes[i] = nodeSummary;
+      i++;
+    }
+  }
+
+  public List<GenericSummary> getNestedSummaryList() {
+    List<GenericSummary> summaries = new ArrayList<>();
+
+    for (GenericSummary summary : nodeDimensionalTemperatureSummaries) {
+      summaries.add(summary);
     }
 
-    public void addNodeSummaries(List<CompactClusterLevelNodeSummary> nodeSummaries) {
-        int i = 0;
-        for (CompactClusterLevelNodeSummary nodeSummary : nodeSummaries) {
-            nodes[i] = nodeSummary;
-            i++;
-        }
+    for (GenericSummary summary : nodes) {
+      summaries.add(summary);
+    }
+    return summaries;
+  }
+
+  @Override
+  public <T extends GeneratedMessageV3> T buildSummaryMessage() {
+    throw new IllegalArgumentException();
+  }
+
+  @Override
+  public void buildSummaryMessageAndAddToFlowUnit(FlowUnitMessage.Builder messageBuilder) {
+    throw new IllegalArgumentException();
+  }
+
+  @Override
+  public String getTableName() {
+    return TABLE_NAME;
+  }
+
+  @Override
+  public List<Field<?>> getSqlSchema() {
+    return getColumns();
+  }
+
+  @Override
+  public List<Object> getSqlValue() {
+    List<Object> values = new ArrayList<>();
+    values.add(numberOfNodes);
+    return values;
+  }
+
+  @Override
+  public JsonElement toJson() {
+    JsonObject summaryObj = new JsonObject();
+
+    JsonArray dimTempArray = new JsonArray();
+    for (ClusterDimensionalSummary summary : nodeDimensionalTemperatureSummaries) {
+      dimTempArray.add(summary.toJson());
+    }
+    if (dimTempArray.size() > 0) {
+      summaryObj.add(ClusterDimensionalSummary.TABLE_NAME, dimTempArray);
     }
 
-    public List<GenericSummary> getNestedSummaryList() {
-        List<GenericSummary> summaries = new ArrayList<>();
-
-        for (GenericSummary summary : nodeDimensionalTemperatureSummaries) {
-            summaries.add(summary);
-        }
-
-        for (GenericSummary summary : nodes) {
-            summaries.add(summary);
-        }
-        return summaries;
+    JsonArray nodesArr = new JsonArray();
+    String elemName = "";
+    for (CompactClusterLevelNodeSummary nodeSummary : nodes) {
+      nodesArr.add(nodeSummary.toJson());
+      elemName = nodeSummary.TABLE_NAME;
     }
-
-    @Override
-    public <T extends GeneratedMessageV3> T buildSummaryMessage() {
-        throw new IllegalArgumentException();
+    if (!elemName.isEmpty()) {
+      summaryObj.add(elemName, nodesArr);
     }
-
-    @Override
-    public void buildSummaryMessageAndAddToFlowUnit(FlowUnitMessage.Builder messageBuilder) {
-        throw new IllegalArgumentException();
-    }
-
-    @Override
-    public String getTableName() {
-        return TABLE_NAME;
-    }
-
-    private static List<Field<?>> getColumns() {
-        List<Field<?>> schema = new ArrayList<>();
-        schema.add(DSL.field(DSL.name(NUM_NODES), Short.class));
-        return schema;
-    }
-
-    @Override
-    public List<Field<?>> getSqlSchema() {
-        return getColumns();
-    }
-
-    @Override
-    public List<Object> getSqlValue() {
-        List<Object> values = new ArrayList<>();
-        values.add(numberOfNodes);
-        return values;
-    }
-
-    @Override
-    public JsonElement toJson() {
-        JsonObject summaryObj = new JsonObject();
-
-        JsonArray dimTempArray = new JsonArray();
-        for (ClusterDimensionalSummary summary : nodeDimensionalTemperatureSummaries) {
-            dimTempArray.add(summary.toJson());
-        }
-        if (dimTempArray.size() > 0) {
-            summaryObj.add(ClusterDimensionalSummary.TABLE_NAME, dimTempArray);
-        }
-
-        JsonArray nodesArr = new JsonArray();
-        String elemName = "";
-        for (CompactClusterLevelNodeSummary nodeSummary : nodes) {
-            nodesArr.add(nodeSummary.toJson());
-            elemName = nodeSummary.TABLE_NAME;
-        }
-        if (!elemName.isEmpty()) {
-            summaryObj.add(elemName, nodesArr);
-        }
-        return summaryObj;
-    }
-
-    /**
-     * The ClusterTemperatureSummary is stored in the SQLite file as three columns:
-     * ClusterTemperatureSummary_ID | num_nodes | RCA_ID
-     *
-     * <p>where column 1 is the primary key of this table. The RCA_ID ties this instance of summary
-     * to an an instance of ClusterTemperatureRCA.
-     *
-     * @param records The table of records. It should only contain one row for a given RCA_ID.
-     * @param context The Database connection context.
-     * @return The Summary object with other nested objects.
-     */
-    public static ClusterTemperatureSummary buildSummaryFromDatabase(Result<Record> records,
-                                                                     DSLContext context) {
-        int numNodes = -1;
-
-        if (records.size() > 1) {
-            throw new IllegalArgumentException("Only 1 ClusterTemperatureSummary expected." + records);
-        }
-
-        Record record = records.get(0);
-        for (Field<?> field : getColumns()) {
-            numNodes = record.get(field, Integer.class);
-        }
-        ClusterTemperatureSummary summary = new ClusterTemperatureSummary(numNodes);
-
-        String dimensionalTablename = ClusterDimensionalSummary.TABLE_NAME;
-        int clusterTemperatureID =
-                record.get(SQLiteQueryUtils.getPrimaryKeyColumnName(TABLE_NAME), Integer.class);
-
-        Field<Integer> foreignKeyForDimensionalTable = DSL.field(
-                SQLiteQueryUtils.getPrimaryKeyColumnName(TABLE_NAME), Integer.class);
-
-
-        SelectJoinStep<Record> rcaQuery = SQLiteQueryUtils
-                .buildSummaryQuery(context, dimensionalTablename, clusterTemperatureID,
-                        foreignKeyForDimensionalTable);
-
-        Result<Record> recordList = rcaQuery.fetch();
-
-        for (Record record1 : recordList) {
-            ClusterDimensionalSummary dimSummary =
-                    ClusterDimensionalSummary.build(record1, context);
-
-            summary.nodeDimensionalTemperatureSummaries[dimSummary.getProfileForDimension().ordinal()] = dimSummary;
-        }
-
-        rcaQuery = SQLiteQueryUtils
-                .buildSummaryQuery(context, CompactClusterLevelNodeSummary.class.getSimpleName(),
-                        clusterTemperatureID,
-                        foreignKeyForDimensionalTable);
-
-        recordList = rcaQuery.fetch();
-        List<CompactClusterLevelNodeSummary> nodeSummaries = new ArrayList<>();
-        for (Record record1 : recordList) {
-            CompactClusterLevelNodeSummary nodeSummary = CompactClusterLevelNodeSummary.build(record1);
-            nodeSummaries.add(nodeSummary);
-        }
-        summary.addNodeSummaries(nodeSummaries);
-        return summary;
-    }
+    return summaryObj;
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/CompactClusterLevelNodeSummary.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/CompactClusterLevelNodeSummary.java
@@ -26,47 +26,48 @@ import org.jooq.exception.DataTypeException;
 
 /**
  * This object is instantiated on the elected master. This is the master's view of the {@code
- * CompactNodeSummary}. The difference is that, the CompactNodeSummary is based on on the node
- * level resource utilization by the shards and the {@code CompactClusterLevelNodeSummary} is
- * based on the utilization across multiple nodes in the cluster.
+ * CompactNodeSummary}. The difference is that, the CompactNodeSummary is based on on the node level
+ * resource utilization by the shards and the {@code CompactClusterLevelNodeSummary} is based on the
+ * utilization across multiple nodes in the cluster.
  */
 public class CompactClusterLevelNodeSummary extends CompactNodeSummary {
-    private static final Logger LOG = LogManager.getLogger(CompactClusterLevelNodeSummary.class);
 
-    public final String TABLE_NAME =
-            CompactClusterLevelNodeSummary.class.getSimpleName();
+  private static final Logger LOG = LogManager.getLogger(CompactClusterLevelNodeSummary.class);
 
-    public CompactClusterLevelNodeSummary(String nodeId, String hostAddress) {
-        super(nodeId, hostAddress);
+  public final String TABLE_NAME =
+      CompactClusterLevelNodeSummary.class.getSimpleName();
+
+  public CompactClusterLevelNodeSummary(String nodeId, String hostAddress) {
+    super(nodeId, hostAddress);
+  }
+
+  /**
+   * CompactClusterLevelNodeSummary_ID|node_id|host_address|CPU_Utilization
+   * |CPU_Utilization_total|..
+   *
+   * @param record A database record
+   * @return Summary object constructed from the database row
+   */
+  public static CompactClusterLevelNodeSummary build(Record record) {
+    String nodeId = record.get(NODE_ID_COL_NAME, String.class);
+    String hostIp = record.get(HOST_IP_ADDRESS_COL_NAME, String.class);
+
+    CompactClusterLevelNodeSummary summary = new CompactClusterLevelNodeSummary(nodeId, hostIp);
+
+    for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
+      try {
+        Short mean = record.get(dimension.NAME + MEAN_SUFFIX_KEY, Short.class);
+        double total = record.get(dimension.NAME + TOTAL_SUFFIX_KEY, Double.class);
+        int num_shards = record.get(dimension.NAME + NUM_SHARDS_SUFFIX_KEY, Integer.class);
+
+        summary.setNumOfShards(dimension, num_shards);
+        summary.setTemperatureForDimension(dimension,
+            new TemperatureVector.NormalizedValue(mean));
+        summary.setTotalConsumedByDimension(dimension, total);
+      } catch (DataTypeException dex) {
+        LOG.error("Could not create valid summary object.", dex);
+      }
     }
-
-    /**
-     * CompactClusterLevelNodeSummary_ID|node_id|host_address|CPU_Utilization
-     * |CPU_Utilization_total|..
-     *
-     * @param record A database record
-     * @return Summary object constructed from the database row
-     */
-    public static CompactClusterLevelNodeSummary build(Record record) {
-        String nodeId = record.get(NODE_ID_COL_NAME, String.class);
-        String hostIp = record.get(HOST_IP_ADDRESS_COL_NAME, String.class);
-
-        CompactClusterLevelNodeSummary summary = new CompactClusterLevelNodeSummary(nodeId, hostIp);
-
-        for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
-            try {
-                Short mean = record.get(dimension.NAME + MEAN_SUFFIX_KEY, Short.class);
-                double total = record.get(dimension.NAME + TOTAL_SUFFIX_KEY, Double.class);
-                int num_shards = record.get(dimension.NAME + NUM_SHARDS_SUFFIX_KEY, Integer.class);
-
-                summary.setNumOfShards(dimension, num_shards);
-                summary.setTemperatureForDimension(dimension,
-                        new TemperatureVector.NormalizedValue(mean));
-                summary.setTotalConsumedByDimension(dimension, total);
-            } catch (DataTypeException dex) {
-                LOG.error("Could not create valid summary object.", dex);
-            }
-        }
-        return summary;
-    }
+    return summary;
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/CompactNodeSummary.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/CompactNodeSummary.java
@@ -21,6 +21,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceTemp
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector.NormalizedValue;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import java.util.ArrayList;
@@ -31,190 +32,195 @@ import org.jooq.impl.DSL;
 
 /**
  * This is created at two places - on each node and again on the cluster. On the node we have the
- * full resolution with dimensions and zones in each dimensions and then shards in zones. But on
- * the elected master we only have the temperature of a node and not zone or shard level
- * information. So, this summary is kept generic so that both can use it.
+ * full resolution with dimensions and zones in each dimensions and then shards in zones. But on the
+ * elected master we only have the temperature of a node and not zone or shard level information.
+ * So, this summary is kept generic so that both can use it.
  */
 public class CompactNodeSummary extends GenericSummary {
-    /**
-     * This will determine the name of the SQLite when this summary is persisted.
-     */
-    public final String TABLE_NAME = CompactNodeSummary.class.getSimpleName();
 
-    protected final String nodeId;
-    protected final String hostAddress;
+  public static final String MEAN_SUFFIX_KEY = "_mean";
+  public static final String TOTAL_SUFFIX_KEY = "_total";
+  public static final String NUM_SHARDS_SUFFIX_KEY = "_num_shards";
+  /**
+   * This will determine the name of the SQLite when this summary is persisted.
+   */
+  public final String TABLE_NAME = CompactNodeSummary.class.getSimpleName();
+  protected final String nodeId;
+  protected final String hostAddress;
+  protected TemperatureVector temperatureVector;
+  /**
+   * This is the actual usage. temperature vector is a normalized value and without the context of
+   * total used, it means nothing.
+   */
+  protected double totalConsumedByDimension[];
+  protected int numOfShards[];
 
-    protected TemperatureVector temperatureVector;
+  public CompactNodeSummary(final String nodeId, final String hostAddress) {
+    super();
+    this.nodeId = nodeId;
+    this.hostAddress = hostAddress;
+    this.temperatureVector = new TemperatureVector();
+    this.totalConsumedByDimension = new double[TemperatureVector.Dimension.values().length];
+    this.numOfShards = new int[TemperatureVector.Dimension.values().length];
+  }
 
-    /**
-     * This is the actual usage. temperature vector is a normalized value and without the
-     * context of total used, it means nothing.
-     */
-    protected double totalConsumedByDimension[];
-    protected int numOfShards[];
+  public static CompactNodeSummary buildNodeTemperatureProfileFromMessage(
+      NodeTemperatureSummaryMessage message) {
+    CompactNodeSummary compactNodeTemperatureSummary =
+        new CompactNodeSummary(message.getNodeID(), message.getHostAddress());
 
+    compactNodeTemperatureSummary.totalConsumedByDimension = new double[TemperatureVector.Dimension
+        .values().length];
+    compactNodeTemperatureSummary.numOfShards = new int[TemperatureVector.Dimension
+        .values().length];
+    for (ResourceTemperatureMessage resourceMessage : message.getCpuTemperatureList()) {
+      TemperatureVector.Dimension dimension =
+          TemperatureVector.Dimension.valueOf(resourceMessage.getResourceName());
+      compactNodeTemperatureSummary.temperatureVector.updateTemperatureForDimension(dimension,
+          new TemperatureVector.NormalizedValue((short) resourceMessage.getMeanUsage()));
+      compactNodeTemperatureSummary.totalConsumedByDimension[dimension.ordinal()] =
+          resourceMessage.getTotalUsage();
+      compactNodeTemperatureSummary.numOfShards[dimension.ordinal()] =
+          resourceMessage.getNumberOfShards();
+    }
+    return compactNodeTemperatureSummary;
+  }
 
-    public static final String MEAN_SUFFIX_KEY = "_mean";
-    public static final String TOTAL_SUFFIX_KEY = "_total";
-    public static final String NUM_SHARDS_SUFFIX_KEY = "_num_shards";
+  public void fillFromNodeProfile(final FullNodeTemperatureSummary nodeProfile) {
+    this.temperatureVector = nodeProfile.getTemperatureVector();
+    this.totalConsumedByDimension = new double[TemperatureVector.Dimension.values().length];
+    this.numOfShards = new int[TemperatureVector.Dimension.values().length];
+    for (NodeLevelDimensionalSummary nodeDimensionProfile : nodeProfile
+        .getNodeDimensionProfiles()) {
+      if (nodeDimensionProfile != null) {
+        int index = nodeDimensionProfile.getProfileForDimension().ordinal();
+        totalConsumedByDimension[index] = nodeDimensionProfile.getTotalUsage();
+        numOfShards[index] = nodeDimensionProfile.getNumberOfShards();
+      }
+    }
+  }
 
-    public CompactNodeSummary(final String nodeId, final String hostAddress) {
-        super();
-        this.nodeId = nodeId;
-        this.hostAddress = hostAddress;
-        this.temperatureVector = new TemperatureVector();
-        this.totalConsumedByDimension = new double[TemperatureVector.Dimension.values().length];
-        this.numOfShards = new int[TemperatureVector.Dimension.values().length];
+  public double getTotalConsumedByDimension(TemperatureVector.Dimension dimension) {
+    return totalConsumedByDimension[dimension.ordinal()];
+  }
+
+  public String getHostAddress() {
+    return hostAddress;
+  }
+
+  public void setTotalConsumedByDimension(TemperatureVector.Dimension dimension,
+      double totalConsumedByDimension) {
+    this.totalConsumedByDimension[dimension.ordinal()] = totalConsumedByDimension;
+  }
+
+  public void setNumOfShards(TemperatureVector.Dimension dimension, int numOfShards) {
+    this.numOfShards[dimension.ordinal()] = numOfShards;
+  }
+
+  public int getNumberOfShardsByDimension(TemperatureVector.Dimension dimension) {
+    return numOfShards[dimension.ordinal()];
+  }
+
+  public void setTemperatureForDimension(TemperatureVector.Dimension dimension,
+      TemperatureVector.NormalizedValue value) {
+    temperatureVector.updateTemperatureForDimension(dimension, value);
+  }
+
+  public String getNodeId() {
+    return nodeId;
+  }
+
+  public @Nullable
+  TemperatureVector.NormalizedValue getTemperatureForDimension(
+      TemperatureVector.Dimension dimension) {
+    return temperatureVector.getTemperatureFor(dimension);
+  }
+
+  @Override
+  public NodeTemperatureSummaryMessage buildSummaryMessage() {
+    if (totalConsumedByDimension == null) {
+      throw new IllegalArgumentException("totalConsumedByDimension is not initialized");
     }
 
-    public void fillFromNodeProfile(final FullNodeTemperatureSummary nodeProfile) {
-        this.temperatureVector = nodeProfile.getTemperatureVector();
-        this.totalConsumedByDimension = new double[TemperatureVector.Dimension.values().length];
-        this.numOfShards = new int[TemperatureVector.Dimension.values().length];
-        for (NodeLevelDimensionalSummary nodeDimensionProfile : nodeProfile.getNodeDimensionProfiles()) {
-            if (nodeDimensionProfile != null) {
-                int index = nodeDimensionProfile.getProfileForDimension().ordinal();
-                totalConsumedByDimension[index] = nodeDimensionProfile.getTotalUsage();
-                numOfShards[index] = nodeDimensionProfile.getNumberOfShards();
-            }
-        }
+    final NodeTemperatureSummaryMessage.Builder summaryBuilder =
+        NodeTemperatureSummaryMessage.newBuilder();
+    summaryBuilder.setNodeID(nodeId);
+    summaryBuilder.setHostAddress(hostAddress);
+
+    for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
+      int index = dimension.ordinal();
+      ResourceTemperatureMessage.Builder builder = ResourceTemperatureMessage.newBuilder();
+      builder.setResourceName(dimension.NAME);
+      NormalizedValue normalizedValue = temperatureVector.getTemperatureFor(dimension);
+      builder.setMeanUsage(normalizedValue == null ? 0 : normalizedValue.getPOINTS());
+      builder.setNumberOfShards(numOfShards[index]);
+      builder.setTotalUsage(totalConsumedByDimension[index]);
+      summaryBuilder.addCpuTemperature(index, builder);
     }
+    return summaryBuilder.build();
+  }
 
-    public double getTotalConsumedByDimension(TemperatureVector.Dimension dimension) {
-        return totalConsumedByDimension[dimension.ordinal()];
+  @Override
+  public void buildSummaryMessageAndAddToFlowUnit(FlowUnitMessage.Builder messageBuilder) {
+    messageBuilder.setNodeTemperatureSummary(buildSummaryMessage());
+  }
+
+  @Override
+  public String getTableName() {
+    return TABLE_NAME;
+  }
+
+  /**
+   * @return Returns a list of columns that this table would contain.
+   */
+  @Override
+  public List<Field<?>> getSqlSchema() {
+    List<Field<?>> schema = new ArrayList<>();
+    schema.add(
+        DSL.field(DSL.name(HotNodeSummary.SQL_SCHEMA_CONSTANTS.NODE_ID_COL_NAME), String.class));
+    schema.add(DSL.field(DSL.name(HotNodeSummary.SQL_SCHEMA_CONSTANTS.HOST_IP_ADDRESS_COL_NAME),
+        String.class));
+
+    for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
+      schema.add(DSL.field(DSL.name(dimension.NAME + MEAN_SUFFIX_KEY), String.class));
+      schema.add(DSL.field(DSL.name(dimension.NAME + TOTAL_SUFFIX_KEY), String.class));
+      schema.add(DSL.field(DSL.name(dimension.NAME + NUM_SHARDS_SUFFIX_KEY), String.class));
     }
+    return schema;
+  }
 
-    public String getHostAddress() {
-        return hostAddress;
+  @Override
+  public List<Object> getSqlValue() {
+    List<Object> value = new ArrayList<>();
+    value.add(nodeId);
+    value.add(hostAddress);
+
+    for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
+      value.add(temperatureVector.getTemperatureFor(dimension));
+      value.add(totalConsumedByDimension[dimension.ordinal()]);
+      value.add(numOfShards[dimension.ordinal()]);
     }
+    return value;
+  }
 
-    public void setTotalConsumedByDimension(TemperatureVector.Dimension dimension,
-                                            double totalConsumedByDimension) {
-        this.totalConsumedByDimension[dimension.ordinal()] = totalConsumedByDimension;
+  @Override
+  public JsonElement toJson() {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty(HotNodeSummary.SQL_SCHEMA_CONSTANTS.NODE_ID_COL_NAME, nodeId);
+    jsonObject
+        .addProperty(HotNodeSummary.SQL_SCHEMA_CONSTANTS.HOST_IP_ADDRESS_COL_NAME, hostAddress);
+
+    for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
+      TemperatureVector.NormalizedValue ret = temperatureVector.getTemperatureFor(dimension);
+      if (ret == null) {
+        ret = new TemperatureVector.NormalizedValue((short) 0);
+      }
+      jsonObject.addProperty(dimension.NAME + MEAN_SUFFIX_KEY, ret.getPOINTS());
+      jsonObject.addProperty(dimension.NAME + TOTAL_SUFFIX_KEY,
+          totalConsumedByDimension[dimension.ordinal()]);
+      jsonObject
+          .addProperty(dimension.NAME + NUM_SHARDS_SUFFIX_KEY, numOfShards[dimension.ordinal()]);
     }
-
-    public void setNumOfShards(TemperatureVector.Dimension dimension, int numOfShards) {
-        this.numOfShards[dimension.ordinal()] = numOfShards;
-    }
-
-    public int getNumberOfShardsByDimension(TemperatureVector.Dimension dimension) {
-        return numOfShards[dimension.ordinal()];
-    }
-
-    public void setTemperatureForDimension(TemperatureVector.Dimension dimension,
-                                           TemperatureVector.NormalizedValue value) {
-        temperatureVector.updateTemperatureForDimension(dimension, value);
-    }
-
-    public String getNodeId() {
-        return nodeId;
-    }
-
-    public @Nullable
-    TemperatureVector.NormalizedValue getTemperatureForDimension(TemperatureVector.Dimension dimension) {
-        return temperatureVector.getTemperatureFor(dimension);
-    }
-
-    @Override
-    public NodeTemperatureSummaryMessage buildSummaryMessage() {
-        if (totalConsumedByDimension == null) {
-            throw new IllegalArgumentException("totalConsumedByDimension is not initialized");
-        }
-
-        final NodeTemperatureSummaryMessage.Builder summaryBuilder =
-                NodeTemperatureSummaryMessage.newBuilder();
-        summaryBuilder.setNodeID(nodeId);
-        summaryBuilder.setHostAddress(hostAddress);
-
-
-        for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
-            int index = dimension.ordinal();
-            ResourceTemperatureMessage.Builder builder = ResourceTemperatureMessage.newBuilder();
-            builder.setResourceName(dimension.NAME);
-            builder.setMeanUsage(temperatureVector.getTemperatureFor(dimension).getPOINTS());
-            builder.setNumberOfShards(numOfShards[index]);
-            builder.setTotalUsage(totalConsumedByDimension[index]);
-            summaryBuilder.setCpuTemperature(index, builder);
-        }
-        return summaryBuilder.build();
-    }
-
-    @Override
-    public void buildSummaryMessageAndAddToFlowUnit(FlowUnitMessage.Builder messageBuilder) {
-        messageBuilder.setNodeTemperatureSummary(buildSummaryMessage());
-    }
-
-    @Override
-    public String getTableName() {
-        return TABLE_NAME;
-    }
-
-    public static CompactNodeSummary buildNodeTemperatureProfileFromMessage(NodeTemperatureSummaryMessage message) {
-        CompactNodeSummary compactNodeTemperatureSummary =
-                new CompactNodeSummary(message.getNodeID(), message.getHostAddress());
-
-        compactNodeTemperatureSummary.totalConsumedByDimension = new double[TemperatureVector.Dimension.values().length];
-        compactNodeTemperatureSummary.numOfShards = new int[TemperatureVector.Dimension.values().length];
-        for (ResourceTemperatureMessage resourceMessage : message.getCpuTemperatureList()) {
-            TemperatureVector.Dimension dimension =
-                    TemperatureVector.Dimension.valueOf(resourceMessage.getResourceName());
-            compactNodeTemperatureSummary.temperatureVector.updateTemperatureForDimension(dimension,
-                    new TemperatureVector.NormalizedValue((short) resourceMessage.getMeanUsage()));
-            compactNodeTemperatureSummary.totalConsumedByDimension[dimension.ordinal()] =
-                    resourceMessage.getTotalUsage();
-            compactNodeTemperatureSummary.numOfShards[dimension.ordinal()] =
-                    resourceMessage.getNumberOfShards();
-        }
-        return compactNodeTemperatureSummary;
-    }
-
-    /**
-     * @return Returns a list of columns that this table would contain.
-     */
-    @Override
-    public List<Field<?>> getSqlSchema() {
-        List<Field<?>> schema = new ArrayList<>();
-        schema.add(DSL.field(DSL.name(HotNodeSummary.SQL_SCHEMA_CONSTANTS.NODE_ID_COL_NAME), String.class));
-        schema.add(DSL.field(DSL.name(HotNodeSummary.SQL_SCHEMA_CONSTANTS.HOST_IP_ADDRESS_COL_NAME), String.class));
-
-        for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
-            schema.add(DSL.field(DSL.name(dimension.NAME + MEAN_SUFFIX_KEY), String.class));
-            schema.add(DSL.field(DSL.name(dimension.NAME + TOTAL_SUFFIX_KEY), String.class));
-            schema.add(DSL.field(DSL.name(dimension.NAME + NUM_SHARDS_SUFFIX_KEY), String.class));
-        }
-        return schema;
-    }
-
-    @Override
-    public List<Object> getSqlValue() {
-        List<Object> value = new ArrayList<>();
-        value.add(nodeId);
-        value.add(hostAddress);
-
-        for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
-            value.add(temperatureVector.getTemperatureFor(dimension));
-            value.add(totalConsumedByDimension[dimension.ordinal()]);
-            value.add(numOfShards[dimension.ordinal()]);
-        }
-        return value;
-    }
-
-    @Override
-    public JsonElement toJson() {
-        JsonObject jsonObject = new JsonObject();
-        jsonObject.addProperty(HotNodeSummary.SQL_SCHEMA_CONSTANTS.NODE_ID_COL_NAME, nodeId);
-        jsonObject.addProperty(HotNodeSummary.SQL_SCHEMA_CONSTANTS.HOST_IP_ADDRESS_COL_NAME, hostAddress);
-
-        for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
-            TemperatureVector.NormalizedValue ret = temperatureVector.getTemperatureFor(dimension);
-            if (ret == null) {
-                ret = new TemperatureVector.NormalizedValue((short) 0);
-            }
-            jsonObject.addProperty(dimension.NAME + MEAN_SUFFIX_KEY, ret.getPOINTS());
-            jsonObject.addProperty(dimension.NAME + TOTAL_SUFFIX_KEY,
-                    totalConsumedByDimension[dimension.ordinal()]);
-            jsonObject.addProperty(dimension.NAME + NUM_SHARDS_SUFFIX_KEY, numOfShards[dimension.ordinal()]);
-        }
-        return jsonObject;
-    }
+    return jsonObject;
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/FullNodeTemperatureSummary.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/FullNodeTemperatureSummary.java
@@ -28,106 +28,108 @@ import org.jooq.Field;
 import org.jooq.impl.DSL;
 
 public class FullNodeTemperatureSummary extends GenericSummary {
-    /**
-     * A node has a temperature profile of its own. The temperature profile of a node is the mean
-     * temperature along each dimension.
-     */
-    private final TemperatureVector temperatureVector;
 
-    /**
-     * A node also has the complete list of shards in each dimension, broken down by the
-     * different temperature zones.
-     */
-    private final NodeLevelDimensionalSummary[] nodeDimensionProfiles;
+  /**
+   * A node has a temperature profile of its own. The temperature profile of a node is the mean
+   * temperature along each dimension.
+   */
+  private final TemperatureVector temperatureVector;
 
-    private final String nodeId;
-    private final String hostAddress;
+  /**
+   * A node also has the complete list of shards in each dimension, broken down by the different
+   * temperature zones.
+   */
+  private final NodeLevelDimensionalSummary[] nodeDimensionProfiles;
 
-    public FullNodeTemperatureSummary(String nodeId, String hostAddress) {
-        this.nodeId = nodeId;
-        this.hostAddress = hostAddress;
-        this.nodeDimensionProfiles =
-                new NodeLevelDimensionalSummary[TemperatureVector.Dimension.values().length];
-        this.temperatureVector = new TemperatureVector();
+  private final String nodeId;
+  private final String hostAddress;
+
+  public FullNodeTemperatureSummary(String nodeId, String hostAddress) {
+    this.nodeId = nodeId;
+    this.hostAddress = hostAddress;
+    this.nodeDimensionProfiles =
+        new NodeLevelDimensionalSummary[TemperatureVector.Dimension.values().length];
+    this.temperatureVector = new TemperatureVector();
+  }
+
+  public TemperatureVector getTemperatureVector() {
+    return temperatureVector;
+  }
+
+  public List<NodeLevelDimensionalSummary> getNodeDimensionProfiles() {
+    return Arrays.asList(nodeDimensionProfiles);
+  }
+
+  public String getNodeId() {
+    return nodeId;
+  }
+
+  public String getHostAddress() {
+    return hostAddress;
+  }
+
+  public void updateNodeDimensionProfile(NodeLevelDimensionalSummary nodeDimensionProfile) {
+    TemperatureVector.Dimension dimension = nodeDimensionProfile.getProfileForDimension();
+    this.nodeDimensionProfiles[dimension.ordinal()] = nodeDimensionProfile;
+    temperatureVector
+        .updateTemperatureForDimension(dimension, nodeDimensionProfile.getMeanTemperature());
+  }
+
+  public List<GenericSummary> getNestedSummaryList() {
+    List<GenericSummary> dimensionalSummaries = new ArrayList<>();
+    for (NodeLevelDimensionalSummary dimSummary : nodeDimensionProfiles) {
+      dimensionalSummaries.add(dimSummary);
     }
+    return dimensionalSummaries;
+  }
 
-    public TemperatureVector getTemperatureVector() {
-        return temperatureVector;
+  @Override
+  public <T extends GeneratedMessageV3> T buildSummaryMessage() {
+    throw new IllegalArgumentException();
+  }
+
+  @Override
+  public void buildSummaryMessageAndAddToFlowUnit(FlowUnitMessage.Builder messageBuilder) {
+    throw new IllegalArgumentException();
+  }
+
+  @Override
+  public String getTableName() {
+    return this.getClass().getSimpleName();
+  }
+
+  @Override
+  public List<Field<?>> getSqlSchema() {
+    List<Field<?>> schema = new ArrayList<>();
+    for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
+      schema.add(DSL.field(DSL.name(dimension.NAME), Short.class));
     }
+    return schema;
+  }
 
-    public List<NodeLevelDimensionalSummary> getNodeDimensionProfiles() {
-        return Arrays.asList(nodeDimensionProfiles);
+  @Override
+  public List<Object> getSqlValue() {
+    List<Object> values = new ArrayList<>();
+    for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
+      values.add(temperatureVector.getTemperatureFor(dimension));
     }
+    return values;
+  }
 
-    public String getNodeId() {
-        return nodeId;
+  @Override
+  public JsonElement toJson() {
+    JsonObject summaryObj = new JsonObject();
+    for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
+      TemperatureVector.NormalizedValue value =
+          temperatureVector.getTemperatureFor(dimension);
+      summaryObj.addProperty(dimension.NAME,
+          value != null ? value.getPOINTS() : null);
     }
-
-    public String getHostAddress() {
-        return hostAddress;
-    }
-
-    public void updateNodeDimensionProfile(NodeLevelDimensionalSummary nodeDimensionProfile) {
-        TemperatureVector.Dimension dimension = nodeDimensionProfile.getProfileForDimension();
-        this.nodeDimensionProfiles[dimension.ordinal()] = nodeDimensionProfile;
-        temperatureVector.updateTemperatureForDimension(dimension, nodeDimensionProfile.getMeanTemperature());
-    }
-
-    public List<GenericSummary> getNestedSummaryList() {
-        List<GenericSummary> dimensionalSummaries = new ArrayList<>();
-        for (NodeLevelDimensionalSummary dimSummary : nodeDimensionProfiles) {
-            dimensionalSummaries.add(dimSummary);
+    getNestedSummaryList().forEach(
+        summary -> {
+          summaryObj.add(summary.getTableName(), summary.toJson());
         }
-        return dimensionalSummaries;
-    }
-
-    @Override
-    public <T extends GeneratedMessageV3> T buildSummaryMessage() {
-        throw new IllegalArgumentException();
-    }
-
-    @Override
-    public void buildSummaryMessageAndAddToFlowUnit(FlowUnitMessage.Builder messageBuilder) {
-        throw new IllegalArgumentException();
-    }
-
-    @Override
-    public String getTableName() {
-        return this.getClass().getSimpleName();
-    }
-
-    @Override
-    public List<Field<?>> getSqlSchema() {
-        List<Field<?>> schema = new ArrayList<>();
-        for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
-            schema.add(DSL.field(DSL.name(dimension.NAME), Short.class));
-        }
-        return schema;
-    }
-
-    @Override
-    public List<Object> getSqlValue() {
-        List<Object> values = new ArrayList<>();
-        for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
-            values.add(temperatureVector.getTemperatureFor(dimension));
-        }
-        return values;
-    }
-
-    @Override
-    public JsonElement toJson() {
-        JsonObject summaryObj = new JsonObject();
-        for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
-            TemperatureVector.NormalizedValue value =
-                    temperatureVector.getTemperatureFor(dimension);
-            summaryObj.addProperty(dimension.NAME,
-                    value != null ? value.getPOINTS() : null);
-        }
-        getNestedSummaryList().forEach(
-                summary -> {
-                    summaryObj.add(summary.getTableName(), summary.toJson());
-                }
-        );
-        return summaryObj;
-    }
+    );
+    return summaryObj;
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/NodeLevelDimensionalSummary.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/NodeLevelDimensionalSummary.java
@@ -33,231 +33,232 @@ import org.jooq.impl.DSL;
  * A node dimension profile is categorization of all shards in the node into different heatZones.
  */
 public class NodeLevelDimensionalSummary extends GenericSummary {
-    private final TemperatureVector.Dimension profileForDimension;
-    private final TemperatureVector.NormalizedValue meanTemperature;
-    private final double totalUsage;
 
-    private final NodeLevelZoneSummary[] zoneProfiles;
-    private int numberOfShards;
+  private final TemperatureVector.Dimension profileForDimension;
+  private final TemperatureVector.NormalizedValue meanTemperature;
+  private final double totalUsage;
 
-    public NodeLevelDimensionalSummary(final TemperatureVector.Dimension profileForDimension,
-                                       final TemperatureVector.NormalizedValue meanTemperature,
-                                       double totalUsage) {
-        this.profileForDimension = profileForDimension;
-        this.meanTemperature = meanTemperature;
-        this.totalUsage = totalUsage;
-        this.zoneProfiles = new NodeLevelZoneSummary[HeatZoneAssigner.Zone.values().length];
-        for (int i = 0; i < this.zoneProfiles.length; i++) {
-            this.zoneProfiles[i] = new NodeLevelZoneSummary(HeatZoneAssigner.Zone.values()[i]);
+  private final NodeLevelZoneSummary[] zoneProfiles;
+  private int numberOfShards;
+
+  public NodeLevelDimensionalSummary(final TemperatureVector.Dimension profileForDimension,
+      final TemperatureVector.NormalizedValue meanTemperature,
+      double totalUsage) {
+    this.profileForDimension = profileForDimension;
+    this.meanTemperature = meanTemperature;
+    this.totalUsage = totalUsage;
+    this.zoneProfiles = new NodeLevelZoneSummary[HeatZoneAssigner.Zone.values().length];
+    for (int i = 0; i < this.zoneProfiles.length; i++) {
+      this.zoneProfiles[i] = new NodeLevelZoneSummary(HeatZoneAssigner.Zone.values()[i]);
+    }
+  }
+
+  public int getNumberOfShards() {
+    return numberOfShards;
+  }
+
+  public void setNumberOfShards(int numberOfShards) {
+    this.numberOfShards = numberOfShards;
+  }
+
+  public void addShardToZone(ShardProfileSummary shard, HeatZoneAssigner.Zone zone) {
+    NodeLevelZoneSummary profile = zoneProfiles[zone.ordinal()];
+    profile.addShard(shard);
+  }
+
+  @Override
+  public String toString() {
+    return "NodeLevelDimensionalSummary{"
+        + "profileForDimension=" + profileForDimension
+        + ", meanTemperature=" + meanTemperature
+        + ", totalUsage=" + totalUsage
+        + ", zoneProfiles=" + Arrays.toString(zoneProfiles)
+        + ", numberOfShards=" + numberOfShards
+        + '}';
+  }
+
+  public TemperatureVector.NormalizedValue getMeanTemperature() {
+    return meanTemperature;
+  }
+
+  public TemperatureVector.Dimension getProfileForDimension() {
+    return profileForDimension;
+  }
+
+  public double getTotalUsage() {
+    return totalUsage;
+  }
+
+  public List<GenericSummary> getNestedSummaryList() {
+    List<GenericSummary> zoneSummaries = new ArrayList<>();
+    for (NodeLevelZoneSummary zone : zoneProfiles) {
+      zoneSummaries.add(zone);
+    }
+    return zoneSummaries;
+  }
+
+  @Override
+  public <T extends GeneratedMessageV3> T buildSummaryMessage() {
+    throw new IllegalArgumentException("This should not be called.");
+  }
+
+  @Override
+  public void buildSummaryMessageAndAddToFlowUnit(FlowUnitMessage.Builder messageBuilder) {
+    throw new IllegalArgumentException("This should not be called.");
+  }
+
+  @Override
+  public String getTableName() {
+    return this.getClass().getSimpleName();
+  }
+
+  @Override
+  public List<Field<?>> getSqlSchema() {
+    List<Field<?>> schema = new ArrayList<>();
+    schema.add(DSL.field(DSL.name("dimension"), String.class));
+    schema.add(DSL.field(DSL.name("mean"), Short.class));
+    schema.add(DSL.field(DSL.name("total"), Double.class));
+    schema.add(DSL.field(DSL.name("numShards"), Integer.class));
+
+    return schema;
+  }
+
+  @Override
+  public List<Object> getSqlValue() {
+    List<Object> row = new ArrayList<>();
+    row.add(getProfileForDimension().NAME);
+    row.add(getMeanTemperature().getPOINTS());
+    row.add(getTotalUsage());
+    row.add(getNumberOfShards());
+    return row;
+  }
+
+  @Override
+  public JsonElement toJson() {
+    JsonObject summaryObj = new JsonObject();
+    summaryObj.addProperty("dimension", getProfileForDimension().NAME);
+    summaryObj.addProperty("mean", getMeanTemperature().getPOINTS());
+    summaryObj.addProperty("total", getTotalUsage());
+    summaryObj.addProperty("numShards", getNumberOfShards());
+    getNestedSummaryList().forEach(
+        summary -> {
+          summaryObj.add(summary.getTableName(), summary.toJson());
         }
+    );
+    return summaryObj;
+  }
+
+  class NodeLevelZoneSummary extends GenericSummary {
+
+    private final HeatZoneAssigner.Zone myZone;
+    List<ShardProfileSummary> shardProfileSummaries;
+    ShardProfileSummary minShard;
+    //ShardProfileSummary maxShard;
+    ShardProfileSummary maxShard;
+
+    NodeLevelZoneSummary(HeatZoneAssigner.Zone myZone) {
+      this.myZone = myZone;
+      shardProfileSummaries = new ArrayList<>();
     }
 
-    public int getNumberOfShards() {
-        return numberOfShards;
+    void addShard(ShardProfileSummary shard) {
+      shardProfileSummaries.add(shard);
+      if (minShard == null) {
+        minShard = shard;
+      } else {
+        if (getMinTemperature().isGreaterThan(shard.getHeatInDimension(profileForDimension))) {
+          minShard = shard;
+        }
+      }
+
+      if (maxShard == null) {
+        maxShard = shard;
+      } else {
+        if (shard.getHeatInDimension(profileForDimension).isGreaterThan(getMaxTemperature())) {
+          maxShard = shard;
+        }
+      }
     }
 
-    public void setNumberOfShards(int numberOfShards) {
-        this.numberOfShards = numberOfShards;
+    @Nullable
+    TemperatureVector.NormalizedValue getMinTemperature() {
+      if (minShard != null) {
+        return minShard.getHeatInDimension(profileForDimension);
+      }
+      return null;
     }
 
-    public void addShardToZone(ShardProfileSummary shard, HeatZoneAssigner.Zone zone) {
-        NodeLevelZoneSummary profile = zoneProfiles[zone.ordinal()];
-        profile.addShard(shard);
+    @Nullable
+    TemperatureVector.NormalizedValue getMaxTemperature() {
+      if (maxShard != null) {
+        return maxShard.getHeatInDimension(profileForDimension);
+      }
+      return null;
     }
 
     @Override
     public String toString() {
-        return "NodeLevelDimensionalSummary{"
-                + "profileForDimension=" + profileForDimension
-                + ", meanTemperature=" + meanTemperature
-                + ", totalUsage=" + totalUsage
-                + ", zoneProfiles=" + Arrays.toString(zoneProfiles)
-                + ", numberOfShards=" + numberOfShards
-                + '}';
+      return "{"
+          + "myZone=" + myZone
+          + ", shardProfiles=" + shardProfileSummaries
+          + ", minShard=" + minShard
+          + ", maxShard=" + maxShard
+          + '}';
     }
 
-    public TemperatureVector.NormalizedValue getMeanTemperature() {
-        return meanTemperature;
-    }
-
-    public TemperatureVector.Dimension getProfileForDimension() {
-        return profileForDimension;
-    }
-
-    public double getTotalUsage() {
-        return totalUsage;
+    public List<GenericSummary> getNestedSummaryList() {
+      List<GenericSummary> shardSummaries = new ArrayList<>();
+      for (ShardProfileSummary shardProfileSummary : shardProfileSummaries) {
+        shardSummaries.add(shardProfileSummary);
+      }
+      return shardSummaries;
     }
 
     @Override
     public <T extends GeneratedMessageV3> T buildSummaryMessage() {
-        throw new IllegalArgumentException("This should not be called.");
+      throw new IllegalArgumentException("");
     }
 
     @Override
     public void buildSummaryMessageAndAddToFlowUnit(FlowUnitMessage.Builder messageBuilder) {
-        throw new IllegalArgumentException("This should not be called.");
+      throw new IllegalArgumentException("");
     }
 
     @Override
     public String getTableName() {
-        return this.getClass().getSimpleName();
-    }
-
-    public List<GenericSummary> getNestedSummaryList() {
-        List<GenericSummary> zoneSummaries = new ArrayList<>();
-        for (NodeLevelZoneSummary zone : zoneProfiles) {
-            zoneSummaries.add(zone);
-        }
-        return zoneSummaries;
+      return this.getClass().getSimpleName();
     }
 
     @Override
     public List<Field<?>> getSqlSchema() {
-        List<Field<?>> schema = new ArrayList<>();
-        schema.add(DSL.field(DSL.name("dimension"), String.class));
-        schema.add(DSL.field(DSL.name("mean"), Short.class));
-        schema.add(DSL.field(DSL.name("total"), Double.class));
-        schema.add(DSL.field(DSL.name("numShards"), Integer.class));
-
-        return schema;
+      List<Field<?>> schema = new ArrayList<>();
+      schema.add(DSL.field(DSL.name("zone"), String.class));
+      schema.add(DSL.field(DSL.name("min"), String.class));
+      schema.add(DSL.field(DSL.name("max"), String.class));
+      return schema;
     }
 
     @Override
     public List<Object> getSqlValue() {
-        List<Object> row = new ArrayList<>();
-        row.add(getProfileForDimension().NAME);
-        row.add(getMeanTemperature().getPOINTS());
-        row.add(getTotalUsage());
-        row.add(getNumberOfShards());
-        return row;
+      List<Object> values = new ArrayList<>();
+      values.add(myZone.name());
+      values.add(minShard == null ? "" : minShard.toString());
+      values.add(maxShard == null ? "" : maxShard.toString());
+      return values;
     }
 
     @Override
     public JsonElement toJson() {
-        JsonObject summaryObj = new JsonObject();
-        summaryObj.addProperty("dimension", getProfileForDimension().NAME);
-        summaryObj.addProperty("mean", getMeanTemperature().getPOINTS());
-        summaryObj.addProperty("total", getTotalUsage());
-        summaryObj.addProperty("numShards", getNumberOfShards());
-        getNestedSummaryList().forEach(
-                summary -> {
-                    summaryObj.add(summary.getTableName(), summary.toJson());
-                }
-        );
-        return summaryObj;
+      JsonObject summaryObj = new JsonObject();
+      summaryObj.addProperty("zone_name", myZone.name());
+      summaryObj.add("min_shard", minShard.toJson());
+      summaryObj.add("max_shard", maxShard.toJson());
+      getNestedSummaryList().forEach(
+          summary -> {
+            summaryObj.add(summary.getTableName(), summary.toJson());
+          }
+      );
+      return summaryObj;
     }
-
-    class NodeLevelZoneSummary extends GenericSummary {
-        List<ShardProfileSummary> shardProfileSummaries;
-        ShardProfileSummary minShard;
-        //ShardProfileSummary maxShard;
-        ShardProfileSummary maxShard;
-
-        private final HeatZoneAssigner.Zone myZone;
-
-        NodeLevelZoneSummary(HeatZoneAssigner.Zone myZone) {
-            this.myZone = myZone;
-            shardProfileSummaries = new ArrayList<>();
-        }
-
-        void addShard(ShardProfileSummary shard) {
-            shardProfileSummaries.add(shard);
-            if (minShard == null) {
-                minShard = shard;
-            } else {
-                if (getMinTemperature().isGreaterThan(shard.getHeatInDimension(profileForDimension))) {
-                    minShard = shard;
-                }
-            }
-
-            if (maxShard == null) {
-                maxShard = shard;
-            } else {
-                if (shard.getHeatInDimension(profileForDimension).isGreaterThan(getMaxTemperature())) {
-                    maxShard = shard;
-                }
-            }
-        }
-
-        @Nullable
-        TemperatureVector.NormalizedValue getMinTemperature() {
-            if (minShard != null) {
-                return minShard.getHeatInDimension(profileForDimension);
-            }
-            return null;
-        }
-
-        @Nullable
-        TemperatureVector.NormalizedValue getMaxTemperature() {
-            if (maxShard != null) {
-                return maxShard.getHeatInDimension(profileForDimension);
-            }
-            return null;
-        }
-
-        @Override
-        public String toString() {
-            return "{"
-                    + "myZone=" + myZone
-                    + ", shardProfiles=" + shardProfileSummaries
-                    + ", minShard=" + minShard
-                    + ", maxShard=" + maxShard
-                    + '}';
-        }
-
-        @Override
-        public <T extends GeneratedMessageV3> T buildSummaryMessage() {
-            throw new IllegalArgumentException("");
-        }
-
-        @Override
-        public void buildSummaryMessageAndAddToFlowUnit(FlowUnitMessage.Builder messageBuilder) {
-            throw new IllegalArgumentException("");
-        }
-
-        @Override
-        public String getTableName() {
-            return this.getClass().getSimpleName();
-        }
-
-        @Override
-        public List<Field<?>> getSqlSchema() {
-            List<Field<?>> schema = new ArrayList<>();
-            schema.add(DSL.field(DSL.name("zone"), String.class));
-            schema.add(DSL.field(DSL.name("min"), String.class));
-            schema.add(DSL.field(DSL.name("max"), String.class));
-            return schema;
-        }
-
-        public List<GenericSummary> getNestedSummaryList() {
-            List<GenericSummary> shardSummaries = new ArrayList<>();
-            for (ShardProfileSummary shardProfileSummary : shardProfileSummaries) {
-                shardSummaries.add(shardProfileSummary);
-            }
-            return shardSummaries;
-        }
-
-        @Override
-        public List<Object> getSqlValue() {
-            List<Object> values = new ArrayList<>();
-            values.add(myZone.name());
-            values.add(minShard == null ? "" : minShard.toString());
-            values.add(maxShard == null ? "" : maxShard.toString());
-            return values;
-        }
-
-        @Override
-        public JsonElement toJson() {
-            JsonObject summaryObj = new JsonObject();
-            summaryObj.addProperty("zone_name", myZone.name());
-            summaryObj.add("min_shard", minShard.toJson());
-            summaryObj.add("max_shard", maxShard.toJson());
-            getNestedSummaryList().forEach(
-                    summary -> {
-                        summaryObj.add(summary.getTableName(), summary.toJson());
-                    }
-            );
-            return summaryObj;
-        }
-    }
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/temperature/HeatZoneAssigner.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/temperature/HeatZoneAssigner.java
@@ -19,32 +19,33 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.co
  * Given the units of the resource consumed and the total consumption and
  */
 public class HeatZoneAssigner {
-    public enum Zone {
-        HOT,
-        WARM,
-        LUKE_WARM,
-        COLD
-    }
 
-    public static Zone assign(final TemperatureVector.NormalizedValue consumed,
-                              final TemperatureVector.NormalizedValue nodeAvg,
-                              final TemperatureVector.NormalizedValue threshold) {
-        Zone zone;
-        if (consumed.isGreaterThan(nodeAvg)) {
-            TemperatureVector.NormalizedValue deviation = consumed.diff(nodeAvg);
-            if (deviation.isGreaterThan(threshold)) {
-                zone = Zone.HOT;
-            } else {
-                zone = Zone.WARM;
-            }
-        } else {
-            TemperatureVector.NormalizedValue deviation = nodeAvg.diff(consumed);
-            if (deviation.isGreaterThan(threshold)) {
-                zone = Zone.COLD;
-            } else {
-                zone = Zone.LUKE_WARM;
-            }
-        }
-        return zone;
+  public static Zone assign(final TemperatureVector.NormalizedValue consumed,
+      final TemperatureVector.NormalizedValue nodeAvg,
+      final TemperatureVector.NormalizedValue threshold) {
+    Zone zone;
+    if (consumed.isGreaterThan(nodeAvg)) {
+      TemperatureVector.NormalizedValue deviation = consumed.diff(nodeAvg);
+      if (deviation.isGreaterThan(threshold)) {
+        zone = Zone.HOT;
+      } else {
+        zone = Zone.WARM;
+      }
+    } else {
+      TemperatureVector.NormalizedValue deviation = nodeAvg.diff(consumed);
+      if (deviation.isGreaterThan(threshold)) {
+        zone = Zone.COLD;
+      } else {
+        zone = Zone.LUKE_WARM;
+      }
     }
+    return zone;
+  }
+
+  public enum Zone {
+    HOT,
+    WARM,
+    LUKE_WARM,
+    COLD
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/temperature/TemperatureVector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/temperature/TemperatureVector.java
@@ -20,117 +20,123 @@ import java.util.Comparator;
 import javax.annotation.Nullable;
 
 public class TemperatureVector {
-    public enum Dimension {
-        CPU_Utilization(com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.CPU_Utilization.NAME),
-        Heap_AllocRate(com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_AllocRate.NAME),
-        IO_READ_SYSCALL_RATE(com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.IO_ReadSyscallRate.NAME),
-        IO_WriteSyscallRate(com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.IO_WriteSyscallRate.NAME);
 
-        public final String NAME;
+  /**
+   * This array contains a normalized value per dimension.
+   */
+  private NormalizedValue[] normalizedValues;
 
-        Dimension(String name) {
-            this.NAME = name;
-        }
+  public TemperatureVector() {
+    normalizedValues = new NormalizedValue[Dimension.values().length];
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder stringBuilder = new StringBuilder();
+
+    String delimiter = "";
+    for (Dimension dim : Dimension.values()) {
+      String key = dim.NAME;
+      NormalizedValue value = normalizedValues[dim.ordinal()];
+      stringBuilder.append(delimiter).append(key).append(":").append(value);
+      delimiter = ",";
     }
 
-    public static class NormalizedValue {
-        public static final int MIN = 0;
-        public static final int MAX = 10;
+    return "TemperatureVector{"
+        + stringBuilder.toString()
+        + '}';
+  }
 
-        private final short POINTS;
+  public JsonObject toJson() {
+    JsonObject jsonObject = new JsonObject();
+    for (Dimension dim : Dimension.values()) {
+      jsonObject.addProperty("dimension", dim.NAME);
 
-        public NormalizedValue(short heatValue) {
-            if (heatValue < MIN || heatValue > MAX) {
-                String err = String.format("Only values between %d and %d allowed. Given: %d", MIN, MAX,
-                        heatValue);
-                throw new IllegalArgumentException(err);
-            }
+      NormalizedValue val = normalizedValues[dim.ordinal()];
+      jsonObject.addProperty("value",
+          val != null ? val.getPOINTS() : null);
+    }
+    return jsonObject;
+  }
 
-            this.POINTS = heatValue;
-        }
+  /**
+   * This can be used to get temperature along a dimension.
+   *
+   * @param dimension one of the dime
+   * @return The normalized temperature value along that dimension.
+   */
+  @Nullable
+  public NormalizedValue getTemperatureFor(Dimension dimension) {
+    return normalizedValues[dimension.ordinal()];
+  }
 
-        /**
-         * Units of a resource consumed is a number between 0 and 10 where 0 being cold(not using any
-         * resource) and 10 being hot(almost all the units of the resource were consumed by it).
-         * Temperature is calculated by determining what parts of 10 is consumed by the resource.
-         */
-        public static NormalizedValue calculate(double consumedByCandidate, double totalConsumption) {
-            return new NormalizedValue((short) (consumedByCandidate * 10 / totalConsumption));
-        }
+  public void updateTemperatureForDimension(Dimension dimension,
+      NormalizedValue normalizedValue) {
+    normalizedValues[dimension.ordinal()] = normalizedValue;
+  }
 
-        public NormalizedValue diff(NormalizedValue b) {
-            return new NormalizedValue((short) (POINTS - b.POINTS));
-        }
+  public enum Dimension {
+    CPU_Utilization(
+        com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.CPU_Utilization.NAME),
+    Heap_AllocRate(
+        com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_AllocRate.NAME),
+    IO_READ_SYSCALL_RATE(
+        com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.IO_ReadSyscallRate.NAME),
+    IO_WriteSyscallRate(
+        com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.IO_WriteSyscallRate.NAME);
 
-        public boolean isGreaterThan(NormalizedValue b) {
-            return POINTS > b.POINTS;
-        }
+    public final String NAME;
 
-        public Comparator<NormalizedValue> comparator() {
-            return Comparator.comparingInt(o -> o.POINTS);
-        }
+    Dimension(String name) {
+      this.NAME = name;
+    }
+  }
 
-        public short getPOINTS() {
-            return POINTS;
-        }
+  public static class NormalizedValue {
 
-        @Override
-        public String toString() {
-            return "" + POINTS;
-        }
+    public static final int MIN = 0;
+    public static final int MAX = 10;
+
+    private final short POINTS;
+
+    public NormalizedValue(short heatValue) {
+      if (heatValue < MIN || heatValue > MAX) {
+        String err = String.format("Only values between %d and %d allowed. Given: %d", MIN, MAX,
+            heatValue);
+        throw new IllegalArgumentException(err);
+      }
+
+      this.POINTS = heatValue;
     }
 
     /**
-     * This array contains a normalized value per dimension.
+     * Units of a resource consumed is a number between 0 and 10 where 0 being cold(not using any
+     * resource) and 10 being hot(almost all the units of the resource were consumed by it).
+     * Temperature is calculated by determining what parts of 10 is consumed by the resource.
      */
-    private NormalizedValue[] normalizedValues;
+    public static NormalizedValue calculate(double consumedByCandidate, double totalConsumption) {
+      return new NormalizedValue((short) (consumedByCandidate * 10 / totalConsumption));
+    }
 
-    public TemperatureVector() {
-        normalizedValues = new NormalizedValue[Dimension.values().length];
+    public NormalizedValue diff(NormalizedValue b) {
+      return new NormalizedValue((short) (POINTS - b.POINTS));
+    }
+
+    public boolean isGreaterThan(NormalizedValue b) {
+      return POINTS > b.POINTS;
+    }
+
+    public Comparator<NormalizedValue> comparator() {
+      return Comparator.comparingInt(o -> o.POINTS);
+    }
+
+    public short getPOINTS() {
+      return POINTS;
     }
 
     @Override
     public String toString() {
-        StringBuilder stringBuilder = new StringBuilder();
-
-        String delimiter = "";
-        for (Dimension dim : Dimension.values()) {
-            String key = dim.NAME;
-            NormalizedValue value = normalizedValues[dim.ordinal()];
-            stringBuilder.append(delimiter).append(key).append(":").append(value);
-            delimiter = ",";
-        }
-
-        return "TemperatureVector{"
-                + stringBuilder.toString()
-                + '}';
+      return "" + POINTS;
     }
-
-    public JsonObject toJson() {
-        JsonObject jsonObject = new JsonObject();
-        for (Dimension dim : Dimension.values()) {
-            jsonObject.addProperty("dimension", dim.NAME);
-
-            NormalizedValue val = normalizedValues[dim.ordinal()];
-            jsonObject.addProperty("value",
-                    val != null ? val.getPOINTS() : null);
-        }
-        return jsonObject;
-    }
-
-    /**
-     * This can be used to get temperature along a dimension.
-     *
-     * @param dimension one of the dime
-     * @return The normalized temperature value along that dimension.
-     */
-    @Nullable
-    public NormalizedValue getTemperatureFor(Dimension dimension) {
-        return normalizedValues[dimension.ordinal()];
-    }
-
-    public void updateTemperatureForDimension(Dimension dimension,
-                                              NormalizedValue normalizedValue) {
-        normalizedValues[dimension.ordinal()] = normalizedValue;
-    }
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/DummyGraph.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/DummyGraph.java
@@ -51,7 +51,11 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.AggregateMetric.AggregateFunction;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.AvgCpuUtilByShardsMetricBasedTemperatureCalculator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.CpuUtilByShardsMetricBasedTemperatureCalculator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.HeapAllocRateByShardAvgTemperatureCalculator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.HeapAllocRateByShardTemperatureCalculator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.capacity.HeapAllocRateTotalTemperatureCalculator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.capacity.TotalCpuUtilForTotalNodeMetric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.shardIndependent.HeapAllocRateShardIndependentTemperatureCalculator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.shardIndependent.ShardIndependentTemperatureCalculatorCpuUtilMetric;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HighHeapUsageClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HotNodeClusterRca;
@@ -62,12 +66,17 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hot
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.ClusterTemperatureRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.NodeTemperatureRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.dimension.CpuUtilDimensionTemperatureRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.dimension.HeapAllocRateTemperatureRca;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class DummyGraph extends AnalysisGraph {
+
+  private static final Logger LOG = LogManager.getLogger(DummyGraph.class);
 
   @Override
   public void construct() {
@@ -75,8 +84,9 @@ public class DummyGraph extends AnalysisGraph {
     Metric gcEvent = new GC_Collection_Event(5);
     Metric heapMax = new Heap_Max(5);
     Metric gc_Collection_Time = new GC_Collection_Time(5);
-    Metric cpuUtilizationGroupByOperation = new AggregateMetric(1, CPU_Utilization.NAME, AggregateFunction.SUM,
-              MetricsDB.AVG, CommonDimension.OPERATION.toString());
+    Metric cpuUtilizationGroupByOperation = new AggregateMetric(1, CPU_Utilization.NAME,
+        AggregateFunction.SUM,
+        MetricsDB.AVG, CommonDimension.OPERATION.toString());
 
     heapUsed.addTag(TAG_LOCUS, LOCUS_DATA_MASTER_NODE);
     gcEvent.addTag(TAG_LOCUS, LOCUS_DATA_MASTER_NODE);
@@ -112,7 +122,8 @@ public class DummyGraph extends AnalysisGraph {
     Rca<ResourceFlowUnit> hotJVMNodeRca = new HotNodeRca(12, highHeapUsageOldGenRca,
         highHeapUsageYoungGenRca, highCpuRca);
     hotJVMNodeRca.addTag(TAG_LOCUS, LOCUS_DATA_MASTER_NODE);
-    hotJVMNodeRca.addAllUpstreams(Arrays.asList(highHeapUsageOldGenRca, highHeapUsageYoungGenRca, highCpuRca));
+    hotJVMNodeRca.addAllUpstreams(
+        Arrays.asList(highHeapUsageOldGenRca, highHeapUsageYoungGenRca, highCpuRca));
 
     Rca<ResourceFlowUnit> highHeapUsageClusterRca =
         new HighHeapUsageClusterRca(12, hotJVMNodeRca);
@@ -125,9 +136,9 @@ public class DummyGraph extends AnalysisGraph {
     hotNodeClusterRca.addTag(TAG_LOCUS, LOCUS_MASTER_NODE);
     hotNodeClusterRca.addAllUpstreams(Collections.singletonList(hotJVMNodeRca));
 
-    // constructResourceHeatMapGraph();
+    constructResourceHeatMapGraph();
   }
-  
+
   private List<Metric> constructNodeStatsMetrics() {
     List<Metric> nodeStatsMetrics = new ArrayList<Metric>() {{
       add(new Cache_FieldData_Size(5));
@@ -150,42 +161,71 @@ public class DummyGraph extends AnalysisGraph {
     }
     return nodeStatsMetrics;
   }
-  
-    protected void constructResourceHeatMapGraph() {
-        ShardStore shardStore = new ShardStore();
 
-        CpuUtilByShardsMetricBasedTemperatureCalculator cpuUtilByShard =
-                new CpuUtilByShardsMetricBasedTemperatureCalculator();
-        AvgCpuUtilByShardsMetricBasedTemperatureCalculator avgCpuUtilByShards =
-                new AvgCpuUtilByShardsMetricBasedTemperatureCalculator();
-        ShardIndependentTemperatureCalculatorCpuUtilMetric shardIndependentCpuUtilMetric =
-                new ShardIndependentTemperatureCalculatorCpuUtilMetric();
-        TotalCpuUtilForTotalNodeMetric cpuUtilPeakUsage = new TotalCpuUtilForTotalNodeMetric();
+  protected void constructResourceHeatMapGraph() {
+    LOG.info("Constructing temperature profile RCA components");
+    ShardStore shardStore = new ShardStore();
 
-        // heap map is developed only for data nodes.
-        cpuUtilByShard.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
-        avgCpuUtilByShards.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
-        shardIndependentCpuUtilMetric.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
-        cpuUtilPeakUsage.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
+    HeapAllocRateByShardTemperatureCalculator heapAllocByShard =
+        new HeapAllocRateByShardTemperatureCalculator();
+    HeapAllocRateByShardAvgTemperatureCalculator heapAllocRateByShardAvg =
+        new HeapAllocRateByShardAvgTemperatureCalculator();
+    HeapAllocRateShardIndependentTemperatureCalculator shardIndependentHeapAllocRate =
+        new HeapAllocRateShardIndependentTemperatureCalculator();
+    HeapAllocRateTotalTemperatureCalculator heapAllocRateTotal =
+        new HeapAllocRateTotalTemperatureCalculator();
 
-        addLeaf(cpuUtilByShard);
-        addLeaf(avgCpuUtilByShards);
-        addLeaf(shardIndependentCpuUtilMetric);
-        addLeaf(cpuUtilPeakUsage);
+    CpuUtilByShardsMetricBasedTemperatureCalculator cpuUtilByShard =
+        new CpuUtilByShardsMetricBasedTemperatureCalculator();
+    AvgCpuUtilByShardsMetricBasedTemperatureCalculator avgCpuUtilByShards =
+        new AvgCpuUtilByShardsMetricBasedTemperatureCalculator();
+    ShardIndependentTemperatureCalculatorCpuUtilMetric shardIndependentCpuUtilMetric =
+        new ShardIndependentTemperatureCalculatorCpuUtilMetric();
+    TotalCpuUtilForTotalNodeMetric cpuUtilPeakUsage = new TotalCpuUtilForTotalNodeMetric();
 
-        CpuUtilDimensionTemperatureRca cpuUtilHeat = new CpuUtilDimensionTemperatureRca(shardStore, cpuUtilByShard,
-                avgCpuUtilByShards,
-                shardIndependentCpuUtilMetric, cpuUtilPeakUsage);
-        cpuUtilHeat.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
-        cpuUtilHeat.addAllUpstreams(Arrays.asList(cpuUtilByShard, avgCpuUtilByShards,
-                shardIndependentCpuUtilMetric, cpuUtilPeakUsage));
+    // heat map is developed only for data nodes.
+    cpuUtilByShard.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
+    avgCpuUtilByShards.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
+    shardIndependentCpuUtilMetric.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
+    cpuUtilPeakUsage.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
 
-        NodeTemperatureRca nodeTemperatureRca = new NodeTemperatureRca(cpuUtilHeat);
-        nodeTemperatureRca.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
-        nodeTemperatureRca.addAllUpstreams(Arrays.asList(cpuUtilHeat));
+    heapAllocByShard.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
+    heapAllocRateByShardAvg.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
+    shardIndependentHeapAllocRate.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
+    heapAllocRateTotal.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
 
-        ClusterTemperatureRca clusterTemperatureRca = new ClusterTemperatureRca(nodeTemperatureRca);
-        clusterTemperatureRca.addTag(TAG_LOCUS, LOCUS_MASTER_NODE);
-        clusterTemperatureRca.addAllUpstreams(Arrays.asList(nodeTemperatureRca));
-    }
+    addLeaf(cpuUtilByShard);
+    addLeaf(avgCpuUtilByShards);
+    addLeaf(shardIndependentCpuUtilMetric);
+    addLeaf(cpuUtilPeakUsage);
+
+    addLeaf(heapAllocByShard);
+    addLeaf(heapAllocRateByShardAvg);
+    addLeaf(shardIndependentHeapAllocRate);
+    addLeaf(heapAllocRateTotal);
+
+    CpuUtilDimensionTemperatureRca cpuUtilHeat = new CpuUtilDimensionTemperatureRca(shardStore,
+        cpuUtilByShard,
+        avgCpuUtilByShards,
+        shardIndependentCpuUtilMetric, cpuUtilPeakUsage);
+    cpuUtilHeat.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
+    cpuUtilHeat.addAllUpstreams(Arrays.asList(cpuUtilByShard, avgCpuUtilByShards,
+        shardIndependentCpuUtilMetric, cpuUtilPeakUsage));
+
+    HeapAllocRateTemperatureRca heapAllocRateHeat = new HeapAllocRateTemperatureRca(shardStore,
+        heapAllocByShard, heapAllocRateByShardAvg, shardIndependentHeapAllocRate,
+        heapAllocRateTotal);
+
+    heapAllocRateHeat.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
+    heapAllocRateHeat.addAllUpstreams(Arrays.asList(heapAllocByShard, heapAllocRateByShardAvg,
+        shardIndependentHeapAllocRate, heapAllocRateTotal));
+
+    NodeTemperatureRca nodeTemperatureRca = new NodeTemperatureRca(cpuUtilHeat, heapAllocRateHeat);
+    nodeTemperatureRca.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
+    nodeTemperatureRca.addAllUpstreams(Arrays.asList(cpuUtilHeat, heapAllocRateHeat));
+
+    ClusterTemperatureRca clusterTemperatureRca = new ClusterTemperatureRca(nodeTemperatureRca);
+    clusterTemperatureRca.addTag(TAG_LOCUS, LOCUS_MASTER_NODE);
+    clusterTemperatureRca.addAllUpstreams(Collections.singletonList(nodeTemperatureRca));
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/AggregateMetric.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/AggregateMetric.java
@@ -33,119 +33,118 @@ import org.jooq.impl.DSL;
 
 
 /**
- * AggregateMetric can be used to group the sqlite to one or more columns
- * and perform sum aggregation and sorting function on the result
- * For example, we can get the sum of cpu usage for each operation and sort them in descending
- * order by constructing this Metric as follows:
+ * AggregateMetric can be used to group the sqlite to one or more columns and perform sum
+ * aggregation and sorting function on the result For example, we can get the sum of cpu usage for
+ * each operation and sort them in descending order by constructing this Metric as follows:
  * <p>
  * new AggregateMetric(5, CPU_Utilization.NAME, CommonDimension.OPERATION.toString());
  * </p>
  */
 public class AggregateMetric extends Metric {
 
-    private static final Logger LOG = LogManager.getLogger(AggregateMetric.class);
-    private final String tableName;
-    private final List<String> groupByFieldsName;
-    private final AggregateFunction aggregateFunction;
-    private final String metricsDBAggrColumn;
+  private static final Logger LOG = LogManager.getLogger(AggregateMetric.class);
+  private final String tableName;
+  private final List<String> groupByFieldsName;
+  private final AggregateFunction aggregateFunction;
+  private final String metricsDBAggrColumn;
 
-    public AggregateMetric(final long evaluationIntervalSeconds, final String tableName,
-                           final AggregateFunction aggregateFunction,
-                           String metricsDBCol, final String... groupByFieldsName) {
-        super("", evaluationIntervalSeconds);
-        this.tableName = tableName;
-        this.groupByFieldsName = new ArrayList<>(Arrays.asList(groupByFieldsName));
-        this.aggregateFunction = aggregateFunction;
+  public AggregateMetric(final long evaluationIntervalSeconds, final String tableName,
+      final AggregateFunction aggregateFunction,
+      String metricsDBCol, final String... groupByFieldsName) {
+    super("", evaluationIntervalSeconds);
+    this.tableName = tableName;
+    this.groupByFieldsName = new ArrayList<>(Arrays.asList(groupByFieldsName));
+    this.aggregateFunction = aggregateFunction;
 
-        switch (metricsDBCol) {
-            case MetricsDB.SUM:
-            case MetricsDB.AVG:
-            case MetricsDB.MIN:
-            case MetricsDB.MAX:
-                this.metricsDBAggrColumn = metricsDBCol;
-                break;
-            default:
-                throw new IllegalArgumentException("Unrecognized metricsDB col: " + metricsDBCol);
-        }
+    switch (metricsDBCol) {
+      case MetricsDB.SUM:
+      case MetricsDB.AVG:
+      case MetricsDB.MIN:
+      case MetricsDB.MAX:
+        this.metricsDBAggrColumn = metricsDBCol;
+        break;
+      default:
+        throw new IllegalArgumentException("Unrecognized metricsDB col: " + metricsDBCol);
     }
+  }
 
-    protected Result<Record> createDslAndFetch(final DSLContext context,
-                                               final String tableName,
-                                               final Field<?> aggDimension,
-                                               final List<Field<?>> groupByFieldsList,
-                                               final List<Field<?>> selectFieldsList) {
-        return context
-                .select(selectFieldsList)
-                .from(tableName)
-                .groupBy(groupByFieldsList)
-                .orderBy(aggDimension.desc())
-                .fetch();
+  protected static Field<?> getAggDimension(final Field<Double> numDimension,
+      AggregateFunction aggregateFunction) {
+    if (aggregateFunction == AggregateFunction.MAX) {
+      return DSL.max(numDimension);
+    } else if (aggregateFunction == AggregateFunction.MIN) {
+      return DSL.min(numDimension);
+    } else if (aggregateFunction == AggregateFunction.AVG) {
+      return DSL.avg(numDimension);
+    } else {
+      return DSL.sum(numDimension);
     }
+  }
 
-    protected List<Field<?>> getGroupByFieldsList() {
-        if (groupByFieldsName.isEmpty()) {
-            return Collections.emptyList();
-        }
-        final List<Field<?>> groupByFieldsList = new ArrayList<>();
-        groupByFieldsName.forEach(f -> groupByFieldsList.add(DSL.field(DSL.name(f))));
-        return groupByFieldsList;
+  protected Result<Record> createDslAndFetch(final DSLContext context,
+      final String tableName,
+      final Field<?> aggDimension,
+      final List<Field<?>> groupByFieldsList,
+      final List<Field<?>> selectFieldsList) {
+    return context
+        .select(selectFieldsList)
+        .from(tableName)
+        .groupBy(groupByFieldsList)
+        .orderBy(aggDimension.desc())
+        .fetch();
+  }
+
+  protected List<Field<?>> getGroupByFieldsList() {
+    if (groupByFieldsName.isEmpty()) {
+      return Collections.emptyList();
     }
+    final List<Field<?>> groupByFieldsList = new ArrayList<>();
+    groupByFieldsName.forEach(f -> groupByFieldsList.add(DSL.field(DSL.name(f))));
+    return groupByFieldsList;
+  }
 
-    protected List<Field<?>> getSelectFieldsList(final List<Field<?>> groupByFields,
-                                                 Field<?> aggrDimension) {
-        List<Field<?>> fieldsList = new ArrayList<>(groupByFields);
-        fieldsList.add(aggrDimension);
-        return fieldsList;
+  protected List<Field<?>> getSelectFieldsList(final List<Field<?>> groupByFields,
+      Field<?> aggrDimension) {
+    List<Field<?>> fieldsList = new ArrayList<>(groupByFields);
+    fieldsList.add(aggrDimension);
+    return fieldsList;
+  }
+
+  protected Field<?> getAggrDimension() {
+    // This is the column from metricsDB that we want to SELECT from.
+    final Field<Double> numDimension = DSL.field(DSL.name(metricsDBAggrColumn), Double.class);
+
+    // This aggregate function is applied after group by.
+    return getAggDimension(numDimension, this.aggregateFunction);
+  }
+
+  @Override
+  public MetricFlowUnit gather(final Queryable queryable) {
+    LOG.debug("Metric: Trying to gather metrics for {}", tableName);
+    final Result<Record> result;
+    List<Field<?>> selectFieldsList;
+    try {
+      final MetricsDB db = queryable.getMetricsDB();
+      final DSLContext context = db.getDSLContext();
+
+      final Field<?> aggDimension = getAggrDimension();
+      final List<Field<?>> groupByFieldsList = getGroupByFieldsList();
+      selectFieldsList = getSelectFieldsList(groupByFieldsList, aggDimension);
+
+      result = createDslAndFetch(context, tableName, aggDimension, groupByFieldsList,
+          selectFieldsList);
+    } catch (Exception e) {
+      //TODO: Emit log/stats that gathering failed.
+      LOG.error("RCA: Caught an exception while getting the DB {}", e.getMessage());
+      return MetricFlowUnit.generic();
     }
+    return new MetricFlowUnit(0, result);
+  }
 
-    protected Field<?> getAggrDimension() {
-        // This is the column from metricsDB that we want to SELECT from.
-        final Field<Double> numDimension = DSL.field(DSL.name(metricsDBAggrColumn), Double.class);
-
-        // This aggregate function is applied after group by.
-        return getAggDimension(numDimension, this.aggregateFunction);
-    }
-
-    @Override
-    public MetricFlowUnit gather(final Queryable queryable) {
-        LOG.debug("Metric: Trying to gather metrics for {}", tableName);
-        final Result<Record> result;
-        List<Field<?>> selectFieldsList;
-        try {
-            final MetricsDB db = queryable.getMetricsDB();
-            final DSLContext context = db.getDSLContext();
-
-            final Field<?> aggDimension = getAggrDimension();
-            final List<Field<?>> groupByFieldsList = getGroupByFieldsList();
-            selectFieldsList = getSelectFieldsList(groupByFieldsList, aggDimension);
-
-            result = createDslAndFetch(context, tableName, aggDimension, groupByFieldsList,
-                    selectFieldsList);
-        } catch (Exception e) {
-            //TODO: Emit log/stats that gathering failed.
-            LOG.error("RCA: Caught an exception while getting the DB {}", e.getMessage());
-            return MetricFlowUnit.generic();
-        }
-        return new MetricFlowUnit(0, result);
-    }
-
-    protected static Field<?> getAggDimension(final Field<Double> numDimension,
-                                              AggregateFunction aggregateFunction) {
-        if (aggregateFunction == AggregateFunction.MAX) {
-            return DSL.max(numDimension);
-        } else if (aggregateFunction == AggregateFunction.MIN) {
-            return DSL.min(numDimension);
-        } else if (aggregateFunction == AggregateFunction.AVG) {
-            return DSL.avg(numDimension);
-        } else {
-            return DSL.sum(numDimension);
-        }
-    }
-
-    public enum AggregateFunction {
-        SUM,
-        MAX,
-        MIN,
-        AVG
-    }
+  public enum AggregateFunction {
+    SUM,
+    MAX,
+    MIN,
+    AVG
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/TemperatureMetricsBase.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/TemperatureMetricsBase.java
@@ -29,52 +29,52 @@ import org.jooq.impl.DSL;
 
 public abstract class TemperatureMetricsBase extends AggregateMetric {
 
-    /**
-     * Metrics are gathered each time they are sampled by the reader. Although the reader polls
-     * for new writer metrics half this interval, its okay to get it every 5 seconds as this is
-     * the frequency at which RCA framework runs.
-     */
-    public static final int METRIC_GATHER_INTERVAL = MetricsConfiguration.SAMPLING_INTERVAL / 1000;
+  /**
+   * Metrics are gathered each time they are sampled by the reader. Although the reader polls for
+   * new writer metrics half this interval, its okay to get it every 5 seconds as this is the
+   * frequency at which RCA framework runs.
+   */
+  public static final int METRIC_GATHER_INTERVAL = MetricsConfiguration.SAMPLING_INTERVAL / 1000;
 
-    /**
-     * This is the metricsDB aggregation column we are interested in. Pyrometer sizes for peak
-     * capacity and therefore, Max is of interest here.
-     */
-    public static final String METRICS_DB_AGG_COLUMN_USED = MetricsDB.MAX;
+  /**
+   * This is the metricsDB aggregation column we are interested in. Pyrometer sizes for peak
+   * capacity and therefore, Max is of interest here.
+   */
+  public static final String METRICS_DB_AGG_COLUMN_USED = MetricsDB.MAX;
 
-    /**
-     * This is the aggregate function applied to the MetricsDB aggregate column after group by.
-     * Because we want to size for maximum capacity, we are interested in the max within each group.
-     */
-    public static final AggregateFunction AGGR_TYPE_OVER_METRICS_DB_COLUMN = AggregateFunction.SUM;
+  /**
+   * This is the aggregate function applied to the MetricsDB aggregate column after group by.
+   * Because we want to size for maximum capacity, we are interested in the max within each group.
+   */
+  public static final AggregateFunction AGGR_TYPE_OVER_METRICS_DB_COLUMN = AggregateFunction.SUM;
 
-    public static final String AGGR_OVER_AGGR_NAME =
-            AGGR_TYPE_OVER_METRICS_DB_COLUMN + "_of_" + METRICS_DB_AGG_COLUMN_USED;
+  public static final String AGGR_OVER_AGGR_NAME =
+      AGGR_TYPE_OVER_METRICS_DB_COLUMN + "_of_" + METRICS_DB_AGG_COLUMN_USED;
 
-    public TemperatureMetricsBase(TemperatureVector.Dimension metricType,
-                                  String[] groupByDimensions) {
-        // The temperature intendeds to spread the temperature around the cluster by re-allocating shards
-        // from the hottest of nodes to the nodes that are relatively cold (with some randomness
-        // so that it does not overwhelm the coldest node). Pyrometer also wants to size for peak
-        // loads. Therefore, here we use MAX as the aggregate function.
-        super(METRIC_GATHER_INTERVAL, metricType.NAME, AGGR_TYPE_OVER_METRICS_DB_COLUMN,
-                METRICS_DB_AGG_COLUMN_USED,
-                groupByDimensions);
-    }
+  public TemperatureMetricsBase(TemperatureVector.Dimension metricType,
+      String[] groupByDimensions) {
+    // The temperature intendeds to spread the temperature around the cluster by re-allocating shards
+    // from the hottest of nodes to the nodes that are relatively cold (with some randomness
+    // so that it does not overwhelm the coldest node). Pyrometer also wants to size for peak
+    // loads. Therefore, here we use MAX as the aggregate function.
+    super(METRIC_GATHER_INTERVAL, metricType.NAME, AGGR_TYPE_OVER_METRICS_DB_COLUMN,
+        METRICS_DB_AGG_COLUMN_USED,
+        groupByDimensions);
+  }
 
-    @Override
-    protected abstract Result<Record> createDslAndFetch(final DSLContext context,
-                                                        final String tableName,
-                                                        final Field<?> aggDimension,
-                                                        final List<Field<?>> groupByFieldsList,
-                                                        final List<Field<?>> selectFieldsList);
+  @Override
+  protected abstract Result<Record> createDslAndFetch(final DSLContext context,
+      final String tableName,
+      final Field<?> aggDimension,
+      final List<Field<?>> groupByFieldsList,
+      final List<Field<?>> selectFieldsList);
 
-    protected List<Field<?>> aggrColumnAsSelectField() {
+  protected List<Field<?>> aggrColumnAsSelectField() {
 
-        final Field<Double> numDimension = DSL.field(
-                DSL.name(TemperatureMetricsBase.METRICS_DB_AGG_COLUMN_USED), Double.class);
-        // This aggregate function is applied after group by.
-        return Arrays.asList(
-                getAggDimension(numDimension, AGGR_TYPE_OVER_METRICS_DB_COLUMN).as(AGGR_OVER_AGGR_NAME));
-    }
+    final Field<Double> numDimension = DSL.field(
+        DSL.name(TemperatureMetricsBase.METRICS_DB_AGG_COLUMN_USED), Double.class);
+    // This aggregate function is applied after group by.
+    return Arrays.asList(
+        getAggDimension(numDimension, AGGR_TYPE_OVER_METRICS_DB_COLUMN).as(AGGR_OVER_AGGR_NAME));
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/AvgCpuUtilByShardsMetricBasedTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/AvgCpuUtilByShardsMetricBasedTemperatureCalculator.java
@@ -18,8 +18,10 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.calculators.AvgShardBasedTemperatureCalculator;
 
-public class AvgCpuUtilByShardsMetricBasedTemperatureCalculator extends AvgShardBasedTemperatureCalculator {
-    public AvgCpuUtilByShardsMetricBasedTemperatureCalculator() {
-        super(TemperatureVector.Dimension.CPU_Utilization);
-    }
+public class AvgCpuUtilByShardsMetricBasedTemperatureCalculator extends
+    AvgShardBasedTemperatureCalculator {
+
+  public AvgCpuUtilByShardsMetricBasedTemperatureCalculator() {
+    super(TemperatureVector.Dimension.CPU_Utilization);
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/CpuUtilByShardsMetricBasedTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/CpuUtilByShardsMetricBasedTemperatureCalculator.java
@@ -18,9 +18,10 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.calculators.ShardBasedTemperatureCalculator;
 
-public class CpuUtilByShardsMetricBasedTemperatureCalculator extends ShardBasedTemperatureCalculator {
+public class CpuUtilByShardsMetricBasedTemperatureCalculator extends
+    ShardBasedTemperatureCalculator {
 
-    public CpuUtilByShardsMetricBasedTemperatureCalculator() {
-        super(TemperatureVector.Dimension.CPU_Utilization);
-    }
+  public CpuUtilByShardsMetricBasedTemperatureCalculator() {
+    super(TemperatureVector.Dimension.CPU_Utilization);
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/HeapAllocRateByShardAvgTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/HeapAllocRateByShardAvgTemperatureCalculator.java
@@ -1,0 +1,12 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector.Dimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.calculators.AvgShardBasedTemperatureCalculator;
+
+public class HeapAllocRateByShardAvgTemperatureCalculator extends
+    AvgShardBasedTemperatureCalculator {
+
+  public HeapAllocRateByShardAvgTemperatureCalculator() {
+    super(Dimension.Heap_AllocRate);
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/HeapAllocRateByShardTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/HeapAllocRateByShardTemperatureCalculator.java
@@ -1,0 +1,11 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector.Dimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.calculators.ShardBasedTemperatureCalculator;
+
+public class HeapAllocRateByShardTemperatureCalculator extends ShardBasedTemperatureCalculator {
+
+  public HeapAllocRateByShardTemperatureCalculator() {
+    super(Dimension.Heap_AllocRate);
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/calculators/ShardBasedTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/calculators/ShardBasedTemperatureCalculator.java
@@ -28,48 +28,49 @@ import org.jooq.impl.DSL;
 
 /**
  * This class gets all rows for the given metric table where the shardID is not NULL. This is to
- * tract resource utilization by shard ID. Shard on a node can be uniquely identified by the
- * index name and shard ID. It might also help to also consider the Operation dimension ?
+ * tract resource utilization by shard ID. Shard on a node can be uniquely identified by the index
+ * name and shard ID. It might also help to also consider the Operation dimension ?
  *
  * <p>This class calculates the sum over all operations for an index,shard pair.
  */
 public class ShardBasedTemperatureCalculator extends TemperatureMetricsBase {
-    private static final String[] dimensions = {
-            AllMetrics.CommonDimension.INDEX_NAME.toString(),
-            AllMetrics.CommonDimension.SHARD_ID.toString()
-    };
 
-    public ShardBasedTemperatureCalculator(TemperatureVector.Dimension metricType) {
-        // The temperature intendeds to spread the temperature around the cluster by re-allocating shards
-        // from the hottest of nodes to the nodes that are relatively cold (with some randomness
-        // so that it does not overwhelm the coldest node). Pyrometer also wants to size for peak
-        // loads. Therefore, here we use MAX as the aggregate function.
-        super(metricType, dimensions);
-    }
+  private static final String[] dimensions = {
+      AllMetrics.CommonDimension.INDEX_NAME.toString(),
+      AllMetrics.CommonDimension.SHARD_ID.toString()
+  };
 
-    protected SelectSeekStep1<Record, ?> getSumOfUtilByIndexShardGroup(final DSLContext context,
-                                                                       final String tableName,
-                                                                       final Field<?> aggDimension,
-                                                                       final List<Field<?>> groupByFieldsList,
-                                                                       final List<Field<?>> selectFieldsList) {
-        Field<?> shardIdField = DSL.field(DSL.name(AllMetrics.CommonDimension.SHARD_ID.toString()));
-        // select indexName, shardId, sum(MetricsDB.max) from MetricsDB where ShardID is not null
-        // group  by indexName, shardID.
-        return context
-                .select(selectFieldsList)
-                .from(tableName)
-                // as the goal is to aggregate by shardID, it cannot be null.
-                .where(shardIdField.isNotNull())
-                .groupBy(groupByFieldsList).orderBy(aggDimension.desc());
-    }
+  public ShardBasedTemperatureCalculator(TemperatureVector.Dimension metricType) {
+    // The temperature intendeds to spread the temperature around the cluster by re-allocating shards
+    // from the hottest of nodes to the nodes that are relatively cold (with some randomness
+    // so that it does not overwhelm the coldest node). Pyrometer also wants to size for peak
+    // loads. Therefore, here we use MAX as the aggregate function.
+    super(metricType, dimensions);
+  }
 
-    @Override
-    protected Result<Record> createDslAndFetch(final DSLContext context,
-                                               final String tableName,
-                                               final Field<?> aggDimension,
-                                               final List<Field<?>> groupByFieldsList,
-                                               final List<Field<?>> selectFieldsList) {
-        return getSumOfUtilByIndexShardGroup(context, tableName, aggDimension, groupByFieldsList,
-                selectFieldsList).fetch();
-    }
+  protected SelectSeekStep1<Record, ?> getSumOfUtilByIndexShardGroup(final DSLContext context,
+      final String tableName,
+      final Field<?> aggDimension,
+      final List<Field<?>> groupByFieldsList,
+      final List<Field<?>> selectFieldsList) {
+    Field<?> shardIdField = DSL.field(DSL.name(AllMetrics.CommonDimension.SHARD_ID.toString()));
+    // select indexName, shardId, sum(MetricsDB.max) from MetricsDB where ShardID is not null
+    // group  by indexName, shardID.
+    return context
+        .select(selectFieldsList)
+        .from(tableName)
+        // as the goal is to aggregate by shardID, it cannot be null.
+        .where(shardIdField.isNotNull())
+        .groupBy(groupByFieldsList).orderBy(aggDimension.desc());
+  }
+
+  @Override
+  protected Result<Record> createDslAndFetch(final DSLContext context,
+      final String tableName,
+      final Field<?> aggDimension,
+      final List<Field<?>> groupByFieldsList,
+      final List<Field<?>> selectFieldsList) {
+    return getSumOfUtilByIndexShardGroup(context, tableName, aggDimension, groupByFieldsList,
+        selectFieldsList).fetch();
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/capacity/HeapAllocRateTotalTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/capacity/HeapAllocRateTotalTemperatureCalculator.java
@@ -1,0 +1,11 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.capacity;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector.Dimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.capacity.calculators.TotalNodeTemperatureCalculator;
+
+public class HeapAllocRateTotalTemperatureCalculator extends TotalNodeTemperatureCalculator {
+
+  public HeapAllocRateTotalTemperatureCalculator() {
+    super(Dimension.Heap_AllocRate);
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/capacity/TotalCpuUtilForTotalNodeMetric.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/capacity/TotalCpuUtilForTotalNodeMetric.java
@@ -20,7 +20,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.
 
 public class TotalCpuUtilForTotalNodeMetric extends TotalNodeTemperatureCalculator {
 
-    public TotalCpuUtilForTotalNodeMetric() {
-        super(TemperatureVector.Dimension.CPU_Utilization);
-    }
+  public TotalCpuUtilForTotalNodeMetric() {
+    super(TemperatureVector.Dimension.CPU_Utilization);
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/capacity/calculators/TotalNodeTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/capacity/calculators/TotalNodeTemperatureCalculator.java
@@ -25,34 +25,35 @@ import org.jooq.Result;
 
 /**
  * This class gets all rows for the given metric table where the shardID is not NULL. This is to
- * tract resource utilization by shard ID. Shard on a node can be uniquely identified by the
- * index name and shard ID. It might also help to also consider the Operation dimension ?
+ * tract resource utilization by shard ID. Shard on a node can be uniquely identified by the index
+ * name and shard ID. It might also help to also consider the Operation dimension ?
  */
 public class TotalNodeTemperatureCalculator extends TemperatureMetricsBase {
-    // For peak usage there is no group by clause used, therefore this is empty.
-    private static final String[] dimensions = {};
 
-    public TotalNodeTemperatureCalculator(TemperatureVector.Dimension metricType) {
-        super(metricType, dimensions);
-    }
+  // For peak usage there is no group by clause used, therefore this is empty.
+  private static final String[] dimensions = {};
 
-    @Override
-    protected Result<Record> createDslAndFetch(final DSLContext context,
-                                               final String tableName,
-                                               final Field<?> aggDimension,
-                                               final List<Field<?>> groupByFieldsList,
-                                               final List<Field<?>> selectFieldsList) {
+  public TotalNodeTemperatureCalculator(TemperatureVector.Dimension metricType) {
+    super(metricType, dimensions);
+  }
 
-        Result<?> r1 = context
-                .select(selectFieldsList)
-                .from(tableName)
-                .fetch();
-        return (Result<Record>) r1;
-    }
+  @Override
+  protected Result<Record> createDslAndFetch(final DSLContext context,
+      final String tableName,
+      final Field<?> aggDimension,
+      final List<Field<?>> groupByFieldsList,
+      final List<Field<?>> selectFieldsList) {
 
-    @Override
-    protected List<Field<?>> getSelectFieldsList(final List<Field<?>> groupByFields,
-                                                 Field<?> aggrDimension) {
-        return aggrColumnAsSelectField();
-    }
+    Result<?> r1 = context
+        .select(selectFieldsList)
+        .from(tableName)
+        .fetch();
+    return (Result<Record>) r1;
+  }
+
+  @Override
+  protected List<Field<?>> getSelectFieldsList(final List<Field<?>> groupByFields,
+      Field<?> aggrDimension) {
+    return aggrColumnAsSelectField();
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/shardIndependent/HeapAllocRateShardIndependentTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/shardIndependent/HeapAllocRateShardIndependentTemperatureCalculator.java
@@ -1,0 +1,12 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.shardIndependent;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector.Dimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.shardIndependent.calculators.ShardIndependentTemperatureCalculator;
+
+public class HeapAllocRateShardIndependentTemperatureCalculator extends
+    ShardIndependentTemperatureCalculator {
+
+  public HeapAllocRateShardIndependentTemperatureCalculator() {
+    super(Dimension.Heap_AllocRate);
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/shardIndependent/ShardIndependentTemperatureCalculatorCpuUtilMetric.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/shardIndependent/ShardIndependentTemperatureCalculatorCpuUtilMetric.java
@@ -18,9 +18,10 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.shardIndependent.calculators.ShardIndependentTemperatureCalculator;
 
-public class ShardIndependentTemperatureCalculatorCpuUtilMetric extends ShardIndependentTemperatureCalculator {
+public class ShardIndependentTemperatureCalculatorCpuUtilMetric extends
+    ShardIndependentTemperatureCalculator {
 
-    public ShardIndependentTemperatureCalculatorCpuUtilMetric() {
-        super(TemperatureVector.Dimension.CPU_Utilization);
-    }
+  public ShardIndependentTemperatureCalculatorCpuUtilMetric() {
+    super(TemperatureVector.Dimension.CPU_Utilization);
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/shardIndependent/calculators/ShardIndependentTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/shardIndependent/calculators/ShardIndependentTemperatureCalculator.java
@@ -17,7 +17,6 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.AggregateMetric;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.TemperatureMetricsBase;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
@@ -29,59 +28,60 @@ import org.jooq.Result;
 import org.jooq.impl.DSL;
 
 /**
- * Even in metrics that has ShardId dimension, it can be null for some rows.
- * For examples here:
+ * Even in metrics that has ShardId dimension, it can be null for some rows. For examples here:
  *
  * <p>Shard Index Op ShardRole Sum avg min max
- * null null other 0 0 0 0 0
- * null null GC 0.0015470341521869385 0.0015470341521869385 0.0015470341521869385 0.0015470341521869385
- * null null generic 0.016626485462826558 0.016626485462826558 0.016626485462826558 0.016626485462826558
- * null null management 0.0015470341521869385 0.0015470341521869385 0.0015470341521869385 0.0015470341521869385
- * null null httpServer 0 0 0 0
- * null null refresh 0.0009010593643813712 0.0009010593643813712 0.0009010593643813712 0.0009010593643813712
+ * null null other 0 0 0 0 0 null null GC 0.0015470341521869385 0.0015470341521869385
+ * 0.0015470341521869385 0.0015470341521869385 null null generic 0.016626485462826558
+ * 0.016626485462826558 0.016626485462826558 0.016626485462826558 null null management
+ * 0.0015470341521869385 0.0015470341521869385 0.0015470341521869385 0.0015470341521869385 null null
+ * httpServer 0 0 0 0 null null refresh 0.0009010593643813712 0.0009010593643813712
+ * 0.0009010593643813712 0.0009010593643813712
  *
  * <p>But they never the less consume CPU and the Pyrometer has to account for these as part of
  * system CPU. The problem is that if a node is high on shardIndependent CPU, then moving shard
  * around is not going to lessen the node temperature. But these should be accounted for in the
- * destination node where a shard is being placed. If it is already hot because of system CPU,
- * maybe its not a good idea to place a hot shard there.
+ * destination node where a shard is being placed. If it is already hot because of system CPU, maybe
+ * its not a good idea to place a hot shard there.
  *
  * <p>CAVEAT: There are cases where the some of the operations should have been associated with a
  * shard but we are not accounting for them just yet(hopefully we will fix them). So, these CPU
- * percentages will be accounted for in the system CPU, where as they should have been
- * associated with as shard and shard movement would have helped lessen the node temperature.
+ * percentages will be accounted for in the system CPU, where as they should have been associated
+ * with as shard and shard movement would have helped lessen the node temperature.
  */
 public class ShardIndependentTemperatureCalculator extends TemperatureMetricsBase {
-    private static final Logger LOG = LogManager.getLogger(ShardIndependentTemperatureCalculator.class);
 
-    private static final String[] dimensions = {
-            AllMetrics.CommonDimension.OPERATION.toString()
-    };
+  private static final Logger LOG = LogManager
+      .getLogger(ShardIndependentTemperatureCalculator.class);
 
-    public ShardIndependentTemperatureCalculator(TemperatureVector.Dimension metricType) {
-        super(metricType, dimensions);
-    }
+  private static final String[] dimensions = {
+      AllMetrics.CommonDimension.OPERATION.toString()
+  };
 
-    @Override
-    protected Result<Record> createDslAndFetch(DSLContext context, String tableName,
-                                               Field<?> aggDimension,
-                                               List<Field<?>> groupByFieldsList,
-                                               List<Field<?>> selectFieldsList) {
-        Field<?> shardIdField = DSL.field(DSL.name(AllMetrics.CommonDimension.SHARD_ID.toString()));
+  public ShardIndependentTemperatureCalculator(TemperatureVector.Dimension metricType) {
+    super(metricType, dimensions);
+  }
 
-        // select sum(max) from <MetricTable> where ShardID is null;
-        Result<?> res = context
-                .select(aggDimension)
-                .from(tableName)
-                .where(shardIdField.isNull())
-                .fetch();
-        LOG.info("ShardIndependentTemperatureCalculator: {}", res);
-        return (Result<Record>) res;
-    }
+  @Override
+  protected Result<Record> createDslAndFetch(DSLContext context, String tableName,
+      Field<?> aggDimension,
+      List<Field<?>> groupByFieldsList,
+      List<Field<?>> selectFieldsList) {
+    Field<?> shardIdField = DSL.field(DSL.name(AllMetrics.CommonDimension.SHARD_ID.toString()));
 
-    @Override
-    protected List<Field<?>> getSelectFieldsList(final List<Field<?>> groupByFields,
-                                                 Field<?> aggrDimension) {
-        return aggrColumnAsSelectField();
-    }
+    // select sum(max) from <MetricTable> where ShardID is null;
+    Result<?> res = context
+        .select(aggDimension)
+        .from(tableName)
+        .where(shardIdField.isNull())
+        .fetch();
+    LOG.info("ShardIndependentTemperatureCalculator: {}", res);
+    return (Result<Record>) res;
+  }
+
+  @Override
+  protected List<Field<?>> getSelectFieldsList(final List<Field<?>> groupByFields,
+      Field<?> aggrDimension) {
+    return aggrColumnAsSelectField();
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/ClusterTemperatureRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/ClusterTemperatureRca.java
@@ -30,85 +30,90 @@ import java.util.List;
 import java.util.Map;
 
 public class ClusterTemperatureRca extends Rca<ClusterTemperatureFlowUnit> {
-    private final NodeTemperatureRca nodeTemperatureRca;
-    public static final String TABLE_NAME = ClusterTemperatureRca.class.getSimpleName();
 
-    public ClusterTemperatureRca(NodeTemperatureRca nodeTemperatureRca) {
-        super(5);
-        this.nodeTemperatureRca = nodeTemperatureRca;
+  public static final String TABLE_NAME = ClusterTemperatureRca.class.getSimpleName();
+  private final NodeTemperatureRca nodeTemperatureRca;
+
+  public ClusterTemperatureRca(NodeTemperatureRca nodeTemperatureRca) {
+    super(5);
+    this.nodeTemperatureRca = nodeTemperatureRca;
+  }
+
+  @Override
+  public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {
+    throw new IllegalArgumentException(name() + "'s generateFlowUnitListFromWire() should not "
+        + "be required.");
+  }
+
+  /**
+   * @return
+   */
+  @Override
+  public ClusterTemperatureFlowUnit operate() {
+    List<CompactNodeTemperatureFlowUnit> flowUnits = nodeTemperatureRca.getFlowUnits();
+    Map<String, CompactClusterLevelNodeSummary> nodeTemperatureSummaryMap =
+        new HashMap<>();
+    final int NUM_NODES = flowUnits.size();
+
+    ClusterTemperatureSummary clusterTemperatureSummary = new ClusterTemperatureSummary(NUM_NODES);
+
+    // For each dimension go through the temperature profiles sent by each node and figure
+    // out the cluster level average along that dimension. Then this method recreates a
+    // temperature profile for each of the nodes. This is required because what nodes sent was
+    // respect to the nodes but at cluster level they need to be re-calibrated at the cluster
+    // level. Note that temperature is a normalized value, normalized by total usage. At node
+    // level, the total usage is at the node level (over all shards and shard-independent
+    // factors), at the master the total usage is the sum over all nodes.
+    for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
+      double totalForDimension = 0.0;
+      for (CompactNodeTemperatureFlowUnit nodeFlowUnit : flowUnits) {
+        CompactNodeSummary summary = nodeFlowUnit.getCompactNodeTemperatureSummary();
+        totalForDimension += summary.getTotalConsumedByDimension(dimension);
+      }
+      double nodeAverageForDimension = totalForDimension / NUM_NODES;
+      TemperatureVector.NormalizedValue normalizedAvgForDimension =
+          TemperatureVector.NormalizedValue.calculate(nodeAverageForDimension, totalForDimension);
+
+      clusterTemperatureSummary.createClusterDimensionalTemperature(dimension,
+          normalizedAvgForDimension, totalForDimension);
+
+      recalibrateNodeTemperaturesAtClusterLevelUsage(flowUnits, nodeTemperatureSummaryMap,
+          dimension, totalForDimension, nodeAverageForDimension);
     }
+    clusterTemperatureSummary.addNodesSummaries(nodeTemperatureSummaryMap);
 
-    @Override
-    public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {
-        throw new IllegalArgumentException(name() + "'s generateFlowUnitListFromWire() should not "
-                + "be required.");
+    return new ClusterTemperatureFlowUnit(System.currentTimeMillis(),
+        new ResourceContext(Resources.State.UNKNOWN), clusterTemperatureSummary);
+  }
+
+  private void recalibrateNodeTemperaturesAtClusterLevelUsage(
+      List<CompactNodeTemperatureFlowUnit> flowUnits,
+      Map<String,
+          CompactClusterLevelNodeSummary> nodeTemperatureSummaryMap,
+      TemperatureVector.Dimension dimension,
+      double totalForDimension,
+      double avgForTheDimension) {
+    for (CompactNodeTemperatureFlowUnit nodeFlowUnit : flowUnits) {
+      CompactNodeSummary obtainedNodeTempSummary =
+          nodeFlowUnit.getCompactNodeTemperatureSummary();
+      String key = obtainedNodeTempSummary.getNodeId();
+
+      nodeTemperatureSummaryMap.putIfAbsent(key,
+          new CompactClusterLevelNodeSummary(obtainedNodeTempSummary.getNodeId(),
+              obtainedNodeTempSummary.getHostAddress()));
+      CompactClusterLevelNodeSummary constructedCompactNodeTemperatureSummary =
+          nodeTemperatureSummaryMap.get(key);
+
+      double obtainedTotal = obtainedNodeTempSummary.getTotalConsumedByDimension(dimension);
+      TemperatureVector.NormalizedValue newClusterBasedValue =
+          TemperatureVector.NormalizedValue.calculate(obtainedTotal, totalForDimension);
+
+      constructedCompactNodeTemperatureSummary
+          .setTemperatureForDimension(dimension, newClusterBasedValue);
+      constructedCompactNodeTemperatureSummary.setNumOfShards(dimension,
+          obtainedNodeTempSummary.getNumberOfShardsByDimension(dimension));
+      constructedCompactNodeTemperatureSummary
+          .setTotalConsumedByDimension(dimension, obtainedTotal);
     }
-
-    /**
-     * @return
-     */
-    @Override
-    public ClusterTemperatureFlowUnit operate() {
-        List<CompactNodeTemperatureFlowUnit> flowUnits = nodeTemperatureRca.getFlowUnits();
-        Map<String, CompactClusterLevelNodeSummary> nodeTemperatureSummaryMap =
-                new HashMap<>();
-        final int NUM_NODES = flowUnits.size();
-
-        ClusterTemperatureSummary clusterTemperatureSummary = new ClusterTemperatureSummary(NUM_NODES);
-
-        // For each dimension go through the temperature profiles sent by each node and figure
-        // out the cluster level average along that dimension. Then this method recreates a
-        // temperature profile for each of the nodes. This is required because what nodes sent was
-        // respect to the nodes but at cluster level they need to be re-calibrated at the cluster
-        // level. Note that temperature is a normalized value, normalized by total usage. At node
-        // level, the total usage is at the node level (over all shards and shard-independent
-        // factors), at the master the total usage is the sum over all nodes.
-        for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
-            double totalForDimension = 0.0;
-            for (CompactNodeTemperatureFlowUnit nodeFlowUnit : flowUnits) {
-                CompactNodeSummary summary = nodeFlowUnit.getCompactNodeTemperatureSummary();
-                totalForDimension += summary.getTotalConsumedByDimension(dimension);
-            }
-            double nodeAverageForDimension = totalForDimension / NUM_NODES;
-            TemperatureVector.NormalizedValue normalizedAvgForDimension =
-                    TemperatureVector.NormalizedValue.calculate(nodeAverageForDimension, totalForDimension);
-
-            clusterTemperatureSummary.createClusterDimensionalTemperature(dimension,
-                    normalizedAvgForDimension, totalForDimension);
-
-            recalibrateNodeTemperaturesAtClusterLevelUsage(flowUnits, nodeTemperatureSummaryMap,
-                    dimension, totalForDimension, nodeAverageForDimension);
-        }
-        clusterTemperatureSummary.addNodesSummaries(nodeTemperatureSummaryMap);
-        return new ClusterTemperatureFlowUnit(System.currentTimeMillis(),
-                new ResourceContext(Resources.State.UNKNOWN), clusterTemperatureSummary);
-    }
-
-    private void recalibrateNodeTemperaturesAtClusterLevelUsage(List<CompactNodeTemperatureFlowUnit> flowUnits,
-                                                                Map<String,
-                                                                        CompactClusterLevelNodeSummary> nodeTemperatureSummaryMap,
-                                                                TemperatureVector.Dimension dimension,
-                                                                double totalForDimension,
-                                                                double avgForTheDimension) {
-        for (CompactNodeTemperatureFlowUnit nodeFlowUnit : flowUnits) {
-            CompactNodeSummary obtainedNodeTempSummary =
-                    nodeFlowUnit.getCompactNodeTemperatureSummary();
-            String key = obtainedNodeTempSummary.getNodeId();
-
-            nodeTemperatureSummaryMap.putIfAbsent(key,
-                    new CompactClusterLevelNodeSummary(obtainedNodeTempSummary.getNodeId(),
-                            obtainedNodeTempSummary.getHostAddress()));
-            CompactClusterLevelNodeSummary constructedCompactNodeTemperatureSummary =
-                    nodeTemperatureSummaryMap.get(key);
-
-            double obtainedTotal = obtainedNodeTempSummary.getTotalConsumedByDimension(dimension);
-            TemperatureVector.NormalizedValue newClusterBasedValue =
-                    TemperatureVector.NormalizedValue.calculate(obtainedTotal, totalForDimension);
-
-            constructedCompactNodeTemperatureSummary.setTemperatureForDimension(dimension, newClusterBasedValue);
-            constructedCompactNodeTemperatureSummary.setNumOfShards(dimension,
-                    obtainedNodeTempSummary.getNumberOfShardsByDimension(dimension));
-            constructedCompactNodeTemperatureSummary.setTotalConsumedByDimension(dimension, obtainedTotal);
-        }
-    }
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/NodeTemperatureRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/NodeTemperatureRca.java
@@ -26,6 +26,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.NodeLevelDimensionalSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.dimension.CpuUtilDimensionTemperatureRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.dimension.HeapAllocRateTemperatureRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,71 +34,93 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class NodeTemperatureRca extends Rca<CompactNodeTemperatureFlowUnit> {
-    private final CpuUtilDimensionTemperatureRca cpuUtilDimensionTemperatureRca;
-    private static final Logger LOG = LogManager.getLogger(NodeTemperatureRca.class);
-    //private final HeapAllocHeatRca heapAllocHeatRca;
 
-    public NodeTemperatureRca(CpuUtilDimensionTemperatureRca cpuUtilDimensionTemperatureRca) {
-        super(5);
-        this.cpuUtilDimensionTemperatureRca = cpuUtilDimensionTemperatureRca;
-        //this.heapAllocHeatRca = heapAllocHeatRca;
+  private static final Logger LOG = LogManager.getLogger(NodeTemperatureRca.class);
+  private final CpuUtilDimensionTemperatureRca cpuUtilDimensionTemperatureRca;
+  private final HeapAllocRateTemperatureRca heapAllocRateTemperatureRca;
+
+  public NodeTemperatureRca(CpuUtilDimensionTemperatureRca cpuUtilDimensionTemperatureRca,
+      HeapAllocRateTemperatureRca heapAllocRateTemperatureRca) {
+    super(5);
+    this.cpuUtilDimensionTemperatureRca = cpuUtilDimensionTemperatureRca;
+    this.heapAllocRateTemperatureRca = heapAllocRateTemperatureRca;
+  }
+
+  @Override
+  public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {
+    final List<FlowUnitMessage> flowUnitMessages =
+        args.getWireHopper().readFromWire(args.getNode());
+    List<CompactNodeTemperatureFlowUnit> flowUnitList = new ArrayList<>();
+    LOG.info("rca: Executing fromWire: {}", this.getClass().getSimpleName());
+    for (FlowUnitMessage flowUnitMessage : flowUnitMessages) {
+      flowUnitList.add(CompactNodeTemperatureFlowUnit.buildFlowUnitFromWrapper(flowUnitMessage));
+    }
+    LOG.info("cntfu: rfw size() = " + flowUnitList.size());
+    setFlowUnits(flowUnitList);
+  }
+
+  /**
+   * The goal of the NodeHeatRca is to build a node level temperature profile.
+   *
+   * <p>This is done by accumulating the {@code DimensionalFlowUnit} s it receives from the
+   * individual ResourceHeatRcas. The temperature profile build here is sent to the elected master
+   * node where this is used to calculate the cluster temperature profile.
+   *
+   * @return
+   */
+  @Override
+  public CompactNodeTemperatureFlowUnit operate() {
+    // TODO: Make this process a list of dimensions instead of writing them out and add the
+    //  processed dimension profiles to the summary.
+    List<DimensionalTemperatureFlowUnit> cpuFlowUnits = cpuUtilDimensionTemperatureRca
+        .getFlowUnits();
+    List<DimensionalTemperatureFlowUnit> heapAllocRateFlowUnits = heapAllocRateTemperatureRca
+        .getFlowUnits();
+    // EachResourceLevelHeat RCA should generate a one @{code DimensionalFlowUnit}.
+    if (cpuFlowUnits.size() != 1) {
+      throw new IllegalArgumentException("One flow unit expected. Found: " + cpuFlowUnits);
     }
 
-    @Override
-    public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {
-        final List<FlowUnitMessage> flowUnitMessages =
-                args.getWireHopper().readFromWire(args.getNode());
-        List<CompactNodeTemperatureFlowUnit> flowUnitList = new ArrayList<>();
-        LOG.debug("rca: Executing fromWire: {}", this.getClass().getSimpleName());
-        for (FlowUnitMessage flowUnitMessage : flowUnitMessages) {
-            flowUnitList.add(CompactNodeTemperatureFlowUnit.buildFlowUnitFromWrapper(flowUnitMessage));
-        }
-        setFlowUnits(flowUnitList);
+    if (heapAllocRateFlowUnits.size() != 1) {
+      throw new IllegalStateException("One flow unit expected. Found: " + heapAllocRateFlowUnits);
     }
 
-    /**
-     * The goal of the NodeHeatRca is to build a node level temperature profile.
-     *
-     * <p>This is done by accumulating the {@code DimensionalFlowUnit} s it receives from the
-     * individual ResourceHeatRcas. The temperature profile build here is sent to the elected master
-     * node where this is used to calculate the cluster temperature profile.
-     *
-     * @return
-     */
-    @Override
-    public CompactNodeTemperatureFlowUnit operate() {
-        List<DimensionalTemperatureFlowUnit> cpuFlowUnits = cpuUtilDimensionTemperatureRca.getFlowUnits();
-        // EachResourceLevelHeat RCA should generate a one @{code DimensionalFlowUnit}.
-        if (cpuFlowUnits.size() != 1) {
-            throw new IllegalArgumentException("One flow unit expected. Found: " + cpuFlowUnits);
-        }
-
-        // This means that the input RCA didn't calculate anything. We can move on as well.
-        if (cpuFlowUnits.get(0).isEmpty()) {
-            return new CompactNodeTemperatureFlowUnit(System.currentTimeMillis());
-        }
-
-        List<NodeLevelDimensionalSummary> nodeDimensionProfiles = new ArrayList<>();
-        nodeDimensionProfiles.add(cpuFlowUnits.get(0).getNodeDimensionProfile());
-        FullNodeTemperatureSummary nodeProfile = buildNodeProfile(nodeDimensionProfiles);
-
-        ResourceContext resourceContext = new ResourceContext(Resources.State.UNKNOWN);
-        CompactNodeSummary summary = new CompactNodeSummary(nodeProfile.getNodeId(),
-                    nodeProfile.getHostAddress());
-        summary.fillFromNodeProfile(nodeProfile);
-
-        return new CompactNodeTemperatureFlowUnit(System.currentTimeMillis(), resourceContext, summary,
-                true);
+    // This means that the input RCA didn't calculate anything. We can move on as well.
+    if (cpuFlowUnits.get(0).isEmpty() && heapAllocRateFlowUnits.get(0).isEmpty()) {
+      return new CompactNodeTemperatureFlowUnit(System.currentTimeMillis());
     }
 
-    private FullNodeTemperatureSummary buildNodeProfile(List<NodeLevelDimensionalSummary> dimensionProfiles) {
-        ClusterDetailsEventProcessor.NodeDetails currentNodeDetails =
-                ClusterDetailsEventProcessor.getCurrentNodeDetails();
-        FullNodeTemperatureSummary nodeProfile = new FullNodeTemperatureSummary(currentNodeDetails.getId(),
-                currentNodeDetails.getHostAddress());
-        for (NodeLevelDimensionalSummary profile : dimensionProfiles) {
-            nodeProfile.updateNodeDimensionProfile(profile);
-        }
-        return nodeProfile;
+    List<NodeLevelDimensionalSummary> nodeDimensionProfiles = new ArrayList<>();
+    if (!cpuFlowUnits.get(0).isEmpty()) {
+      nodeDimensionProfiles.add(cpuFlowUnits.get(0).getNodeDimensionProfile());
     }
+
+    if (!heapAllocRateFlowUnits.get(0).isEmpty()) {
+      nodeDimensionProfiles.add(heapAllocRateFlowUnits.get(0).getNodeDimensionProfile());
+    }
+    FullNodeTemperatureSummary nodeProfile = buildNodeProfile(nodeDimensionProfiles);
+
+    ResourceContext resourceContext = new ResourceContext(Resources.State.UNKNOWN);
+    CompactNodeSummary summary = new CompactNodeSummary(nodeProfile.getNodeId(),
+        nodeProfile.getHostAddress());
+    summary.fillFromNodeProfile(nodeProfile);
+
+    return new CompactNodeTemperatureFlowUnit(
+        System.currentTimeMillis(), resourceContext,
+        summary,
+        true);
+  }
+
+  private FullNodeTemperatureSummary buildNodeProfile(
+      List<NodeLevelDimensionalSummary> dimensionProfiles) {
+    ClusterDetailsEventProcessor.NodeDetails currentNodeDetails =
+        ClusterDetailsEventProcessor.getCurrentNodeDetails();
+    FullNodeTemperatureSummary nodeProfile = new FullNodeTemperatureSummary(
+        currentNodeDetails.getId(),
+        currentNodeDetails.getHostAddress());
+    for (NodeLevelDimensionalSummary profile : dimensionProfiles) {
+      nodeProfile.updateNodeDimensionProfile(profile);
+    }
+    return nodeProfile;
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/dimension/HeapAllocRateTemperatureRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/dimension/HeapAllocRateTemperatureRca.java
@@ -1,0 +1,61 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.dimension;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Rca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.temperature.DimensionalTemperatureFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.ShardStore;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector.Dimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector.NormalizedValue;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.HeapAllocRateByShardAvgTemperatureCalculator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.HeapAllocRateByShardTemperatureCalculator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.capacity.HeapAllocRateTotalTemperatureCalculator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.shardIndependent.HeapAllocRateShardIndependentTemperatureCalculator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.DimensionalTemperatureCalculator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class HeapAllocRateTemperatureRca extends Rca<DimensionalTemperatureFlowUnit> {
+
+  private static final Logger LOG = LogManager.getLogger(HeapAllocRateTemperatureRca.class);
+  // The threshold set here is an initial threshold only.
+  // TODO: Update the threshold appropriately after testing so that we assign heat correctly.
+  private static final NormalizedValue THRESHOLD = new TemperatureVector.NormalizedValue((short) 2);
+  private static final int EVALUATION_INTERVAL_IN_S = 5;
+  private final HeapAllocRateByShardTemperatureCalculator HEAP_ALLOC_RATE_BY_SHARD;
+  private final HeapAllocRateByShardAvgTemperatureCalculator HEAP_ALLOC_RATE_BY_SHARD_AVG;
+  private final HeapAllocRateShardIndependentTemperatureCalculator HEAP_ALLOC_RATE_SHARD_INDEPENDENT;
+  private final HeapAllocRateTotalTemperatureCalculator HEAP_ALLOC_RATE_TOTAL;
+  private final ShardStore SHARD_STORE;
+
+  public HeapAllocRateTemperatureRca(final ShardStore shardStore,
+      final HeapAllocRateByShardTemperatureCalculator heapAllocByShard,
+      final HeapAllocRateByShardAvgTemperatureCalculator heapAllocByShardAvg,
+      final HeapAllocRateShardIndependentTemperatureCalculator shardIndependentHeapAllocRate,
+      final HeapAllocRateTotalTemperatureCalculator heapAllocRateTotal) {
+    super(EVALUATION_INTERVAL_IN_S);
+    this.SHARD_STORE = shardStore;
+    this.HEAP_ALLOC_RATE_BY_SHARD = heapAllocByShard;
+    this.HEAP_ALLOC_RATE_BY_SHARD_AVG = heapAllocByShardAvg;
+    this.HEAP_ALLOC_RATE_SHARD_INDEPENDENT = shardIndependentHeapAllocRate;
+    this.HEAP_ALLOC_RATE_TOTAL = heapAllocRateTotal;
+  }
+
+  @Override
+  public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {
+    throw new IllegalStateException("This node: [" + name() + "] should not have received flow "
+        + "units from remote nodes.");
+  }
+
+  @Override
+  public DimensionalTemperatureFlowUnit operate() {
+    LOG.debug("executing : {}", name());
+    DimensionalTemperatureFlowUnit heapAllocRateTemperatureFlowUnit =
+        DimensionalTemperatureCalculator.getTemperatureForDimension(SHARD_STORE,
+            Dimension.Heap_AllocRate, HEAP_ALLOC_RATE_BY_SHARD, HEAP_ALLOC_RATE_BY_SHARD_AVG,
+            HEAP_ALLOC_RATE_SHARD_INDEPENDENT, HEAP_ALLOC_RATE_TOTAL, THRESHOLD);
+    LOG.info("Heap allocation rate temperature calculated: {}",
+        heapAllocRateTemperatureFlowUnit.getNodeDimensionProfile());
+    return heapAllocRateTemperatureFlowUnit;
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ResourceHeatMapGraphTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ResourceHeatMapGraphTest.java
@@ -485,9 +485,9 @@ public class ResourceHeatMapGraphTest {
                     0.01);
             Assert.assertEquals(3, node.get("CPU_Utilization_num_shards").getAsInt());
 
-            Assert.assertEquals(0, node.get("Heap_AllocRate_mean").getAsInt());
-            Assert.assertEquals(0, node.get("Heap_AllocRate_total").getAsInt());
-            Assert.assertEquals(0, node.get("Heap_AllocRate_num_shards").getAsInt());
+            Assert.assertEquals(10, node.get("Heap_AllocRate_mean").getAsInt());
+            Assert.assertEquals(239855498, node.get("Heap_AllocRate_total").getAsInt());
+            Assert.assertEquals(3, node.get("Heap_AllocRate_num_shards").getAsInt());
 
             Assert.assertEquals(0, node.get("IO_READ_SYSCALL_RATE_mean").getAsInt());
             Assert.assertEquals(0, node.get("IO_READ_SYSCALL_RATE_total").getAsInt());


### PR DESCRIPTION
*Issue #, if available:*
#150 
*Description of changes:*
This is a first cut addition of heap allocation rate as a dimension in the temperature profile.

This change adds 4 new supporting metric vertices, which flow into the HeapAllocRateTemperatureRca vertex, which then contributes to NodeTemperatureRca thereby adding heap allocation rate as dimension across which heat is measured in the cluster.

There are some cosmetic changes that can be made at a later point in time, these are marked as TODOs.
 
*Tests:*
Tested with cortisol on an odfe docker setup on a c4.4xl instance.

*Code coverage percentage for this patch:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
