### PR TITLE
Add temperature profile along heap allocation rate dimension with no …

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/temperature/CompactNodeTemperatureFlowUnit.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/temperature/CompactNodeTemperatureFlowUnit.java
@@ -48,7 +48,9 @@ public class CompactNodeTemperatureFlowUnit extends ResourceFlowUnit {
         builder.setGraphNode(graphNode);
         builder.setEsNode(esNode);
         builder.setTimeStamp(System.currentTimeMillis());
-        compactNodeTemperatureSummary.buildSummaryMessageAndAddToFlowUnit(builder);
+        if (compactNodeTemperatureSummary != null) {
+            compactNodeTemperatureSummary.buildSummaryMessageAndAddToFlowUnit(builder);
+        }
         return builder.build();
     }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/CompactNodeSummary.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/CompactNodeSummary.java
@@ -21,6 +21,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceTemp
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector.NormalizedValue;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import java.util.ArrayList;
@@ -131,7 +132,12 @@ public class CompactNodeSummary extends GenericSummary {
             int index = dimension.ordinal();
             ResourceTemperatureMessage.Builder builder = ResourceTemperatureMessage.newBuilder();
             builder.setResourceName(dimension.NAME);
-            builder.setMeanUsage(temperatureVector.getTemperatureFor(dimension).getPOINTS());
+            NormalizedValue normalizedMean = temperatureVector.getTemperatureFor(dimension);
+            if (normalizedMean != null) {
+                builder.setMeanUsage(normalizedMean.getPOINTS());
+            } else {
+                builder.setMeanUsage(0);
+            }
             builder.setNumberOfShards(numOfShards[index]);
             builder.setTotalUsage(totalConsumedByDimension[index]);
             summaryBuilder.setCpuTemperature(index, builder);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/ShardProfileSummary.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/ShardProfileSummary.java
@@ -101,13 +101,8 @@ public class ShardProfileSummary extends GenericSummary {
 
     public void addTemperatureForDimension(TemperatureVector.Dimension dimension,
                                            TemperatureVector.NormalizedValue value) {
-        TemperatureVector.NormalizedValue oldValue = getHeatInDimension(dimension);
-        if (oldValue != null) {
-            String err = String.format("Trying to update the temperature along dimension '%s' of "
-                    + "shard '%s' twice. OldValue: '%s', newValue: '%s'", dimension, toString(),
-                    oldValue, value);
-            throw new IllegalArgumentException(err);
-        }
+        // TODO: Need to handle rcas updating heat profile of a shard along a dimension multiple
+        //  times per tick.
         temperatureVector.updateTemperatureForDimension(dimension, value);
     }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/DummyGraph.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/DummyGraph.java
@@ -51,7 +51,11 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.AggregateMetric.AggregateFunction;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.AvgCpuUtilByShardsMetricBasedTemperatureCalculator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.CpuUtilByShardsMetricBasedTemperatureCalculator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.HeapAllocRateByShardAvgTemperatureCalculator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.HeapAllocRateByShardTemperatureCalculator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.capacity.HeapAllocRateTotalTemperatureCalculator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.capacity.TotalCpuUtilForTotalNodeMetric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.shardIndependent.HeapAllocRateShardIndependentTemperatureCalculator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.shardIndependent.ShardIndependentTemperatureCalculatorCpuUtilMetric;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HighHeapUsageClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HotNodeClusterRca;
@@ -62,12 +66,17 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hot
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.ClusterTemperatureRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.NodeTemperatureRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.dimension.CpuUtilDimensionTemperatureRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.dimension.HeapAllocRateTemperatureRca;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class DummyGraph extends AnalysisGraph {
+
+  private static final Logger LOG = LogManager.getLogger(DummyGraph.class);
 
   @Override
   public void construct() {
@@ -75,8 +84,9 @@ public class DummyGraph extends AnalysisGraph {
     Metric gcEvent = new GC_Collection_Event(5);
     Metric heapMax = new Heap_Max(5);
     Metric gc_Collection_Time = new GC_Collection_Time(5);
-    Metric cpuUtilizationGroupByOperation = new AggregateMetric(1, CPU_Utilization.NAME, AggregateFunction.SUM,
-              MetricsDB.AVG, CommonDimension.OPERATION.toString());
+    Metric cpuUtilizationGroupByOperation = new AggregateMetric(1, CPU_Utilization.NAME,
+        AggregateFunction.SUM,
+        MetricsDB.AVG, CommonDimension.OPERATION.toString());
 
     heapUsed.addTag(TAG_LOCUS, LOCUS_DATA_MASTER_NODE);
     gcEvent.addTag(TAG_LOCUS, LOCUS_DATA_MASTER_NODE);
@@ -112,7 +122,8 @@ public class DummyGraph extends AnalysisGraph {
     Rca<ResourceFlowUnit> hotJVMNodeRca = new HotNodeRca(12, highHeapUsageOldGenRca,
         highHeapUsageYoungGenRca, highCpuRca);
     hotJVMNodeRca.addTag(TAG_LOCUS, LOCUS_DATA_MASTER_NODE);
-    hotJVMNodeRca.addAllUpstreams(Arrays.asList(highHeapUsageOldGenRca, highHeapUsageYoungGenRca, highCpuRca));
+    hotJVMNodeRca.addAllUpstreams(
+        Arrays.asList(highHeapUsageOldGenRca, highHeapUsageYoungGenRca, highCpuRca));
 
     Rca<ResourceFlowUnit> highHeapUsageClusterRca =
         new HighHeapUsageClusterRca(12, hotJVMNodeRca);
@@ -125,9 +136,9 @@ public class DummyGraph extends AnalysisGraph {
     hotNodeClusterRca.addTag(TAG_LOCUS, LOCUS_MASTER_NODE);
     hotNodeClusterRca.addAllUpstreams(Collections.singletonList(hotJVMNodeRca));
 
-    // constructResourceHeatMapGraph();
+    constructResourceHeatMapGraph();
   }
-  
+
   private List<Metric> constructNodeStatsMetrics() {
     List<Metric> nodeStatsMetrics = new ArrayList<Metric>() {{
       add(new Cache_FieldData_Size(5));
@@ -150,42 +161,71 @@ public class DummyGraph extends AnalysisGraph {
     }
     return nodeStatsMetrics;
   }
-  
-    protected void constructResourceHeatMapGraph() {
-        ShardStore shardStore = new ShardStore();
 
-        CpuUtilByShardsMetricBasedTemperatureCalculator cpuUtilByShard =
-                new CpuUtilByShardsMetricBasedTemperatureCalculator();
-        AvgCpuUtilByShardsMetricBasedTemperatureCalculator avgCpuUtilByShards =
-                new AvgCpuUtilByShardsMetricBasedTemperatureCalculator();
-        ShardIndependentTemperatureCalculatorCpuUtilMetric shardIndependentCpuUtilMetric =
-                new ShardIndependentTemperatureCalculatorCpuUtilMetric();
-        TotalCpuUtilForTotalNodeMetric cpuUtilPeakUsage = new TotalCpuUtilForTotalNodeMetric();
+  protected void constructResourceHeatMapGraph() {
+    LOG.info("Constructing temperature profile RCA components");
+    ShardStore shardStore = new ShardStore();
 
-        // heap map is developed only for data nodes.
-        cpuUtilByShard.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
-        avgCpuUtilByShards.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
-        shardIndependentCpuUtilMetric.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
-        cpuUtilPeakUsage.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
+    HeapAllocRateByShardTemperatureCalculator heapAllocByShard =
+        new HeapAllocRateByShardTemperatureCalculator();
+    HeapAllocRateByShardAvgTemperatureCalculator heapAllocRateByShardAvg =
+        new HeapAllocRateByShardAvgTemperatureCalculator();
+    HeapAllocRateShardIndependentTemperatureCalculator shardIndependentHeapAllocRate =
+        new HeapAllocRateShardIndependentTemperatureCalculator();
+    HeapAllocRateTotalTemperatureCalculator heapAllocRateTotal =
+        new HeapAllocRateTotalTemperatureCalculator();
 
-        addLeaf(cpuUtilByShard);
-        addLeaf(avgCpuUtilByShards);
-        addLeaf(shardIndependentCpuUtilMetric);
-        addLeaf(cpuUtilPeakUsage);
+    CpuUtilByShardsMetricBasedTemperatureCalculator cpuUtilByShard =
+        new CpuUtilByShardsMetricBasedTemperatureCalculator();
+    AvgCpuUtilByShardsMetricBasedTemperatureCalculator avgCpuUtilByShards =
+        new AvgCpuUtilByShardsMetricBasedTemperatureCalculator();
+    ShardIndependentTemperatureCalculatorCpuUtilMetric shardIndependentCpuUtilMetric =
+        new ShardIndependentTemperatureCalculatorCpuUtilMetric();
+    TotalCpuUtilForTotalNodeMetric cpuUtilPeakUsage = new TotalCpuUtilForTotalNodeMetric();
 
-        CpuUtilDimensionTemperatureRca cpuUtilHeat = new CpuUtilDimensionTemperatureRca(shardStore, cpuUtilByShard,
-                avgCpuUtilByShards,
-                shardIndependentCpuUtilMetric, cpuUtilPeakUsage);
-        cpuUtilHeat.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
-        cpuUtilHeat.addAllUpstreams(Arrays.asList(cpuUtilByShard, avgCpuUtilByShards,
-                shardIndependentCpuUtilMetric, cpuUtilPeakUsage));
+    // heat map is developed only for data nodes.
+    cpuUtilByShard.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
+    avgCpuUtilByShards.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
+    shardIndependentCpuUtilMetric.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
+    cpuUtilPeakUsage.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
 
-        NodeTemperatureRca nodeTemperatureRca = new NodeTemperatureRca(cpuUtilHeat);
-        nodeTemperatureRca.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
-        nodeTemperatureRca.addAllUpstreams(Arrays.asList(cpuUtilHeat));
+    heapAllocByShard.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
+    heapAllocRateByShardAvg.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
+    shardIndependentHeapAllocRate.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
+    heapAllocRateTotal.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
 
-        ClusterTemperatureRca clusterTemperatureRca = new ClusterTemperatureRca(nodeTemperatureRca);
-        clusterTemperatureRca.addTag(TAG_LOCUS, LOCUS_MASTER_NODE);
-        clusterTemperatureRca.addAllUpstreams(Arrays.asList(nodeTemperatureRca));
-    }
+    addLeaf(cpuUtilByShard);
+    addLeaf(avgCpuUtilByShards);
+    addLeaf(shardIndependentCpuUtilMetric);
+    addLeaf(cpuUtilPeakUsage);
+
+    addLeaf(heapAllocByShard);
+    addLeaf(heapAllocRateByShardAvg);
+    addLeaf(shardIndependentHeapAllocRate);
+    addLeaf(heapAllocRateTotal);
+
+    CpuUtilDimensionTemperatureRca cpuUtilHeat = new CpuUtilDimensionTemperatureRca(shardStore,
+        cpuUtilByShard,
+        avgCpuUtilByShards,
+        shardIndependentCpuUtilMetric, cpuUtilPeakUsage);
+    cpuUtilHeat.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
+    cpuUtilHeat.addAllUpstreams(Arrays.asList(cpuUtilByShard, avgCpuUtilByShards,
+        shardIndependentCpuUtilMetric, cpuUtilPeakUsage));
+
+    HeapAllocRateTemperatureRca heapAllocRateHeat = new HeapAllocRateTemperatureRca(shardStore,
+        heapAllocByShard, heapAllocRateByShardAvg, shardIndependentHeapAllocRate,
+        heapAllocRateTotal);
+
+    heapAllocRateHeat.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
+    heapAllocRateHeat.addAllUpstreams(Arrays.asList(heapAllocByShard, heapAllocRateByShardAvg,
+        shardIndependentHeapAllocRate, heapAllocRateTotal));
+
+    NodeTemperatureRca nodeTemperatureRca = new NodeTemperatureRca(cpuUtilHeat, heapAllocRateHeat);
+    nodeTemperatureRca.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
+    nodeTemperatureRca.addAllUpstreams(Arrays.asList(cpuUtilHeat, heapAllocRateHeat));
+
+    ClusterTemperatureRca clusterTemperatureRca = new ClusterTemperatureRca(nodeTemperatureRca);
+    clusterTemperatureRca.addTag(TAG_LOCUS, LOCUS_MASTER_NODE);
+    clusterTemperatureRca.addAllUpstreams(Collections.singletonList(nodeTemperatureRca));
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/HeapAllocRateByShardAvgTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/HeapAllocRateByShardAvgTemperatureCalculator.java
@@ -1,0 +1,12 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector.Dimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.calculators.AvgShardBasedTemperatureCalculator;
+
+public class HeapAllocRateByShardAvgTemperatureCalculator extends
+    AvgShardBasedTemperatureCalculator {
+
+  public HeapAllocRateByShardAvgTemperatureCalculator() {
+    super(Dimension.Heap_AllocRate);
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/HeapAllocRateByShardTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/HeapAllocRateByShardTemperatureCalculator.java
@@ -1,0 +1,11 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector.Dimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.calculators.ShardBasedTemperatureCalculator;
+
+public class HeapAllocRateByShardTemperatureCalculator extends ShardBasedTemperatureCalculator {
+
+  public HeapAllocRateByShardTemperatureCalculator() {
+    super(Dimension.Heap_AllocRate);
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/capacity/HeapAllocRateTotalTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/capacity/HeapAllocRateTotalTemperatureCalculator.java
@@ -1,0 +1,11 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.capacity;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector.Dimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.capacity.calculators.TotalNodeTemperatureCalculator;
+
+public class HeapAllocRateTotalTemperatureCalculator extends TotalNodeTemperatureCalculator {
+
+  public HeapAllocRateTotalTemperatureCalculator() {
+    super(Dimension.Heap_AllocRate);
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/shardIndependent/HeapAllocRateShardIndependentTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/shardIndependent/HeapAllocRateShardIndependentTemperatureCalculator.java
@@ -1,0 +1,12 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.shardIndependent;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector.Dimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.shardIndependent.calculators.ShardIndependentTemperatureCalculator;
+
+public class HeapAllocRateShardIndependentTemperatureCalculator extends
+    ShardIndependentTemperatureCalculator {
+
+  public HeapAllocRateShardIndependentTemperatureCalculator() {
+    super(Dimension.Heap_AllocRate);
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/NodeTemperatureRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/NodeTemperatureRca.java
@@ -26,6 +26,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.NodeLevelDimensionalSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.dimension.CpuUtilDimensionTemperatureRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.dimension.HeapAllocRateTemperatureRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,71 +34,92 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class NodeTemperatureRca extends Rca<CompactNodeTemperatureFlowUnit> {
-    private final CpuUtilDimensionTemperatureRca cpuUtilDimensionTemperatureRca;
-    private static final Logger LOG = LogManager.getLogger(NodeTemperatureRca.class);
-    //private final HeapAllocHeatRca heapAllocHeatRca;
 
-    public NodeTemperatureRca(CpuUtilDimensionTemperatureRca cpuUtilDimensionTemperatureRca) {
-        super(5);
-        this.cpuUtilDimensionTemperatureRca = cpuUtilDimensionTemperatureRca;
-        //this.heapAllocHeatRca = heapAllocHeatRca;
+  private static final Logger LOG = LogManager.getLogger(NodeTemperatureRca.class);
+  private final CpuUtilDimensionTemperatureRca cpuUtilDimensionTemperatureRca;
+  private final HeapAllocRateTemperatureRca heapAllocRateTemperatureRca;
+
+  public NodeTemperatureRca(CpuUtilDimensionTemperatureRca cpuUtilDimensionTemperatureRca,
+      HeapAllocRateTemperatureRca heapAllocRateTemperatureRca) {
+    super(5);
+    this.cpuUtilDimensionTemperatureRca = cpuUtilDimensionTemperatureRca;
+    this.heapAllocRateTemperatureRca = heapAllocRateTemperatureRca;
+  }
+
+  @Override
+  public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {
+    final List<FlowUnitMessage> flowUnitMessages =
+        args.getWireHopper().readFromWire(args.getNode());
+    List<CompactNodeTemperatureFlowUnit> flowUnitList = new ArrayList<>();
+    LOG.debug("rca: Executing fromWire: {}", this.getClass().getSimpleName());
+    for (FlowUnitMessage flowUnitMessage : flowUnitMessages) {
+      flowUnitList.add(CompactNodeTemperatureFlowUnit.buildFlowUnitFromWrapper(flowUnitMessage));
+    }
+    setFlowUnits(flowUnitList);
+  }
+
+  /**
+   * The goal of the NodeHeatRca is to build a node level temperature profile.
+   *
+   * <p>This is done by accumulating the {@code DimensionalFlowUnit} s it receives from the
+   * individual ResourceHeatRcas. The temperature profile build here is sent to the elected master
+   * node where this is used to calculate the cluster temperature profile.
+   *
+   * @return
+   */
+  @Override
+  public CompactNodeTemperatureFlowUnit operate() {
+    // TODO: Make this process a list of dimensions instead of writing them out and add the
+    //  processed dimension profiles to the summary.
+    List<DimensionalTemperatureFlowUnit> cpuFlowUnits = cpuUtilDimensionTemperatureRca
+        .getFlowUnits();
+    List<DimensionalTemperatureFlowUnit> heapAllocRateFlowUnits = heapAllocRateTemperatureRca
+        .getFlowUnits();
+    // EachResourceLevelHeat RCA should generate a one @{code DimensionalFlowUnit}.
+    if (cpuFlowUnits.size() != 1) {
+      throw new IllegalArgumentException("One flow unit expected. Found: " + cpuFlowUnits);
     }
 
-    @Override
-    public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {
-        final List<FlowUnitMessage> flowUnitMessages =
-                args.getWireHopper().readFromWire(args.getNode());
-        List<CompactNodeTemperatureFlowUnit> flowUnitList = new ArrayList<>();
-        LOG.debug("rca: Executing fromWire: {}", this.getClass().getSimpleName());
-        for (FlowUnitMessage flowUnitMessage : flowUnitMessages) {
-            flowUnitList.add(CompactNodeTemperatureFlowUnit.buildFlowUnitFromWrapper(flowUnitMessage));
-        }
-        setFlowUnits(flowUnitList);
+    if (heapAllocRateFlowUnits.size() != 1) {
+      throw new IllegalStateException("One flow unit expected. Found: " + heapAllocRateFlowUnits);
     }
 
-    /**
-     * The goal of the NodeHeatRca is to build a node level temperature profile.
-     *
-     * <p>This is done by accumulating the {@code DimensionalFlowUnit} s it receives from the
-     * individual ResourceHeatRcas. The temperature profile build here is sent to the elected master
-     * node where this is used to calculate the cluster temperature profile.
-     *
-     * @return
-     */
-    @Override
-    public CompactNodeTemperatureFlowUnit operate() {
-        List<DimensionalTemperatureFlowUnit> cpuFlowUnits = cpuUtilDimensionTemperatureRca.getFlowUnits();
-        // EachResourceLevelHeat RCA should generate a one @{code DimensionalFlowUnit}.
-        if (cpuFlowUnits.size() != 1) {
-            throw new IllegalArgumentException("One flow unit expected. Found: " + cpuFlowUnits);
-        }
-
-        // This means that the input RCA didn't calculate anything. We can move on as well.
-        if (cpuFlowUnits.get(0).isEmpty()) {
-            return new CompactNodeTemperatureFlowUnit(System.currentTimeMillis());
-        }
-
-        List<NodeLevelDimensionalSummary> nodeDimensionProfiles = new ArrayList<>();
-        nodeDimensionProfiles.add(cpuFlowUnits.get(0).getNodeDimensionProfile());
-        FullNodeTemperatureSummary nodeProfile = buildNodeProfile(nodeDimensionProfiles);
-
-        ResourceContext resourceContext = new ResourceContext(Resources.State.UNKNOWN);
-        CompactNodeSummary summary = new CompactNodeSummary(nodeProfile.getNodeId(),
-                    nodeProfile.getHostAddress());
-        summary.fillFromNodeProfile(nodeProfile);
-
-        return new CompactNodeTemperatureFlowUnit(System.currentTimeMillis(), resourceContext, summary,
-                true);
+    // This means that the input RCA didn't calculate anything. We can move on as well.
+    if (cpuFlowUnits.get(0).isEmpty() && heapAllocRateFlowUnits.get(0).isEmpty()) {
+      return new CompactNodeTemperatureFlowUnit(System.currentTimeMillis());
     }
 
-    private FullNodeTemperatureSummary buildNodeProfile(List<NodeLevelDimensionalSummary> dimensionProfiles) {
-        ClusterDetailsEventProcessor.NodeDetails currentNodeDetails =
-                ClusterDetailsEventProcessor.getCurrentNodeDetails();
-        FullNodeTemperatureSummary nodeProfile = new FullNodeTemperatureSummary(currentNodeDetails.getId(),
-                currentNodeDetails.getHostAddress());
-        for (NodeLevelDimensionalSummary profile : dimensionProfiles) {
-            nodeProfile.updateNodeDimensionProfile(profile);
-        }
-        return nodeProfile;
+    List<NodeLevelDimensionalSummary> nodeDimensionProfiles = new ArrayList<>();
+    if (!cpuFlowUnits.get(0).isEmpty()) {
+      nodeDimensionProfiles.add(cpuFlowUnits.get(0).getNodeDimensionProfile());
     }
+
+    if (!heapAllocRateFlowUnits.get(0).isEmpty()) {
+      nodeDimensionProfiles.add(heapAllocRateFlowUnits.get(0).getNodeDimensionProfile());
+    }
+    FullNodeTemperatureSummary nodeProfile = buildNodeProfile(nodeDimensionProfiles);
+
+    ResourceContext resourceContext = new ResourceContext(Resources.State.UNKNOWN);
+    CompactNodeSummary summary = new CompactNodeSummary(nodeProfile.getNodeId(),
+        nodeProfile.getHostAddress());
+    summary.fillFromNodeProfile(nodeProfile);
+
+    return new CompactNodeTemperatureFlowUnit(
+        System.currentTimeMillis(), resourceContext,
+        summary,
+        true);
+  }
+
+  private FullNodeTemperatureSummary buildNodeProfile(
+      List<NodeLevelDimensionalSummary> dimensionProfiles) {
+    ClusterDetailsEventProcessor.NodeDetails currentNodeDetails =
+        ClusterDetailsEventProcessor.getCurrentNodeDetails();
+    FullNodeTemperatureSummary nodeProfile = new FullNodeTemperatureSummary(
+        currentNodeDetails.getId(),
+        currentNodeDetails.getHostAddress());
+    for (NodeLevelDimensionalSummary profile : dimensionProfiles) {
+      nodeProfile.updateNodeDimensionProfile(profile);
+    }
+    return nodeProfile;
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/dimension/HeapAllocRateTemperatureRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/dimension/HeapAllocRateTemperatureRca.java
@@ -1,0 +1,61 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.dimension;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Rca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.temperature.DimensionalTemperatureFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.ShardStore;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector.Dimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector.NormalizedValue;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.HeapAllocRateByShardAvgTemperatureCalculator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.HeapAllocRateByShardTemperatureCalculator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.capacity.HeapAllocRateTotalTemperatureCalculator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.shardIndependent.HeapAllocRateShardIndependentTemperatureCalculator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.DimensionalTemperatureCalculator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class HeapAllocRateTemperatureRca extends Rca<DimensionalTemperatureFlowUnit> {
+
+  private static final Logger LOG = LogManager.getLogger(HeapAllocRateTemperatureRca.class);
+  // The threshold set here is an initial threshold only.
+  // TODO: Update the threshold appropriately after testing so that we assign heat correctly.
+  private static final NormalizedValue THRESHOLD = new TemperatureVector.NormalizedValue((short) 2);
+  private static final int EVALUATION_INTERVAL_IN_S = 5;
+  private final HeapAllocRateByShardTemperatureCalculator HEAP_ALLOC_RATE_BY_SHARD;
+  private final HeapAllocRateByShardAvgTemperatureCalculator HEAP_ALLOC_RATE_BY_SHARD_AVG;
+  private final HeapAllocRateShardIndependentTemperatureCalculator HEAP_ALLOC_RATE_SHARD_INDEPENDENT;
+  private final HeapAllocRateTotalTemperatureCalculator HEAP_ALLOC_RATE_TOTAL;
+  private final ShardStore SHARD_STORE;
+
+  public HeapAllocRateTemperatureRca(final ShardStore shardStore,
+      final HeapAllocRateByShardTemperatureCalculator heapAllocByShard,
+      final HeapAllocRateByShardAvgTemperatureCalculator heapAllocByShardAvg,
+      final HeapAllocRateShardIndependentTemperatureCalculator shardIndependentHeapAllocRate,
+      final HeapAllocRateTotalTemperatureCalculator heapAllocRateTotal) {
+    super(EVALUATION_INTERVAL_IN_S);
+    this.SHARD_STORE = shardStore;
+    this.HEAP_ALLOC_RATE_BY_SHARD = heapAllocByShard;
+    this.HEAP_ALLOC_RATE_BY_SHARD_AVG = heapAllocByShardAvg;
+    this.HEAP_ALLOC_RATE_SHARD_INDEPENDENT = shardIndependentHeapAllocRate;
+    this.HEAP_ALLOC_RATE_TOTAL = heapAllocRateTotal;
+  }
+
+  @Override
+  public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {
+    throw new IllegalStateException("This node: [" + name() + "] should not have received flow "
+        + "units from remote nodes.");
+  }
+
+  @Override
+  public DimensionalTemperatureFlowUnit operate() {
+    LOG.debug("executing : {}", name());
+    DimensionalTemperatureFlowUnit heapAllocRateTemperatureFlowUnit =
+        DimensionalTemperatureCalculator.getTemperatureForDimension(SHARD_STORE,
+            Dimension.Heap_AllocRate, HEAP_ALLOC_RATE_BY_SHARD, HEAP_ALLOC_RATE_BY_SHARD_AVG,
+            HEAP_ALLOC_RATE_SHARD_INDEPENDENT, HEAP_ALLOC_RATE_TOTAL, THRESHOLD);
+    LOG.info("Heap allocation rate temperature calculated: {}",
+        heapAllocRateTemperatureFlowUnit.getNodeDimensionProfile());
+    return heapAllocRateTemperatureFlowUnit;
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ResourceHeatMapGraphTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ResourceHeatMapGraphTest.java
@@ -485,9 +485,9 @@ public class ResourceHeatMapGraphTest {
                     0.01);
             Assert.assertEquals(3, node.get("CPU_Utilization_num_shards").getAsInt());
 
-            Assert.assertEquals(0, node.get("Heap_AllocRate_mean").getAsInt());
-            Assert.assertEquals(0, node.get("Heap_AllocRate_total").getAsInt());
-            Assert.assertEquals(0, node.get("Heap_AllocRate_num_shards").getAsInt());
+            Assert.assertEquals(10, node.get("Heap_AllocRate_mean").getAsInt());
+            Assert.assertEquals(239855498, node.get("Heap_AllocRate_total").getAsInt());
+            Assert.assertEquals(3, node.get("Heap_AllocRate_num_shards").getAsInt());
 
             Assert.assertEquals(0, node.get("IO_READ_SYSCALL_RATE_mean").getAsInt());
             Assert.assertEquals(0, node.get("IO_READ_SYSCALL_RATE_total").getAsInt());


### PR DESCRIPTION
Issue #, if available:
#150 
Description of changes:
This is a first cut addition of heap allocation rate as a dimension in the temperature profile.

This change adds 4 new supporting metric vertices, which flow into the HeapAllocRateTemperatureRca vertex, which then contributes to NodeTemperatureRca thereby adding heap allocation rate as dimension across which heat is measured in the cluster.

There are some cosmetic changes that can be made at a later point in time, these are marked as TODOs.

Tests:
Tested with cortisol on an odfe docker setup on a c4.4xl instance.

Code coverage percentage for this patch:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.