### PR TITLE
Adding NPE Fix during RCA controller start up

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -225,6 +225,12 @@ public class RcaController {
         }
         updateRcaState();
 
+        // If RCA is enabled, update Analysis graph with Muted RCAs value
+        if (rcaEnabled) {
+          LOG.debug("Updating Analysis Graph with Muted RCAs");
+          readAndUpdateMutesRcas();
+        }
+
         long duration = System.currentTimeMillis() - startTime;
         if (duration < rcaStateCheckIntervalMillis) {
           Thread.sleep(rcaStateCheckIntervalMillis - duration);
@@ -261,12 +267,6 @@ public class RcaController {
             rcaEnabled = rcaEnabledDefaultValue;
           }
         });
-
-    // If RCA is enabled, update Analysis graph with Muted RCAs value
-    if (rcaEnabled) {
-      LOG.debug("Updating Analysis Graph with Muted RCAs");
-      readAndUpdateMutesRcas();
-    }
   }
 
   /**
@@ -276,6 +276,11 @@ public class RcaController {
    * <p>In case all the RCAs in param value are incorrect, return without any update.
    */
   private void readAndUpdateMutesRcas() {
+    if (rcaConf == null) {
+      LOG.error("RCA Conf: {} null, returning.", rcaConf);
+      return;
+    }
+
     // If the rca config file has been updated since the lastModifiedTimeInMillisInMemory in memory,
     // refresh the `muted-rcas` value from rca config file.
     long lastModifiedTimeInMillisOnDisk = rcaConf.getLastModifiedTime();

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -143,7 +143,6 @@ public class RcaController {
   }
 
   private void start() {
-    rcaConf = RcaControllerHelper.pickRcaConfForRole(currentRole);
     try {
       subscriptionManager.setCurrentLocus(rcaConf.getTagMap().get("locus"));
       List<ConnectedComponent> connectedComponents = RcaUtil.getAnalysisGraphComponents(rcaConf);
@@ -223,13 +222,14 @@ public class RcaController {
             checkUpdateNodeRole(nodeDetails);
           }
         }
-        updateRcaState();
 
         // If RCA is enabled, update Analysis graph with Muted RCAs value
         if (rcaEnabled) {
+          rcaConf = RcaControllerHelper.pickRcaConfForRole(currentRole);
           LOG.debug("Updating Analysis Graph with Muted RCAs");
           readAndUpdateMutesRcas();
         }
+        updateRcaState();
 
         long duration = System.currentTimeMillis() - startTime;
         if (duration < rcaStateCheckIntervalMillis) {
@@ -276,16 +276,11 @@ public class RcaController {
    * <p>In case all the RCAs in param value are incorrect, return without any update.
    */
   private void readAndUpdateMutesRcas() {
-    if (rcaConf == null) {
-      LOG.error("RCA Conf: {} null, returning.", rcaConf);
-      return;
-    }
-
-    // If the rca config file has been updated since the lastModifiedTimeInMillisInMemory in memory,
-    // refresh the `muted-rcas` value from rca config file.
-    long lastModifiedTimeInMillisOnDisk = rcaConf.getLastModifiedTime();
-    if (lastModifiedTimeInMillisOnDisk > lastModifiedTimeInMillisInMemory) {
-      try {
+    try {
+      // If the rca config file has been updated since the lastModifiedTimeInMillisInMemory in memory,
+      // refresh the `muted-rcas` value from rca config file.
+      long lastModifiedTimeInMillisOnDisk = rcaConf.getLastModifiedTime();
+      if (lastModifiedTimeInMillisOnDisk > lastModifiedTimeInMillisInMemory) {
         Set<String> rcasForMute = new HashSet<>(rcaConf.getMutedRcaList());
         LOG.info("RCAs provided for muting : {}", rcasForMute);
 
@@ -302,11 +297,11 @@ public class RcaController {
 
         LOG.info("Updating the muted RCA Graph to : {}", rcasForMute);
         Stats.getInstance().updateMutedGraphNodes(rcasForMute);
-      } catch (Exception e) {
-        LOG.error("Couldn't read/update the muted RCAs.", e);
       }
+      lastModifiedTimeInMillisInMemory = lastModifiedTimeInMillisOnDisk;
+    } catch (Exception e) {
+        LOG.error("Couldn't read/update the muted RCAs.", e);
     }
-    lastModifiedTimeInMillisInMemory = lastModifiedTimeInMillisOnDisk;
   }
 
   /**

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
@@ -172,6 +172,11 @@ public class RcaControllerTest {
     Field field = rcaController.getClass().getDeclaredField("rcaConf");
     field.setAccessible(true);
 
+    // 0. rcaConf is null
+    updateConfFileForMutedRcas(rcaConfPath, "CPU_Utilization, Heap_AllocRate");
+    field.set(rcaController, null);
+    Assert.assertTrue(Stats.getInstance().getMutedGraphNodes().isEmpty());
+
     // 1. Muted Graph : "CPU_Utilization, Heap_AllocRate", updating RCA Config with "CPU_Utilization, Heap_AllocRate"
     // Muted Graph should have "CPU_Utilization, Heap_AllocRate"
     updateConfFileForMutedRcas(rcaConfPath, "CPU_Utilization, Heap_AllocRate");

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
@@ -175,6 +175,7 @@ public class RcaControllerTest {
     // 0. rcaConf is null
     updateConfFileForMutedRcas(rcaConfPath, "CPU_Utilization, Heap_AllocRate");
     field.set(rcaController, null);
+    readAndUpdateMutesRcas.invoke(rcaController);
     Assert.assertTrue(Stats.getInstance().getMutedGraphNodes().isEmpty());
 
     // 1. Muted Graph : "CPU_Utilization, Heap_AllocRate", updating RCA Config with "CPU_Utilization, Heap_AllocRate"


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/issues/172

*Description of changes:*
1. Added the rcaConf null check under `readAndUpdateMutesRcas()`
2. Moved the invocation of `readAndUpdateMutesRcas()` to after rcaConf initialization and rcaScheduler restart in `updateRcaState()`

*Tests:* Added a UT to check the NPE condition for rcaConf

*Code coverage percentage for this patch:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
