### PR TITLE
Handle race condition between RCA Scheduler start and RCA Node muting

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
@@ -31,7 +31,6 @@ public enum StatExceptionCode {
   REQUEST_ERROR("RequestError"),
   REQUEST_REMOTE_ERROR("RequestRemoteError"),
   READER_PARSER_ERROR("ReaderParserError"),
-  MUTE_RCA_ERROR("MuteRcaError"),
   READER_RESTART_PROCESSING("ReaderRestartProcessing"),
   RCA_SCHEDULER_RESTART_PROCESSING("RCASchedulerRestartProcessing"),
   RCA_NETWORK_ERROR("RcaNetworkError"),

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
@@ -31,6 +31,7 @@ public enum StatExceptionCode {
   REQUEST_ERROR("RequestError"),
   REQUEST_REMOTE_ERROR("RequestRemoteError"),
   READER_PARSER_ERROR("ReaderParserError"),
+  MUTE_RCA_ERROR("MuteRcaError"),
   READER_RESTART_PROCESSING("ReaderRestartProcessing"),
   RCA_SCHEDULER_RESTART_PROCESSING("RCASchedulerRestartProcessing"),
   RCA_NETWORK_ERROR("RcaNetworkError"),

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -147,6 +147,10 @@ public class RcaController {
     try {
       subscriptionManager.setCurrentLocus(rcaConf.getTagMap().get("locus"));
       List<ConnectedComponent> connectedComponents = RcaUtil.getAnalysisGraphComponents(rcaConf);
+
+      // Mute the rca nodes after the graph creation and before the scheduler start
+      readAndUpdateMutesRcas();
+
       Queryable db = new MetricsDBProvider();
       ThresholdMain thresholdMain = new ThresholdMain(RcaConsts.THRESHOLDS_PATH, rcaConf);
       Persistable persistable = PersistenceFactory.create(rcaConf);
@@ -278,6 +282,11 @@ public class RcaController {
    */
   private void readAndUpdateMutesRcas() {
     try {
+      if(ConnectedComponent.getNodeNames().isEmpty()) {
+        LOG.info("Analysis graph not initialized/has been reset; returning.");
+        return;
+      }
+
       // If the rca config file has been updated since the lastModifiedTimeInMillisInMemory in memory,
       // refresh the `muted-rcas` value from rca config file.
       long lastModifiedTimeInMillisOnDisk = rcaConf.getLastModifiedTime();

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -15,10 +15,11 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca;
 
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts.RCA_MUTE_ERROR_METRIC;
+
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.ClientServers;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerThreads;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatExceptionCode;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.core.Util;
@@ -282,7 +283,7 @@ public class RcaController {
    */
   private void readAndUpdateMutesRcas() {
     try {
-      if(ConnectedComponent.getNodeNames().isEmpty()) {
+      if (ConnectedComponent.getNodeNames().isEmpty()) {
         LOG.info("Analysis graph not initialized/has been reset; returning.");
         return;
       }
@@ -311,7 +312,7 @@ public class RcaController {
       lastModifiedTimeInMillisInMemory = lastModifiedTimeInMillisOnDisk;
     } catch (Exception e) {
       LOG.error("Couldn't read/update the muted RCAs", e);
-      StatsCollector.instance().logException(StatExceptionCode.MUTE_RCA_ERROR);
+      StatsCollector.instance().logMetric(RCA_MUTE_ERROR_METRIC);
     }
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -18,6 +18,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.ClientServers;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerThreads;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatExceptionCode;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.core.Util;
@@ -300,7 +301,8 @@ public class RcaController {
       }
       lastModifiedTimeInMillisInMemory = lastModifiedTimeInMillisOnDisk;
     } catch (Exception e) {
-        LOG.error("Couldn't read/update the muted RCAs.", e);
+      LOG.error("Couldn't read/update the muted RCAs", e);
+      StatsCollector.instance().logException(StatExceptionCode.MUTE_RCA_ERROR);
     }
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/ConfJsonWrapper.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/ConfJsonWrapper.java
@@ -19,7 +19,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.configs.HighH
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -105,7 +104,7 @@ class ConfJsonWrapper {
       @JsonProperty("network-queue-length") int networkQueueLength,
       @JsonProperty("max-flow-units-per-vertex-buffer") int perVertexBufferLength,
       @JsonProperty("high-heap-usage-old-gen-rca") Map<String, String> highHeapUsageOldGenRcaSettings,
-      @JsonProperty("muted-rcas") String mutedRcas) {
+      @JsonProperty("muted-rcas") List<String> mutedRcas) {
     this.creationTime = System.currentTimeMillis();
     this.rcaStoreLoc = rcaStoreLoc;
     this.thresholdStoreLoc = thresholdStoreLoc;
@@ -118,16 +117,6 @@ class ConfJsonWrapper {
     this.networkQueueLength = networkQueueLength;
     this.perVertexBufferLength = perVertexBufferLength;
     this.highHeapUsageOldGenRcaConfig = new HighHeapUsageOldGenRcaConfig(highHeapUsageOldGenRcaSettings);
-
-    if (mutedRcas.isEmpty()) {
-      this.mutedRcaList = Collections.emptyList();
-    } else {
-      // Split the string on a delimiter defined as: zero or more whitespace,
-      // a literal comma, zero or more whitespace
-      this.mutedRcaList = Arrays.asList(mutedRcas.split("\\s*,\\s*"));
-      this.mutedRcaList.stream().forEach(
-              mutedRca -> mutedRca.trim()
-      );
-    }
+    this.mutedRcaList = mutedRcas;
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/RcaConsts.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/RcaConsts.java
@@ -46,6 +46,7 @@ public class RcaConsts {
       Paths.get(CONFIG_DIR_PATH, RCA_CONF_IDLE_MASTER_FILENAME).toString();
   public static final String THRESHOLDS_PATH =
       Paths.get(CONFIG_DIR_PATH, THRESHOLDS_DIR_NAME).toString();
+  public static final String RCA_MUTE_ERROR_METRIC = "RcaMuteError";
 
   static final String dir = System.getProperty("user.dir");
   public static final String TEST_CONFIG_PATH =

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
@@ -170,7 +170,7 @@ public class RcaControllerTest {
   }
 
   @Test
-  public void readAndUpdateMutesRcasBeforeGraphCreation() throws Exception {
+  public void readAndUpdateMutedRcasBeforeGraphCreation() throws Exception {
     Method readAndUpdateMutesRcas = rcaController.getClass()
             .getDeclaredMethod("readAndUpdateMutesRcas", null);
     readAndUpdateMutesRcas.setAccessible(true);
@@ -195,7 +195,7 @@ public class RcaControllerTest {
   }
 
   @Test
-  public void readAndUpdateMutesRcas() throws Exception {
+  public void readAndUpdateMutedRcas() throws Exception {
     String rcaConfPath = Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca_muted.conf").toString();
     List<String> mutedRcas1 = Arrays.asList("CPU_Utilization", "Heap_AllocRate");
     List<String> mutedRcas2 = Arrays.asList("Paging_MajfltRate");

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaTestHelper.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaTestHelper.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.io.File;
@@ -140,7 +141,7 @@ public class RcaTestHelper {
     }
   }
 
-  public static void updateConfFileForMutedRcas(String rcaConfPath, String mutedRcas) throws Exception {
+  public static void updateConfFileForMutedRcas(String rcaConfPath, List<String> mutedRcas) throws Exception {
 
     // create the config json Object from rca config file
     Scanner scanner = new Scanner(new FileInputStream(rcaConfPath), StandardCharsets.UTF_8.name());
@@ -151,7 +152,8 @@ public class RcaTestHelper {
     JsonNode configObject = mapper.readTree(jsonText);
 
     // update the `MUTED_RCAS_CONFIG` value in config Object
-    ((ObjectNode) configObject).put("muted-rcas", mutedRcas);
+    ArrayNode array = mapper.valueToTree(mutedRcas);
+    ((ObjectNode) configObject).putArray("muted-rcas").addAll(array);
     mapper.writeValue(new FileOutputStream(rcaConfPath), configObject);
   }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/spec/RcaConfTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/spec/RcaConfTests.java
@@ -18,24 +18,27 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.spec;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaTestHelper.updateConfFileForMutedRcas;
 import static com.google.common.collect.Maps.newHashMap;
 import static junit.framework.TestCase.assertTrue;
-import static org.hamcrest.CoreMatchers.hasItems;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(GradleTaskForRca.class)
 public class RcaConfTests {
+
+  List<String> mutedRcas = Arrays.asList("CPU_Utilization", "Heap_AllocRate");
+
   @Test
   public void testRcaConfRead() throws Exception {
-    updateConfFileForMutedRcas(Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca_master.conf").toString(), "CPU_Utilization, Heap_AllocRate");
+    updateConfFileForMutedRcas(Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca_master.conf").toString(), mutedRcas);
     RcaConf rcaConf = new RcaConf(Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca_master.conf").toString());
 
     assertEquals("s3://sifi-store/rcas/", rcaConf.getRcaStoreLoc());
@@ -59,36 +62,19 @@ public class RcaConfTests {
   @Test
   public void testMutedRcasValue() throws Exception {
     String rcaConfPath = Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca_master.conf").toString();
+    List<String> mutedRcas1 = Arrays.asList("CPU_Utilization");
 
-    // 1. Comma, followed space
-    updateConfFileForMutedRcas(rcaConfPath, "CPU_Utilization, Heap_AllocRate");
+    updateConfFileForMutedRcas(rcaConfPath, mutedRcas);
     RcaConf rcaConf = new RcaConf(rcaConfPath);
-    assertEquals(Arrays.asList("CPU_Utilization", "Heap_AllocRate"), rcaConf.getMutedRcaList());
+    assertEquals(mutedRcas, rcaConf.getMutedRcaList());
 
-    // 2. Comma, Without any space
-    updateConfFileForMutedRcas(rcaConfPath, "CPU_Utilization,Heap_AllocRate");
+    updateConfFileForMutedRcas(rcaConfPath, mutedRcas1);
     rcaConf = new RcaConf(rcaConfPath);
-    assertEquals(Arrays.asList("CPU_Utilization", "Heap_AllocRate"), rcaConf.getMutedRcaList());
+    assertEquals(mutedRcas1, rcaConf.getMutedRcaList());
 
-    // 3. Without any comma
-    updateConfFileForMutedRcas(rcaConfPath, "CPU_Utilization");
-    rcaConf = new RcaConf(rcaConfPath);
-    assertEquals(Arrays.asList("CPU_Utilization"), rcaConf.getMutedRcaList());
-
-    // 4. Empty String
-    updateConfFileForMutedRcas(rcaConfPath, "");
+    updateConfFileForMutedRcas(rcaConfPath, Collections.EMPTY_LIST);
     rcaConf = new RcaConf(rcaConfPath);
     assertTrue(rcaConf.getMutedRcaList().isEmpty());
-
-    // 5. Leading and Trailing space
-    updateConfFileForMutedRcas(rcaConfPath, " CPU_Utilization, Heap_AllocRate ");
-    rcaConf = new RcaConf(rcaConfPath);
-    assertEquals(Arrays.asList(" CPU_Utilization", "Heap_AllocRate "), rcaConf.getMutedRcaList());
-
-    // 6. Space within the muted_rca value
-    updateConfFileForMutedRcas(rcaConfPath, " CPU Utilization, Heap_AllocRate ");
-    rcaConf = new RcaConf(rcaConfPath);
-    assertEquals(Arrays.asList(" CPU Utilization", "Heap_AllocRate "), rcaConf.getMutedRcaList());
 
   }
 }

--- a/src/test/resources/rca/rca_muted.conf
+++ b/src/test/resources/rca/rca_muted.conf
@@ -44,5 +44,5 @@
     "rotation-period-seconds": 21600
   },
 
-  "muted-rcas": "CPU_Utilization, Heap_AllocRate"
+  "muted-rcas": ["CPU_Utilization, Heap_AllocRate"]
 }

--- a/src/test/resources/rca/rca_muted.conf
+++ b/src/test/resources/rca/rca_muted.conf
@@ -44,5 +44,5 @@
     "rotation-period-seconds": 21600
   },
 
-  "muted-rcas": ["CPU_Utilization, Heap_AllocRate"]
+  "muted-rcas": ["CPU_Utilization", "Heap_AllocRate"]
 }


### PR DESCRIPTION
*Description of changes:* Ideally, the RCA Node muting should be performed after the graph creation and before the RCA Scheduler starts.  When RCA nodes are muted before the graph creation, we get the following error :
```
PerformanceAnalyzer.log.2020-04-30-01:[2020-04-30T01:00:43,236][ERROR][c.a.o.e.p.r.RcaController] Incorrect RCA(s): [HighHeapUsageClusterRca, HotNodeRca], cannot be muted. Valid RCAs: [], Muted RCAs: []
PerformanceAnalyzer.log.2020-04-30-01:[2020-04-30T01:17:35,339][ERROR][c.a.o.e.p.r.RcaController] Incorrect RCA(s): [HighHeapUsageClusterRca], cannot be muted. Valid RCAs: [], Muted RCAs: null
```
So, now : 
1. Invoking `readAndUpdateMutesRcas()` as part of `start()`, after the graph creation to ensure that muted RCAs are present for the first run when scheduler comes up.
2. Checking as part `readAndUpdateMutesRcas()` for graphNodes as non-empty (indicative of graph creation)

Also, added a metric to track `MuteRcaError`
***

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
