### PR TITLE
Fix flaky PersistFlowUnitAndSummaryTest

### DIFF
--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopperTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopperTest.java
@@ -164,9 +164,11 @@ public class WireHopperTest {
         uut.sendData(msg);
         WaitFor.waitFor(() -> nodeStateManager.getLastReceivedTimestamp(NODE1, LOCALHOST) != 0, 1,
                 TimeUnit.SECONDS);
-        List<FlowUnitMessage> receivedMags = receivedFlowUnitStore.drainNode(NODE1);
-        Assert.assertEquals(1L, receivedMags.size());
-
+        // Verify that the data gets persisted into receivedFlowUnitStore once it's received
+        WaitFor.waitFor(() -> {
+            List<FlowUnitMessage> receivedMags = receivedFlowUnitStore.drainNode(NODE1);
+            return receivedMags.size() == 1;
+        }, 10, TimeUnit.SECONDS);
         // verify resilience to RejectedExecutionException
         clientExecutor.set(rejectingExecutor);
         uut.sendData(msg);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistFlowUnitAndSummaryTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistFlowUnitAndSummaryTest.java
@@ -166,18 +166,16 @@ public class PersistFlowUnitAndSummaryTest {
     RcaConf rcaConf = new RcaConf(Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca.conf").toString());
     Persistable persistable = PersistenceFactory.create(rcaConf);
     RCAScheduler scheduler = startScheduler(rcaConf, graph, persistable, this.queryable, AllMetrics.NodeRole.DATA);
-    // Wait at most 1 minute for the persisted data to show up
+    // Wait at most 1 minute for the persisted data to show up with the correct contents
     WaitFor.waitFor(() -> {
       String readTableStr = persistable.read();
-      return readTableStr != null && readTableStr.contains("HotResourceSummary");
+      if (readTableStr != null) {
+        return readTableStr.contains("HotResourceSummary") && readTableStr.contains("DummyYoungGenRca")
+                && readTableStr.contains("HotNodeSummary") && readTableStr.contains("HotNodeRcaX")
+                && readTableStr.contains("HighHeapUsageClusterRcaX");
+      }
+      return false;
     }, 1, TimeUnit.MINUTES);
-    // Verify the persisted data's contents
-    String readTableStr = persistable.read();
-    Assert.assertTrue(readTableStr.contains("HotResourceSummary"));
-    Assert.assertTrue(readTableStr.contains("DummyYoungGenRca"));
-    Assert.assertTrue(readTableStr.contains("HotNodeSummary"));
-    Assert.assertTrue(readTableStr.contains("HotNodeRcaX"));
-    Assert.assertFalse(readTableStr.contains("HighHeapUsageClusterRcaX"));
     scheduler.shutdown();
     persistable.close();
   }
@@ -196,18 +194,16 @@ public class PersistFlowUnitAndSummaryTest {
     RcaConf rcaConf = new RcaConf(Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca_elected_master.conf").toString());
     Persistable persistable = PersistenceFactory.create(rcaConf);
     RCAScheduler scheduler = startScheduler(rcaConf, graph, persistable, this.queryable, NodeRole.ELECTED_MASTER);
-    // Wait at most 1 minute for the persisted data to show up
+    // Wait at most 1 minute for the persisted data to show up with the correct contents
     WaitFor.waitFor(() -> {
       String readTableStr = persistable.read();
-      return readTableStr != null && readTableStr.contains("HotResourceSummary");
+      if (readTableStr != null) {
+        return readTableStr.contains("HotResourceSummary") && readTableStr.contains("DummyYoungGenRca")
+                && readTableStr.contains("HotNodeSummary") && readTableStr.contains("HotNodeRcaX")
+                && readTableStr.contains("HighHeapUsageClusterRcaX");
+      }
+      return false;
     }, 1, TimeUnit.MINUTES);
-    // Verify the persisted data's contents
-    String readTableStr = persistable.read();
-    Assert.assertTrue(readTableStr.contains("HotResourceSummary"));
-    Assert.assertTrue(readTableStr.contains("DummyYoungGenRca"));
-    Assert.assertTrue(readTableStr.contains("HotNodeSummary"));
-    Assert.assertTrue(readTableStr.contains("HotNodeRcaX"));
-    Assert.assertTrue(readTableStr.contains("HighHeapUsageClusterRcaX"));
     scheduler.shutdown();
     persistable.close();
   }


### PR DESCRIPTION
This test had an arbitrary sleep which caused it to fail intermittently.
The sleep has been replaced by a polling waitFor.

*Issue #, if available:* N/A

*Description of changes:* 

This test had an arbitrary sleep which caused it to fail intermittently.
The sleep has been replaced by a polling waitFor.

*Tests:* PersistFlowUnitAndSummaryTest

*Code coverage percentage for this patch:* Unchanged

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
