### PR TITLE
Allow retrieving temperature profile RCAs from all nodes.

### DIFF
--- a/pa_config/rca.conf
+++ b/pa_config/rca.conf
@@ -51,5 +51,20 @@
     }
   },
 
-  "muted-rcas": ["HighCPUShardRca", "HotShardClusterRca"]
+  "muted-rcas": [
+    "HighCPUShardRca",
+    "HotShardClusterRca",
+    "HeapAllocRateByShardTemperatureCalculator",
+    "HeapAllocRateByShardAvgTemperatureCalculator",
+    "HeapAllocRateShardIndependentTemperatureCalculator",
+    "HeapAllocRateTotalTemperatureCalculator",
+    "CpuUtilByShardsMetricBasedTemperatureCalculator",
+    "AvgCpuUtilByShardsMetricBasedTemperatureCalculator",
+    "ShardIndependentTemperatureCalculatorCpuUtilMetric",
+    "TotalCpuUtilForTotalNodeMetric",
+    "CpuUtilDimensionTemperatureRca",
+    "HeapAllocRateTemperatureRca",
+    "NodeTemperatureRca",
+    "ClusterTemperatureRca"
+   ]
 }

--- a/pa_config/rca_idle_master.conf
+++ b/pa_config/rca_idle_master.conf
@@ -56,5 +56,20 @@
     }
   },
 
-  "muted-rcas": ["HighCPUShardRca", "HotShardClusterRca"]
+  "muted-rcas": [
+    "HighCPUShardRca",
+    "HotShardClusterRca",
+    "HeapAllocRateByShardTemperatureCalculator",
+    "HeapAllocRateByShardAvgTemperatureCalculator",
+    "HeapAllocRateShardIndependentTemperatureCalculator",
+    "HeapAllocRateTotalTemperatureCalculator",
+    "CpuUtilByShardsMetricBasedTemperatureCalculator",
+    "AvgCpuUtilByShardsMetricBasedTemperatureCalculator",
+    "ShardIndependentTemperatureCalculatorCpuUtilMetric",
+    "TotalCpuUtilForTotalNodeMetric",
+    "CpuUtilDimensionTemperatureRca",
+    "HeapAllocRateTemperatureRca",
+    "NodeTemperatureRca",
+    "ClusterTemperatureRca"
+  ]
 }

--- a/pa_config/rca_master.conf
+++ b/pa_config/rca_master.conf
@@ -56,5 +56,20 @@
     }
   },
 
-  "muted-rcas": ["HighCPUShardRca", "HotShardClusterRca"]
+  "muted-rcas": [
+    "HighCPUShardRca",
+    "HotShardClusterRca",
+    "HeapAllocRateByShardTemperatureCalculator",
+    "HeapAllocRateByShardAvgTemperatureCalculator",
+    "HeapAllocRateShardIndependentTemperatureCalculator",
+    "HeapAllocRateTotalTemperatureCalculator",
+    "CpuUtilByShardsMetricBasedTemperatureCalculator",
+    "AvgCpuUtilByShardsMetricBasedTemperatureCalculator",
+    "ShardIndependentTemperatureCalculatorCpuUtilMetric",
+    "TotalCpuUtilForTotalNodeMetric",
+    "CpuUtilDimensionTemperatureRca",
+    "HeapAllocRateTemperatureRca",
+    "NodeTemperatureRca",
+    "ClusterTemperatureRca"
+  ]
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/MetricsRestUtil.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/MetricsRestUtil.java
@@ -22,15 +22,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class MetricsRestUtil {
-
-  private static final String WEBSERVICE_BIND_HOST_NAME = "webservice-bind-host";
-  private static final Logger LOG = LogManager.getLogger(MetricsRestUtil.class);
-  private static final int INCOMING_QUEUE_LENGTH = 1;
-  private static final String QUERY_URL = "/_opendistro/_performanceanalyzer/metrics";
 
   public String nodeJsonBuilder(ConcurrentHashMap<String, String> nodeResponses) {
     StringBuilder outputJson = new StringBuilder();

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/CompactNodeSummary.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/CompactNodeSummary.java
@@ -30,6 +30,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jooq.DSLContext;
 import org.jooq.Field;
 import org.jooq.Record;
@@ -43,6 +45,8 @@ import org.jooq.impl.DSL;
  * information. So, this summary is kept generic so that both can use it.
  */
 public class CompactNodeSummary extends GenericSummary {
+
+    private static final Logger LOG = LogManager.getLogger(CompactNodeSummary.class);
     /**
      * This will determine the name of the SQLite when this summary is persisted.
      */
@@ -77,6 +81,8 @@ public class CompactNodeSummary extends GenericSummary {
     public static CompactNodeSummary buildSummaryFromDatabase(Result<Record> records,
         DSLContext context) {
         if (records.size() != 1) {
+            LOG.error("Expected 1 compact node summary, got {}. Summaries: {}", records.size(),
+                records);
             throw new IllegalArgumentException(
                 "Only 1 CompactNodeSummary expected. Found: " + records.size());
         }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/CompactNodeSummary.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/CompactNodeSummary.java
@@ -36,6 +36,7 @@ import org.jooq.DSLContext;
 import org.jooq.Field;
 import org.jooq.Record;
 import org.jooq.Result;
+import org.jooq.exception.DataTypeException;
 import org.jooq.impl.DSL;
 
 /**
@@ -104,42 +105,59 @@ public class CompactNodeSummary extends GenericSummary {
     }
 
     private static void readAndSetTemperatureVector(Record record, CompactNodeSummary summary) {
-        for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
-            String normalizedMeanUsageForDimension = record
-                .get((DSL.field(DSL.name(dimension.NAME + MEAN_SUFFIX_KEY),
-                    String.class)));
-            short value = 0;
-            if (normalizedMeanUsageForDimension != null && !normalizedMeanUsageForDimension.isEmpty()) {
-                value = Short.parseShort(normalizedMeanUsageForDimension);
+        try {
+            for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
+                String normalizedMeanUsageForDimension = record
+                    .get((DSL.field(DSL.name(dimension.NAME + MEAN_SUFFIX_KEY),
+                        String.class)));
+                short value = 0;
+                if (normalizedMeanUsageForDimension != null && !normalizedMeanUsageForDimension
+                    .isEmpty()) {
+                    value = Short.parseShort(normalizedMeanUsageForDimension);
+                }
+                summary.setTemperatureForDimension(dimension,
+                    new NormalizedValue(value));
             }
-            summary.setTemperatureForDimension(dimension,
-                new NormalizedValue(value));
+        } catch (final DataTypeException dte) {
+            LOG.error("Couldn't convert to the right data type while reading temperature vector "
+                + "from the DB. {}", dte.getMessage(), dte);
         }
     }
 
     private static void readAndSetNumShardsPerDimension(Record record, CompactNodeSummary summary) {
-        for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
-            String numShardsForDimension = record
-                .get((DSL.field(DSL.name(dimension.NAME + NUM_SHARDS_SUFFIX_KEY),
-                    String.class)));
-            int value = 0;
-            if (numShardsForDimension != null && !numShardsForDimension.isEmpty()) {
-                value = Integer.parseInt(numShardsForDimension);
+        try {
+            for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
+                String numShardsForDimension = record
+                    .get((DSL.field(DSL.name(dimension.NAME + NUM_SHARDS_SUFFIX_KEY),
+                        String.class)));
+                int value = 0;
+                if (numShardsForDimension != null && !numShardsForDimension.isEmpty()) {
+                    value = Integer.parseInt(numShardsForDimension);
+                }
+                summary.setNumOfShards(dimension, value);
             }
-            summary.setNumOfShards(dimension, value);
+        } catch (final DataTypeException dte) {
+            LOG.error("Couldn't convert to the right data type while reading num shards per"
+                + " dimension from the DB. {}", dte.getMessage(), dte);
         }
     }
 
     private static void readAndSetTotalConsumedPerDimension(Record record,
         CompactNodeSummary summary) {
-        for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
-            String totalConsumedForDimension =
-                record.get((DSL.field(DSL.name(dimension.NAME + TOTAL_SUFFIX_KEY), String.class)));
-            double value = 0;
-            if (totalConsumedForDimension != null && !totalConsumedForDimension.isEmpty()) {
-                value = Double.parseDouble(totalConsumedForDimension);
+        try {
+            for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
+                String totalConsumedForDimension =
+                    record.get(
+                        (DSL.field(DSL.name(dimension.NAME + TOTAL_SUFFIX_KEY), String.class)));
+                double value = 0;
+                if (totalConsumedForDimension != null && !totalConsumedForDimension.isEmpty()) {
+                    value = Double.parseDouble(totalConsumedForDimension);
+                }
+                summary.setTotalConsumedByDimension(dimension, value);
             }
-            summary.setTotalConsumedByDimension(dimension, value);
+        } catch (final DataTypeException dte) {
+            LOG.error("Couldn't convert to the right data type while reading total consumed per"
+                + " dimension from the DB. {}", dte.getMessage(), dte);
         }
     }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/NodeLevelDimensionalSummary.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/NodeLevelDimensionalSummary.java
@@ -33,7 +33,11 @@ import org.jooq.impl.DSL;
  * A node dimension profile is categorization of all shards in the node into different heatZones.
  */
 public class NodeLevelDimensionalSummary extends GenericSummary {
-    private final TemperatureVector.Dimension profileForDimension;
+
+  public static final String SUMMARY_TABLE_NAME = "NodeLevelDimensionalSummary";
+  public static final String ZONE_SUMMARY_TABLE_NAME = "NodeLevelZoneSummary";
+
+  private final TemperatureVector.Dimension profileForDimension;
     private final TemperatureVector.NormalizedValue meanTemperature;
     private final double totalUsage;
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/ShardProfileSummary.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/ShardProfileSummary.java
@@ -28,7 +28,9 @@ import org.jooq.Field;
 import org.jooq.impl.DSL;
 
 public class ShardProfileSummary extends GenericSummary {
-    private final String indexName;
+
+  public static final String SUMMARY_TABLE_NAME = "ShardProfileSummary";
+  private final String indexName;
     private final int shardId;
 
     private final TemperatureVector temperatureVector;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/SQLiteQueryUtils.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/SQLiteQueryUtils.java
@@ -23,10 +23,14 @@ import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framew
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit.ResourceFlowUnitFieldValue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.ClusterDimensionalSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.ClusterDimensionalSummary.ZoneSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.ClusterTemperatureSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.NodeLevelDimensionalSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.ShardProfileSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HighHeapUsageClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HotNodeClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.ClusterTemperatureRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.NodeTemperatureRca;
 import com.google.common.collect.ImmutableList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -45,13 +49,14 @@ import org.jooq.impl.DSL;
  */
 public class SQLiteQueryUtils {
   private static final Map<String, String> nestedTableMap;
+  private static final Map<String, String> temperatureProfileNestedSummaryMap;
   private static final Set<String> clusterLevelRCA;
+  private static final Set<String> temperatureProfileRCASet;
 
   // to map table => its nested table
   // e.g. HotClusterSummary => HotNodeSummary
   static {
     Map<String, String> tableMap = new HashMap<>();
-    tableMap.put(ResourceFlowUnit.RCA_TABLE_NAME, ClusterTemperatureSummary.TABLE_NAME);
     tableMap.put(ClusterTemperatureSummary.TABLE_NAME, ClusterDimensionalSummary.TABLE_NAME);
 
     tableMap.put(ResourceFlowUnit.RCA_TABLE_NAME, HOT_CLUSTER_SUMMARY_TABLE);
@@ -59,6 +64,18 @@ public class SQLiteQueryUtils {
     tableMap.put(HOT_NODE_SUMMARY_TABLE, HOT_RESOURCE_SUMMARY_TABLE);
     tableMap.put(HOT_RESOURCE_SUMMARY_TABLE, TOP_CONSUMER_SUMMARY_TABLE);
     nestedTableMap = Collections.unmodifiableMap(tableMap);
+  }
+
+  static {
+    Map<String, String> temperatureSummaryMap = new HashMap<>();
+    temperatureSummaryMap.put(ResourceFlowUnit.RCA_TABLE_NAME,
+        NodeLevelDimensionalSummary.SUMMARY_TABLE_NAME);
+    temperatureSummaryMap.put(NodeLevelDimensionalSummary.SUMMARY_TABLE_NAME,
+        NodeLevelDimensionalSummary.ZONE_SUMMARY_TABLE_NAME);
+    temperatureSummaryMap.put(NodeLevelDimensionalSummary.ZONE_SUMMARY_TABLE_NAME,
+        ShardProfileSummary.SUMMARY_TABLE_NAME);
+
+    temperatureProfileNestedSummaryMap = Collections.unmodifiableMap(temperatureSummaryMap);
   }
 
   // RCAs that can be queried by RCA API
@@ -70,6 +87,15 @@ public class SQLiteQueryUtils {
     rcaSet.add(HighHeapUsageClusterRca.RCA_TABLE_NAME);
     rcaSet.add(HotNodeClusterRca.RCA_TABLE_NAME);
     clusterLevelRCA = Collections.unmodifiableSet(rcaSet);
+  }
+
+  // Temperature profile RCAs that can be queried by the RCA API.
+  static {
+    Set<String> tempProfileRcaSet = new HashSet<>();
+
+    tempProfileRcaSet.add(NodeTemperatureRca.TABLE_NAME);
+    tempProfileRcaSet.add(ClusterTemperatureRca.TABLE_NAME);
+    temperatureProfileRCASet = Collections.unmodifiableSet(tempProfileRcaSet);
   }
 
   /**
@@ -142,6 +168,18 @@ public class SQLiteQueryUtils {
    */
   public static String getPrimaryKeyColumnName(String tableName) {
     return tableName + "_ID";
+  }
+
+  public static List<String> getTemperatureProfileRcas() {
+    return ImmutableList.copyOf(temperatureProfileRCASet);
+  }
+
+  public static boolean isTemperatureProfileRca(String rca) {
+    if (rca == null) {
+      return false;
+    }
+
+    return temperatureProfileRCASet.contains(rca);
   }
 }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
@@ -240,6 +240,7 @@ class SQLitePersistor extends PersistorBase {
         response.addNestedSummaryList(summary);
       }
     } catch (DataAccessException dex) {
+      LOG.error("Failed to read temperature profile RCA for {}", rca, dex);
       dex.printStackTrace();
     }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
@@ -18,15 +18,18 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Resources.State;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit.ResourceFlowUnitFieldValue;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.temperature.CompactNodeTemperatureFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotClusterSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.TopConsumerSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.ClusterTemperatureSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.CompactNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.SQLiteQueryUtils;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.response.RcaResponse;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.ClusterTemperatureRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.NodeTemperatureRca;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -179,6 +182,10 @@ class SQLitePersistor extends PersistorBase {
   // to support range query based on timestamp.
   @Override
   public synchronized RcaResponse readRca(String rca) {
+    // TODO: Need to generalize the persistence logic further.
+    if (SQLiteQueryUtils.isTemperatureProfileRca(rca)) {
+      return readTemperatureProfileRca(rca);
+    }
     RcaResponse response = null;
     Field<Integer> primaryKeyField = DSL.field(
         SQLiteQueryUtils.getPrimaryKeyColumnName(ResourceFlowUnit.RCA_TABLE_NAME), Integer.class);
@@ -191,28 +198,51 @@ class SQLitePersistor extends PersistorBase {
         if (response.getState().equals(State.UNHEALTHY.toString())) {
           readSummary(response, mostRecentRecord.get(primaryKeyField));
         }
-
-        if (rca.equals(ClusterTemperatureRca.TABLE_NAME)) {
-          Field<Integer> foreignKeyField = DSL.field(
-                  SQLiteQueryUtils.getPrimaryKeyColumnName(ResourceFlowUnit.RCA_TABLE_NAME), Integer.class);
-          SelectJoinStep<Record> query = SQLiteQueryUtils
-                  .buildSummaryQuery(create, ClusterTemperatureSummary.TABLE_NAME,
-                          mostRecentRecord.get(primaryKeyField),
-                          foreignKeyField);
-          try {
-            Result<Record> temperaureSummary = query.fetch();
-            GenericSummary summary =
-                    ClusterTemperatureSummary.buildSummaryFromDatabase(temperaureSummary, create);
-            response.addNestedSummaryList(summary);
-          } catch (DataAccessException dex) {
-            dex.printStackTrace();
-          }
-        }
       }
     } catch (DataAccessException de) {
       // it is totally fine if we fail to read some certain tables.
       LOG.warn("Fail to read RCA : {}, query = {},  exceptions : {}", rca, rcaQuery.toString(), de.getStackTrace());
     }
+    return response;
+  }
+
+  private RcaResponse readTemperatureProfileRca(String rca) {
+    RcaResponse response = null;
+    Field<Integer> primaryKeyField = DSL.field(
+        SQLiteQueryUtils.getPrimaryKeyColumnName(ResourceFlowUnit.RCA_TABLE_NAME), Integer.class);
+    SelectJoinStep<Record> rcaQuery = SQLiteQueryUtils.buildRcaQuery(create, rca);
+    try {
+      List<Record> recordList = rcaQuery.fetch();
+      if (recordList == null || recordList.isEmpty()) {
+        return null;
+      }
+      Record mostRecentRecord = recordList.get(0);
+      response = RcaResponse.buildResponse(mostRecentRecord);
+
+      if (rca.equals(ClusterTemperatureRca.TABLE_NAME)) {
+        Field<Integer> foreignKeyField = DSL.field(
+            SQLiteQueryUtils.getPrimaryKeyColumnName(ResourceFlowUnit.RCA_TABLE_NAME),
+            Integer.class);
+        SelectJoinStep<Record> query = SQLiteQueryUtils
+            .buildSummaryQuery(create, ClusterTemperatureSummary.TABLE_NAME,
+                mostRecentRecord.get(primaryKeyField),
+                foreignKeyField);
+        Result<Record> temperatureSummary = query.fetch();
+        GenericSummary summary =
+            ClusterTemperatureSummary.buildSummaryFromDatabase(temperatureSummary, create);
+        response.addNestedSummaryList(summary);
+      } else if (rca.equalsIgnoreCase(NodeTemperatureRca.TABLE_NAME)) {
+        SelectJoinStep<Record> query = SQLiteQueryUtils.buildSummaryQuery(create,
+            "CompactNodeSummary", mostRecentRecord.get(primaryKeyField), primaryKeyField);
+        Result<Record> nodeTemperatureCompactSummary = query.fetch();
+        GenericSummary summary =
+            CompactNodeSummary.buildSummaryFromDatabase(nodeTemperatureCompactSummary, create);
+        response.addNestedSummaryList(summary);
+      }
+    } catch (DataAccessException dex) {
+      dex.printStackTrace();
+    }
+
     return response;
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
@@ -219,6 +219,9 @@ class SQLitePersistor extends PersistorBase {
       Record mostRecentRecord = recordList.get(0);
       response = RcaResponse.buildResponse(mostRecentRecord);
 
+      // ClusterTemperatureRca can only be retrieved from the elected master. If the request is
+      // made from a data node, it returns a 400 saying it can only be queried from the elected
+      // master.
       if (rca.equals(ClusterTemperatureRca.TABLE_NAME)) {
         Field<Integer> foreignKeyField = DSL.field(
             SQLiteQueryUtils.getPrimaryKeyColumnName(ResourceFlowUnit.RCA_TABLE_NAME),

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
@@ -142,7 +142,7 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
     hotNodeClusterRca.addAllUpstreams(Collections.singletonList(hotJVMNodeRca));
 
     constructShardResourceUsageGraph();
-    // constructResourceHeatMapGraph();
+    constructResourceHeatMapGraph();
   }
 
   private void constructShardResourceUsageGraph() {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
@@ -142,7 +142,6 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
     hotNodeClusterRca.addAllUpstreams(Collections.singletonList(hotJVMNodeRca));
 
     constructShardResourceUsageGraph();
-
     // constructResourceHeatMapGraph();
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/NodeTemperatureRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/NodeTemperatureRca.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.Logger;
 
 public class NodeTemperatureRca extends Rca<CompactNodeTemperatureFlowUnit> {
 
+  public static final String TABLE_NAME = NodeTemperatureRca.class.getSimpleName();
   private static final Logger LOG = LogManager.getLogger(NodeTemperatureRca.class);
   private final CpuUtilDimensionTemperatureRca cpuUtilDimensionTemperatureRca;
   private final HeapAllocRateTemperatureRca heapAllocRateTemperatureRca;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtilsTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtilsTest.java
@@ -43,6 +43,8 @@ public class ClusterUtilsTest {
 
     @Test
     public void testIsHostAddressInCluster() {
+        // Explicitly reset ClusterDetailsEventProcessor. Test fails on mac otherwise.
+        ClusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(EMPTY_DETAILS));
         // method should return false when there are no peers
         Assert.assertFalse(ClusterUtils.isHostAddressInCluster(HOST));
         // method should properly recognize which hosts are peers and which aren't


### PR DESCRIPTION
*Issue #, if available:*
#151 
*Description of changes:*
This change adds the ability to get temperature profile RCAs from the data node. Currently only compact node temperature can be retrieved from any data node.

Support for retrieving temperature profiles with higher fidelity will be added in the next PR.

This PR also mutes the temperature profile RCAs while allowing them to be constructed.
*Tests:*
* Tested on the docker environment for RCA output.
* Tested for muting and unmuting of temperature profile RCA and metric nodes.

*Code coverage percentage for this patch:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
