### PR TITLE
Refactoring to rename the HighCPUShardRca to HotShardRca

### DIFF
--- a/pa_config/rca.conf
+++ b/pa_config/rca.conf
@@ -51,5 +51,5 @@
     }
   },
 
-  "muted-rcas": ["HighCPUShardRca", "HotShardClusterRca"]
+  "muted-rcas": ["HotShardRca", "HotShardClusterRca"]
 }

--- a/pa_config/rca_idle_master.conf
+++ b/pa_config/rca_idle_master.conf
@@ -56,5 +56,5 @@
     }
   },
 
-  "muted-rcas": ["HighCPUShardRca", "HotShardClusterRca"]
+  "muted-rcas": ["HotShardRca", "HotShardClusterRca"]
 }

--- a/pa_config/rca_master.conf
+++ b/pa_config/rca_master.conf
@@ -56,5 +56,5 @@
     }
   },
 
-  "muted-rcas": ["HighCPUShardRca", "HotShardClusterRca"]
+  "muted-rcas": ["HotShardRca", "HotShardClusterRca"]
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
@@ -65,8 +65,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.Hot
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hot_node.HighCpuRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotheap.HighHeapUsageOldGenRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotheap.HighHeapUsageYoungGenRca;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotshard.HighCPUShardRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotshard.HotShardClusterRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotshard.HotShardRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.ClusterTemperatureRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.NodeTemperatureRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.dimension.CpuUtilDimensionTemperatureRca;
@@ -159,14 +159,14 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
     addLeaf(ioTotSyscallRate);
 
     // High CPU Utilization RCA
-    HighCPUShardRca highCPUShardRca = new HighCPUShardRca(5, 12, cpuUtilization, ioTotThroughput, ioTotSyscallRate);
-    highCPUShardRca.addTag(TAG_LOCUS, LOCUS_DATA_MASTER_NODE);
-    highCPUShardRca.addAllUpstreams(Arrays.asList(cpuUtilization, ioTotThroughput, ioTotSyscallRate));
+    HotShardRca hotShardRca = new HotShardRca(5, 12, cpuUtilization, ioTotThroughput, ioTotSyscallRate);
+    hotShardRca.addTag(TAG_LOCUS, LOCUS_DATA_MASTER_NODE);
+    hotShardRca.addAllUpstreams(Arrays.asList(cpuUtilization, ioTotThroughput, ioTotSyscallRate));
 
     // Hot Shard Cluster RCA which consumes the above
-    HotShardClusterRca hotShardClusterRca = new HotShardClusterRca(12, highCPUShardRca);
+    HotShardClusterRca hotShardClusterRca = new HotShardClusterRca(12, hotShardRca);
     hotShardClusterRca.addTag(TAG_LOCUS, LOCUS_MASTER_NODE);
-    hotShardClusterRca.addAllUpstreams(Collections.singletonList(highCPUShardRca));
+    hotShardClusterRca.addAllUpstreams(Collections.singletonList(hotShardRca));
     hotShardClusterRca.addTag(TAG_AGGREGATE_UPSTREAM, LOCUS_DATA_NODE);
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotshard/HotShardClusterRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotshard/HotShardClusterRca.java
@@ -40,7 +40,7 @@ import org.apache.logging.log4j.Logger;
 
 /**
  * This RCA is used to find hot shards per index in a cluster using the HotShardSummary
- * sent from each node via 'HighCPUShardRca'. If the resource utilization is (threshold)%
+ * sent from each node via 'HotShardRca'. If the resource utilization is (threshold)%
  * higher than the mean resource utilization for the index, we declare the shard hot.
  *
  */
@@ -51,7 +51,7 @@ public class HotShardClusterRca extends Rca<ResourceFlowUnit> {
     private static final double IO_THROUGHPUT_DEFAULT_THRESHOLD_IN_PERCENTAGE = 0.3;
     private static final double IO_SYSCALLRATE_DEFAULT_THRESHOLD_IN_PERCENTAGE = 0.3;
     private static final int SLIDING_WINDOW_IN_SECONDS = 60;
-    private final Rca<ResourceFlowUnit> highCPUShardRca;
+    private final Rca<ResourceFlowUnit> hotShardRca;
     private int rcaPeriod;
     private int counter;
 
@@ -60,9 +60,9 @@ public class HotShardClusterRca extends Rca<ResourceFlowUnit> {
     private Table<String, NodeShardKey, Double> IOThroughputInfoTable;
     private Table<String, NodeShardKey, Double> IOSysCallRateInfoTable;
 
-    public <R extends Rca> HotShardClusterRca(final int rcaPeriod, final R highCPUShardRca) {
+    public <R extends Rca> HotShardClusterRca(final int rcaPeriod, final R hotShardRca) {
         super(5);
-        this.highCPUShardRca = highCPUShardRca;
+        this.hotShardRca = hotShardRca;
         this.rcaPeriod = rcaPeriod;
         this.counter = 0;
         this.cpuUtilizationInfoTable = HashBasedTable.create();
@@ -135,7 +135,7 @@ public class HotShardClusterRca extends Rca<ResourceFlowUnit> {
         counter++;
 
         // Populate the Table, compiling the information per index
-        final List<ResourceFlowUnit> resourceFlowUnits = highCPUShardRca.getFlowUnits();
+        final List<ResourceFlowUnit> resourceFlowUnits = hotShardRca.getFlowUnits();
         for (final ResourceFlowUnit resourceFlowUnit : resourceFlowUnits) {
             if (resourceFlowUnit.isEmpty()) {
                 continue;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotshard/HotShardRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotshard/HotShardRca.java
@@ -57,9 +57,9 @@ import org.jooq.Record;
  * 2. Paging_RSS
  *
  */
-public class HighCPUShardRca extends Rca<ResourceFlowUnit> {
+public class HotShardRca extends Rca<ResourceFlowUnit> {
 
-    private static final Logger LOG = LogManager.getLogger(HighCPUShardRca.class);
+    private static final Logger LOG = LogManager.getLogger(HotShardRca.class);
     private static final int SLIDING_WINDOW_IN_SECONDS =  60;
 
     //TODO : {@khushbr} refine the threshold values and read same from config file
@@ -80,8 +80,8 @@ public class HighCPUShardRca extends Rca<ResourceFlowUnit> {
     private HashMap<IndexShardKey, SlidingWindow<SlidingWindowData>> ioTotThroughputMap;
     private HashMap<IndexShardKey, SlidingWindow<SlidingWindowData>> ioTotSyscallRateMap;
 
-    public <M extends Metric> HighCPUShardRca(final long evaluationIntervalSeconds, final int rcaPeriod,
-            final M cpuUtilization, final M ioTotThroughput, final M ioTotSyscallRate) {
+    public <M extends Metric> HotShardRca(final long evaluationIntervalSeconds, final int rcaPeriod,
+                                          final M cpuUtilization, final M ioTotThroughput, final M ioTotSyscallRate) {
         super(evaluationIntervalSeconds);
         this.cpuUtilization = cpuUtilization;
         this.ioTotThroughput = ioTotThroughput;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotshard/HotShardRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotshard/HotShardRcaTest.java
@@ -11,7 +11,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.MetricTestHelper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotShardSummary;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotshard.HighCPUShardRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotshard.HotShardRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
 
 import java.time.Clock;
@@ -27,9 +27,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(GradleTaskForRca.class)
-public class HighCPUShardRcaTest {
+public class HotShardRcaTest {
 
-    private HighCPUShardRcaX highCPUShardRcaX;
+    private HotShardRcaX hotShardRcaX;
     private MetricTestHelper cpuUtilization;
     private MetricTestHelper ioTotThroughput;
     private MetricTestHelper ioTotSyscallRate;
@@ -47,7 +47,7 @@ public class HighCPUShardRcaTest {
         cpuUtilization = new MetricTestHelper(5);
         ioTotThroughput = new MetricTestHelper(5);
         ioTotSyscallRate = new MetricTestHelper(5);
-        highCPUShardRcaX = new HighCPUShardRcaX(5, 1,
+        hotShardRcaX = new HotShardRcaX(5, 1,
                 cpuUtilization, ioTotThroughput, ioTotSyscallRate);
         columnName = Arrays.asList(INDEX_NAME.toString(), SHARD_ID.toString(), MetricsDB.SUM);
 
@@ -69,7 +69,7 @@ public class HighCPUShardRcaTest {
         ioTotThroughput = null;
         ioTotSyscallRate = null;
 
-        ResourceFlowUnit flowUnit = highCPUShardRcaX.operate();
+        ResourceFlowUnit flowUnit = hotShardRcaX.operate();
         Assert.assertFalse(flowUnit.getResourceContext().isUnhealthy());
     }
 
@@ -80,7 +80,7 @@ public class HighCPUShardRcaTest {
         ioTotThroughput.createTestFlowUnits(columnName, Collections.emptyList());
         ioTotSyscallRate.createTestFlowUnits(columnName, Collections.emptyList());
 
-        ResourceFlowUnit flowUnit = highCPUShardRcaX.operate();
+        ResourceFlowUnit flowUnit = hotShardRcaX.operate();
         Assert.assertFalse(flowUnit.getResourceContext().isUnhealthy());
     }
 
@@ -97,8 +97,8 @@ public class HighCPUShardRcaTest {
                 Arrays.asList(index.index_1.toString(), "1", String.valueOf(0)));
         ioTotSyscallRate.createTestFlowUnits(columnName,
                 Arrays.asList(index.index_1.toString(), "1", String.valueOf(0)));
-        highCPUShardRcaX.setClock(constantClock);
-        ResourceFlowUnit flowUnit = highCPUShardRcaX.operate();
+        hotShardRcaX.setClock(constantClock);
+        ResourceFlowUnit flowUnit = hotShardRcaX.operate();
         Assert.assertFalse(flowUnit.getResourceContext().isUnhealthy());
 
         // ts = 1
@@ -110,8 +110,8 @@ public class HighCPUShardRcaTest {
         ioTotSyscallRate.createTestFlowUnits(columnName,
                 Arrays.asList(index.index_1.toString(), "1", String.valueOf(0.005)));
 
-        highCPUShardRcaX.setClock(Clock.offset(constantClock, Duration.ofSeconds(1)));
-        flowUnit = highCPUShardRcaX.operate();
+        hotShardRcaX.setClock(Clock.offset(constantClock, Duration.ofSeconds(1)));
+        flowUnit = hotShardRcaX.operate();
         Assert.assertFalse(flowUnit.getResourceContext().isUnhealthy());
 
         //ts = 2
@@ -123,8 +123,8 @@ public class HighCPUShardRcaTest {
         ioTotSyscallRate.createTestFlowUnits(columnName,
                 Arrays.asList(index.index_1.toString(), "1", String.valueOf(0.005)));
 
-        highCPUShardRcaX.setClock(Clock.offset(constantClock, Duration.ofSeconds(2)));
-        flowUnit = highCPUShardRcaX.operate();
+        hotShardRcaX.setClock(Clock.offset(constantClock, Duration.ofSeconds(2)));
+        flowUnit = hotShardRcaX.operate();
         HotNodeSummary summary1 = (HotNodeSummary) flowUnit.getResourceSummary();
         List<HotShardSummary> hotShardSummaryList1 = summary1.getHotShardSummaryList();
 
@@ -147,8 +147,8 @@ public class HighCPUShardRcaTest {
         ioTotSyscallRate.createTestFlowUnits(columnName,
                 Arrays.asList(index.index_1.toString(), "2", String.valueOf(0.10)));;
 
-        highCPUShardRcaX.setClock(Clock.offset(constantClock, Duration.ofSeconds(3)));
-        flowUnit = highCPUShardRcaX.operate();
+        hotShardRcaX.setClock(Clock.offset(constantClock, Duration.ofSeconds(3)));
+        flowUnit = hotShardRcaX.operate();
 
         cpuUtilization.createTestFlowUnits(columnName,
                 Arrays.asList(index.index_1.toString(), "2", String.valueOf(0.25)));
@@ -157,8 +157,8 @@ public class HighCPUShardRcaTest {
         ioTotSyscallRate.createTestFlowUnits(columnName,
                 Arrays.asList(index.index_1.toString(), "2", String.valueOf(0.10)));;
 
-        highCPUShardRcaX.setClock(Clock.offset(constantClock, Duration.ofSeconds(4)));
-        flowUnit = highCPUShardRcaX.operate();
+        hotShardRcaX.setClock(Clock.offset(constantClock, Duration.ofSeconds(4)));
+        flowUnit = hotShardRcaX.operate();
         HotNodeSummary summary2 = (HotNodeSummary) flowUnit.getResourceSummary();
         List<HotShardSummary> hotShardSummaryList2 = summary2.getHotShardSummaryList();
 
@@ -173,9 +173,9 @@ public class HighCPUShardRcaTest {
 
     }
 
-    private static class HighCPUShardRcaX extends HighCPUShardRca {
-        public <M extends Metric> HighCPUShardRcaX(final long evaluationIntervalSeconds,
-            final int rcaPeriod, final M cpuUtilization, final M ioTotThroughput, final M ioTotSyscallRate) {
+    private static class HotShardRcaX extends HotShardRca {
+        public <M extends Metric> HotShardRcaX(final long evaluationIntervalSeconds, final int rcaPeriod,
+                                               final M cpuUtilization, final M ioTotThroughput, final M ioTotSyscallRate) {
           super(evaluationIntervalSeconds, rcaPeriod, cpuUtilization, ioTotThroughput,ioTotSyscallRate);
         }
 


### PR DESCRIPTION
*Description of changes:* Refactoring the HighCPUShardRca to HotShardRca since now we evaluate the hot shard on node based on `IO_TotalSyscallRate`, `IO_TotThroughput`, along with the `CPU_Utilization`
