### PR TITLE
Ut fix

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -55,22 +55,17 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.threads.ThreadPro
 import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.SQLException;
-import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Scanner;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -280,43 +275,6 @@ public class RcaController {
         });
   }
 
-  private Set<String> getAllClasses() {
-    // We are assuming that all the metrics and RCA files will be located under
-    // `com.amazon.opendistro.elasticsearch.performanceanalyzer.rca`
-    String packageName = "com.amazon.opendistro.elasticsearch.performanceanalyzer.rca";
-    Set<String> classes = new TreeSet<>();
-    try {
-      ClassLoader classLoader = RcaController.class.getClassLoader();
-      String packagePath = packageName.replace('.', '/');
-      Enumeration<URL> resources = classLoader.getResources(packagePath);
-      while (resources.hasMoreElements()) {
-        URL resource = resources.nextElement();
-        classes.addAll(findClasses(resource.getFile(), packagePath));
-      }
-    } catch (Exception e) {
-      LOG.error("Failed to get all the classes for muting", e);
-    }
-    return classes;
-  }
-
-  private static Set<String> findClasses(String path, String packagePath) throws Exception {
-    Set<String> classes = new TreeSet<>();
-    if (path.startsWith("file:") && path.contains("!")) {
-      URL jar = new URL(path.split("!")[0]);
-      ZipInputStream zip = new ZipInputStream(jar.openStream());
-      ZipEntry entry;
-      while ((entry = zip.getNextEntry()) != null) {
-        String classFilePath = entry.getName();
-        if (classFilePath.startsWith(packagePath) && classFilePath.endsWith(".class")) {
-          String className = classFilePath.substring(
-                  classFilePath.lastIndexOf("/") + 1, classFilePath.indexOf("."));
-          classes.add(className);
-        }
-      }
-    }
-    return classes;
-  }
-
   private void readAndUpdateMutesRcasDuringStart() {
     try {
       /* We have an edge case where both `readAndUpdateMutesRcas()` and `readAndUpdateMutesRcasDuringStart()`
@@ -324,22 +282,13 @@ public class RcaController {
        * was turned off and then on.
        *
        * <p> `readAndUpdateMutesRcasDuringStart()` should only be read at the start of the process, when
-       * RCA graph is not constructed and we cannot validate the new new muted RCAs. For any other update\
+       * RCA graph is not constructed and we cannot validate the new new muted RCAs. For any other update
        * to the muted list, the periodic rca.conf update checker will take care of it.
        *
        */
       if (lastModifiedTimeInMillisInMemory == 0) {
         Set<String> rcasForMute = new HashSet<>(rcaConf.getMutedRcaList());
-        final Set<String> classes = getAllClasses();
-        rcasForMute.forEach(
-                mutedRca -> {
-                  if (classes.contains(mutedRca)) {
-                    Stats.getInstance().addToMutedGraphNodes(mutedRca);
-                  } else {
-                    LOG.error("RCA: {} provided for muting isn't valid", mutedRca);
-                  }
-                }
-        );
+        rcasForMute.forEach(mutedRca -> Stats.getInstance().addToMutedGraphNodes(mutedRca));
         LOG.info("Updated the muted RCA Graph to : {}", rcaConf.getMutedRcaList());
       }
     } catch (Exception e) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -288,7 +288,7 @@ public class RcaController {
        */
       if (lastModifiedTimeInMillisInMemory == 0) {
         Set<String> rcasForMute = new HashSet<>(rcaConf.getMutedRcaList());
-        rcasForMute.forEach(mutedRca -> Stats.getInstance().addToMutedGraphNodes(mutedRca));
+        Stats.getInstance().updateMutedGraphNodes(rcasForMute);
         LOG.info("Updated the muted RCA Graph to : {}", rcaConf.getMutedRcaList());
       }
     } catch (Exception e) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Stats.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Stats.java
@@ -93,14 +93,11 @@ public class Stats {
     return new ArrayList<>(graphs.values());
   }
 
-  public boolean updateMutedGraphNodes(Set<String> nodeNames) {
-    // Add all the rcaNodes if the mutedGraphNodes is empty
-    // else, retain the ones provided in param value
-    if (mutedGraphNodes.isEmpty()) {
-      return mutedGraphNodes.addAll(nodeNames);
-    } else {
-      return mutedGraphNodes.retainAll(nodeNames);
-    }
+  public void updateMutedGraphNodes(Set<String> nodeNames) {
+    // Currently, we update mutedGraphNodes only via rca.conf,
+    // thus, it is safe to clear out the older value and add all new muted RCAs
+    mutedGraphNodes.clear();
+    mutedGraphNodes.addAll(nodeNames);
   }
 
   public boolean addToMutedGraphNodes(String nodeName) {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
@@ -17,6 +17,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.Rca
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.threads.ThreadProvider;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.util.WaitFor;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
@@ -204,8 +205,12 @@ public class RcaControllerTest {
     changeRcaRunState(RcaState.RUN);
     setMyIp(masterIP, AllMetrics.NodeRole.MASTER);
     RcaControllerHelper.set(Paths.get(rcaEnabledFileLoc.toString(), "rca.conf").toString(),
-            Paths.get(rcaEnabledFileLoc.toString(), "rca_muted.conf").toString(),
+            mutedRcaConfPath,
             Paths.get(rcaEnabledFileLoc.toString(), "rca_elected_master.conf").toString());
+
+    WaitFor.waitFor(() -> rcaController.getCurrentRole() == AllMetrics.NodeRole.MASTER, 10, TimeUnit.SECONDS);
+    WaitFor.waitFor(() -> RcaControllerHelper.pickRcaConfForRole(AllMetrics.NodeRole.MASTER).getConfigFileLoc() == mutedRcaConfPath,
+            10, TimeUnit.SECONDS);
 
     // 1. Muted Graph : "CPU_Utilization, Heap_AllocRate", updating RCA Config with "CPU_Utilization, Heap_AllocRate"
     // Muted Graph should have "CPU_Utilization, Heap_AllocRate"


### PR DESCRIPTION
*Description of changes:* 
* Adding `readAndUpdateMutesRcasDuringStart()` invoked during the controller `start()`. This method is invoked after graph initialization and before the RCASchedulerTask is initialized. This allows for a clean way to update the mutedRCA list within the Analysis graph. 
* Fixing the readAndUpdateMutedRcas() UT.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
