### PR TITLE
Fix ClusterUtilsTest flakiness

### DIFF
--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtilsTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtilsTest.java
@@ -5,6 +5,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDet
 import com.google.common.collect.Lists;
 import java.util.Collections;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 public class ClusterUtilsTest {
@@ -13,9 +14,13 @@ public class ClusterUtilsTest {
     private static final ClusterDetailsEventProcessor.NodeDetails EMPTY_DETAILS =
             ClusterDetailsEventProcessorTestHelper.newNodeDetails("", "", false);
 
+    @Before
+    public void setup() {
+        ClusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(EMPTY_DETAILS));
+    }
+
     @Test
     public void testGetCurrentHostAddress() {
-        ClusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(EMPTY_DETAILS));
         Assert.assertEquals(ClusterUtils.EMPTY_STRING, ClusterUtils.getCurrentNodeHostAddress());
         ClusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(
                 ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, HOST, false)
@@ -26,7 +31,6 @@ public class ClusterUtilsTest {
     @Test
     public void testGetAllPeerHostAddresses() {
         // method should behave when fed an empty list of peers
-        ClusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(EMPTY_DETAILS));
         Assert.assertEquals(Collections.emptyList(), ClusterUtils.getAllPeerHostAddresses());
         // method should not include the current node in the list of peers
         ClusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(


### PR DESCRIPTION
This test could fail when tests were executed in a certain order. This
commit ensures that the tests can execute in any order.

*Issue #, if available:* N/A

*Description of changes:* This test could fail when tests were executed in a certain order. This
commit ensures that the tests can execute in any order.

*Tests:* ClusterUtilsTest

*Code coverage percentage for this patch:* unchanged

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
