### PR TITLE
Fix testReadFromWire race condition in WireHopperTest

### DIFF
--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopperTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopperTest.java
@@ -21,6 +21,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDet
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.util.WaitFor;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 
 import java.util.Collections;
@@ -197,9 +198,10 @@ public class WireHopperTest {
         List<FlowUnitMessage> actualMsgList = uut.readFromWire(node);
         Assert.assertEquals(msgList, actualMsgList);
         // Verify expected interactions with the subscription manager
-        WaitFor.waitFor(() -> subscriptionManager.getSubscribersFor(node.name()).size() == 1, 1,
-                TimeUnit.SECONDS);
-        Assert.assertEquals(LOCALHOST, subscriptionManager.getSubscribersFor(node.name()).asList().get(0));
+        WaitFor.waitFor(() -> {
+                ImmutableSet<String> subscribers = subscriptionManager.getSubscribersFor(node.name());
+                return subscribers.size() == 1 && subscribers.asList().get(0).equals(LOCALHOST);
+            }, 1, TimeUnit.SECONDS);
         // Verify resilience to RejectedExecutionException
         clientExecutor.set(rejectingExecutor);
         uut.readFromWire(node);


### PR DESCRIPTION
The subscription manager's list of subscribers for a given node could
previously change between 2 assertions. This has been fixed by saving
the list into a variable.

*Issue #, if available:* N/A

*Description of changes:* Bugfix for WireHopperTest

*Tests:* WireHopperTest#testReadFromWire

*Code coverage percentage for this patch:* N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
