### PR TITLE
Prepare RCA to work with the Integration Test framework

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,7 +32,7 @@ jobs:
         java-version: 1.12
     - name: Build RCA with Gradle
       working-directory:  ./tmp/rca
-      run: ./gradlew build
+      run: ./gradlew build --info
     - name: Publish RCA jar to maven local
       working-directory: ./tmp/rca
       run: ./gradlew publishToMavenLocal

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,7 +32,7 @@ jobs:
         java-version: 1.12
     - name: Build RCA with Gradle
       working-directory:  ./tmp/rca
-      run: ./gradlew build --info --stacktrace
+      run: ./gradlew build
     - name: Publish RCA jar to maven local
       working-directory: ./tmp/rca
       run: ./gradlew publishToMavenLocal

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,7 +32,7 @@ jobs:
         java-version: 1.12
     - name: Build RCA with Gradle
       working-directory:  ./tmp/rca
-      run: ./gradlew build --info
+      run: ./gradlew build --info --stacktrace
     - name: Publish RCA jar to maven local
       working-directory: ./tmp/rca
       run: ./gradlew publishToMavenLocal

--- a/build.gradle
+++ b/build.gradle
@@ -508,6 +508,28 @@ task unzipPerfTop(type: Copy) {
     enabled = !file(perfTopBin).exists()
 }
 
+task enablePa(type: Exec) {
+    dependsOn(waitForES)
+    doFirst {
+        sleep(5000)
+    }
+    commandLine('curl', 'localhost:9200/_opendistro/_performanceanalyzer/cluster/config', '-H',
+            'Content-Type: application/json', '-d', '{"enabled": true}')
+    doLast {
+        sleep(5000)
+    }
+}
+
+task enablePaAndRca(type: Exec) {
+    dependsOn(enablePa)
+    commandLine('curl', 'localhost:9200/_opendistro/_performanceanalyzer/rca/cluster/config',
+            '-H', 'Content-Type: application/json', '-d', '{"enabled": true}')
+    doLast {
+        sleep(5000)
+    }
+}
+
+/*
 task enablePaAndRca(type: Exec) {
     dependsOn(waitForES)
     commandLine('curl', 'localhost:9200/_opendistro/_performanceanalyzer/cluster/config', '-H',
@@ -515,6 +537,7 @@ task enablePaAndRca(type: Exec) {
     commandLine('curl', 'localhost:9200/_opendistro/_performanceanalyzer/rca/cluster/config',
             '-H', 'Content-Type: application/json', '-d', '{"enabled": true}')
 }
+ */
 
 task runPerftop {
     dependsOn(enablePaAndRca, unzipPerfTop)

--- a/build.gradle
+++ b/build.gradle
@@ -355,6 +355,7 @@ task buildDocker(type: Exec) {
     commandLine 'docker', 'build', '-t', 'odfe-es/pa-rca:1.0', '.'
 }
 
+/*
 task printComposeLocation() {
     dependsOn(buildDocker)
     def output = new ByteArrayOutputStream()
@@ -372,9 +373,10 @@ task printComposeLocation() {
     }
     println "Docker compose version is: $output"
 }
+*/
 
 task runDocker(type: Exec) {
-    dependsOn(buildDocker, printComposeLocation)
+    dependsOn(buildDocker)
 
     workingDir(dockerArtifactsDir)
 

--- a/build.gradle
+++ b/build.gradle
@@ -525,27 +525,27 @@ task unzipPerfTop(type: Copy) {
 
 task enablePa(type: Exec) {
     dependsOn(waitForES)
-    doFirst {
+    doFirst { // Ensures we don't get a Connection refused error on port 9200 from Elasticsearch
         sleep(5000)
     }
     commandLine('curl', 'localhost:9200/_opendistro/_performanceanalyzer/cluster/config', '-H',
             'Content-Type: application/json', '-d', '{"enabled": true}')
-    doLast {
+    doLast { // Ensures PA is enabled before subsequent tasks rely on it
         sleep(5000)
     }
 }
 
-task enablePaAndRca(type: Exec) {
+task enableRca(type: Exec) {
     dependsOn(enablePa)
     commandLine('curl', 'localhost:9200/_opendistro/_performanceanalyzer/rca/cluster/config',
             '-H', 'Content-Type: application/json', '-d', '{"enabled": true}')
-    doLast {
+    doLast { // Ensures RCA is enabled before subsequent tasks rely on it
         sleep(5000)
     }
 }
 
 task runPerftop {
-    dependsOn(enablePaAndRca, unzipPerfTop)
+    dependsOn(enableRca, unzipPerfTop)
     doLast {
         println '============================================================================'
         println 'invoke perftop as: '
@@ -555,7 +555,7 @@ task runPerftop {
 }
 
 task generateLoad {
-    dependsOn(enablePaAndRca, runPerftop)
+    dependsOn(enableRca, runPerftop)
 
     doLast {
         String[] deleteIndex = ['curl', '-X', 'DELETE', 'localhost:9200/accounts?pretty']
@@ -584,7 +584,7 @@ task generateLoad {
 }
 
 task runRally {
-    dependsOn(enablePaAndRca, runPerftop)
+    dependsOn(enableRca, runPerftop)
 
     doLast {
         String rallyTrack='pmc'

--- a/build.gradle
+++ b/build.gradle
@@ -355,15 +355,38 @@ task buildDocker(type: Exec) {
     commandLine 'docker', 'build', '-t', 'odfe-es/pa-rca:1.0', '.'
 }
 
+task printComposeLocation() {
+    dependsOn(copyAllArtifacts)
+    def output = new ByteArrayOutputStream()
+    exec {
+        workingDir(dockerArtifactsDir)
+        standardOutput = output
+        commandLine 'which', 'docker-compose'
+    }
+    println "Docker compose location is: \n$output"
+    output.reset()
+    exec {
+        workingDir(dockerArtifactsDir)
+        standardOutput = output
+        commandLine 'docker-compose', '-v'
+    }
+    println "Docker compose version is: $output"
+}
+
 task runDocker(type: Exec) {
-    dependsOn(buildDocker)
+    dependsOn(buildDocker, printComposeLocation)
 
     workingDir(dockerArtifactsDir)
+
+    def docker_compose_location = "docker-compose"
+    if (System.getenv("DOCKER_COMPOSE_LOCATION") != null) {
+        docker_compose_location = System.getenv("DOCKER_COMPOSE_LOCATION")
+    }
 
     environment 'DATA_VOLUME1', 'esdata1'
     environment 'DATA_VOLUME2', 'esdata2'
 
-    commandLine('docker-compose',
+    commandLine(docker_compose_location,
             '-f', 'docker-compose.yml',
             '-f', 'docker-compose.hostports.yml',
             '-f', 'docker-compose.cluster.yml',
@@ -411,7 +434,9 @@ def runInProcess(commandArr) {
 }
 
 def runDockerCompose = { executionPath ->
-    String[] commandArray = ['docker-compose',
+    String dockerCompose = System.getenv("DOCKER_COMPOSE_LOCATION") == null ? "docker-compose" : System.getenv("DOCKER_COMPOSE_LOCATION")
+    println "Docker Compose LOC is $dockerCompose"
+    String[] commandArray = [dockerCompose,
                              '-f', 'docker-compose.yml',
                              '-f', 'docker-compose.hostports.yml',
                              '-f', 'docker-compose.cluster.yml',
@@ -455,7 +480,7 @@ Boolean esIsUp
 
 def esUpChecker = {
     String server = "http://localhost:9200"
-    int timeoutSeconds = 5 * 60
+    int timeoutSeconds = 2 * 60
     getHttpResponse(server, timeoutSeconds)
     esIsUp = true
 }

--- a/build.gradle
+++ b/build.gradle
@@ -356,7 +356,7 @@ task buildDocker(type: Exec) {
 }
 
 task printComposeLocation() {
-    dependsOn(copyAllArtifacts)
+    dependsOn(buildDocker)
     def output = new ByteArrayOutputStream()
     exec {
         workingDir(dockerArtifactsDir)

--- a/build.gradle
+++ b/build.gradle
@@ -355,31 +355,15 @@ task buildDocker(type: Exec) {
     commandLine 'docker', 'build', '-t', 'odfe-es/pa-rca:1.0', '.'
 }
 
-/*
-task printComposeLocation() {
-    dependsOn(buildDocker)
-    def output = new ByteArrayOutputStream()
-    exec {
-        workingDir(dockerArtifactsDir)
-        standardOutput = output
-        commandLine 'which', 'docker-compose'
-    }
-    println "Docker compose location is: \n$output"
-    output.reset()
-    exec {
-        workingDir(dockerArtifactsDir)
-        standardOutput = output
-        commandLine 'docker-compose', '-v'
-    }
-    println "Docker compose version is: $output"
-}
-*/
-
 task runDocker(type: Exec) {
     dependsOn(buildDocker)
 
     workingDir(dockerArtifactsDir)
 
+    // This block is included to make the runDocker task work with Github Actions
+    // It sets the path to the docker-compose program from an environment variable
+    // The DOCKER_COMPOSE_LOCATION environment variable is set in the gradle.yml file inside the
+    // performance-analyzer repository.
     def docker_compose_location = "docker-compose"
     if (System.getenv("DOCKER_COMPOSE_LOCATION") != null) {
         docker_compose_location = System.getenv("DOCKER_COMPOSE_LOCATION")
@@ -436,8 +420,12 @@ def runInProcess(commandArr) {
 }
 
 def runDockerCompose = { executionPath ->
-    String dockerCompose = System.getenv("DOCKER_COMPOSE_LOCATION") == null ? "docker-compose" : System.getenv("DOCKER_COMPOSE_LOCATION")
-    println "Docker Compose LOC is $dockerCompose"
+    // This block is included to make the runDocker task work with Github Actions
+    // It sets the path to the docker-compose program from an environment variable
+    // The DOCKER_COMPOSE_LOCATION environment variable is set in the gradle.yml file inside the
+    // performance-analyzer repository.
+    String dockerCompose = System.getenv("DOCKER_COMPOSE_LOCATION") == null ?
+            "docker-compose" : System.getenv("DOCKER_COMPOSE_LOCATION")
     String[] commandArray = [dockerCompose,
                              '-f', 'docker-compose.yml',
                              '-f', 'docker-compose.hostports.yml',
@@ -555,16 +543,6 @@ task enablePaAndRca(type: Exec) {
         sleep(5000)
     }
 }
-
-/*
-task enablePaAndRca(type: Exec) {
-    dependsOn(waitForES)
-    commandLine('curl', 'localhost:9200/_opendistro/_performanceanalyzer/cluster/config', '-H',
-            'Content-Type: application/json', '-d', '{"enabled": true}')
-    commandLine('curl', 'localhost:9200/_opendistro/_performanceanalyzer/rca/cluster/config',
-            '-H', 'Content-Type: application/json', '-d', '{"enabled": true}')
-}
- */
 
 task runPerftop {
     dependsOn(enablePaAndRca, unzipPerfTop)


### PR DESCRIPTION
*Issue #, if available:* 22

*Description of changes:* Modified the enablePaAndRca task to properly execute in stages. PA is enabled, then RCA is enabled. Previously this task would not always properly enable the two components.

Also modified gradle task logic to use a specified path to the docker-compose program if an environment variable is set. This allows the ES cluster to spin up on local machines as well as on the Github Actions CI runner.

*Tests:* N/A

*Code coverage percentage for this patch:* N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
