### PR TITLE
Incoporating 1:n NodeSummary changes into Hot Shard RCA

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/SQLiteQueryUtils.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/SQLiteQueryUtils.java
@@ -21,6 +21,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.ShardProfileSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HighHeapUsageClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HotNodeClusterRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotshard.HotShardClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.ClusterTemperatureRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.NodeTemperatureRca;
 import com.google.common.collect.ImmutableList;
@@ -64,6 +65,7 @@ public class SQLiteQueryUtils {
     rcaSet.add(ClusterTemperatureRca.TABLE_NAME);
     rcaSet.add(HighHeapUsageClusterRca.RCA_TABLE_NAME);
     rcaSet.add(HotNodeClusterRca.RCA_TABLE_NAME);
+    rcaSet.add(HotShardClusterRca.RCA_TABLE_NAME);
     clusterLevelRCA = Collections.unmodifiableSet(rcaSet);
   }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/RcaTestHelper.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/RcaTestHelper.java
@@ -66,7 +66,8 @@ public class RcaTestHelper extends Rca<ResourceFlowUnit> {
     hotShardSummary.setIoThroughputThreshold(500000);
     hotShardSummary.setIoSysCallrate(io_sys_callrate);
     hotShardSummary.setIoSysCallrateThreshold(0.50);
-    HotNodeSummary nodeSummary = new HotNodeSummary(nodeID, "127.0.0.0", Arrays.asList(hotShardSummary));
+    HotNodeSummary nodeSummary = new HotNodeSummary(nodeID, "127.0.0.0");
+    nodeSummary.addNestedSummaryList(Arrays.asList(hotShardSummary));
     return new ResourceFlowUnit(System.currentTimeMillis(), new ResourceContext(health), nodeSummary);
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/HotNodeSummaryTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/HotNodeSummaryTest.java
@@ -44,7 +44,8 @@ public class HotNodeSummaryTest {
         hotShardSummary.setIoThroughputThreshold(250000);
         hotShardSummary.setIoSysCallrate(0.232);
         hotShardSummary.setIoSysCallrateThreshold(0.10);
-        uut = new HotNodeSummary(NODE_ID, HOST_ADDRESS, Arrays.asList(hotShardSummary));
+        uut = new HotNodeSummary(NODE_ID, HOST_ADDRESS);
+        uut.addNestedSummaryList(Arrays.asList(hotShardSummary));
     }
 
     @Test
@@ -53,7 +54,7 @@ public class HotNodeSummaryTest {
         Assert.assertNotNull(msg);
         Assert.assertEquals(NODE_ID, msg.getNodeID());
         Assert.assertEquals(HOST_ADDRESS, msg.getHostAddress());
-        Assert.assertEquals(1, uut.getHotShardSummaryList().size());
+        Assert.assertEquals(1, uut.getNestedSummaryList().size());
     }
 
     @Test
@@ -66,7 +67,7 @@ public class HotNodeSummaryTest {
 
     @Test
     public void testToString() {
-        Assert.assertEquals(NODE_ID + " " + HOST_ADDRESS + " " + uut.getNestedSummaryList() + " " +  uut.getHotShardSummaryList(),
+        Assert.assertEquals(NODE_ID + " " + HOST_ADDRESS + " " + uut.getNestedSummaryList(),
                 uut.toString());
     }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotshard/HotShardRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotshard/HotShardRcaTest.java
@@ -11,6 +11,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.MetricTestHelper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotShardSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotshard.HotShardRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
 
@@ -126,13 +127,15 @@ public class HotShardRcaTest {
         hotShardRcaX.setClock(Clock.offset(constantClock, Duration.ofSeconds(2)));
         flowUnit = hotShardRcaX.operate();
         HotNodeSummary summary1 = (HotNodeSummary) flowUnit.getResourceSummary();
-        List<HotShardSummary> hotShardSummaryList1 = summary1.getHotShardSummaryList();
+        List<GenericSummary> hotShardSummaryList1 = summary1.getNestedSummaryList();
 
         Assert.assertTrue(flowUnit.getResourceContext().isUnhealthy());
         Assert.assertEquals(1, hotShardSummaryList1.size());
-        Assert.assertEquals("1", hotShardSummaryList1.get(0).getShardId());
-        Assert.assertEquals(index.index_1.toString(), hotShardSummaryList1.get(0).getIndexName());
-        Assert.assertEquals("node1", hotShardSummaryList1.get(0).getNodeId());
+
+        HotShardSummary hotShardSummary1 = (HotShardSummary) hotShardSummaryList1.get(0);
+        Assert.assertEquals("1", hotShardSummary1.getShardId());
+        Assert.assertEquals(index.index_1.toString(), hotShardSummary1.getIndexName());
+        Assert.assertEquals("node1", hotShardSummary1.getNodeId());
 
         // ts = 3
         // index = index_1, shard = shard_2, cpuUtilization = 0.75, ioTotThroughput = 400000, ioTotSyscallRate = 0.10
@@ -160,17 +163,19 @@ public class HotShardRcaTest {
         hotShardRcaX.setClock(Clock.offset(constantClock, Duration.ofSeconds(4)));
         flowUnit = hotShardRcaX.operate();
         HotNodeSummary summary2 = (HotNodeSummary) flowUnit.getResourceSummary();
-        List<HotShardSummary> hotShardSummaryList2 = summary2.getHotShardSummaryList();
+        List<GenericSummary> hotShardSummaryList2 = summary2.getNestedSummaryList();
 
         Assert.assertTrue(flowUnit.getResourceContext().isUnhealthy());
         Assert.assertEquals(2, hotShardSummaryList2.size());
-        Assert.assertEquals(index.index_1.toString(), hotShardSummaryList2.get(0).getIndexName());
-        Assert.assertEquals("1", hotShardSummaryList2.get(0).getShardId());
-        Assert.assertEquals("node1", hotShardSummaryList2.get(0).getNodeId());
-        Assert.assertEquals("2", hotShardSummaryList2.get(1).getShardId());
-        Assert.assertEquals(index.index_1.toString(), hotShardSummaryList2.get(1).getIndexName());
-        Assert.assertEquals("node1", hotShardSummaryList2.get(1).getNodeId());
 
+        HotShardSummary hotShardSummary2 = (HotShardSummary) hotShardSummaryList2.get(0);
+        HotShardSummary hotShardSummary3 = (HotShardSummary) hotShardSummaryList2.get(1);
+        Assert.assertEquals(index.index_1.toString(), hotShardSummary2.getIndexName());
+        Assert.assertEquals("1", hotShardSummary2.getShardId());
+        Assert.assertEquals("node1", hotShardSummary2.getNodeId());
+        Assert.assertEquals("2", hotShardSummary3.getShardId());
+        Assert.assertEquals(index.index_1.toString(), hotShardSummary3.getIndexName());
+        Assert.assertEquals("node1", hotShardSummary3.getNodeId());
     }
 
     private static class HotShardRcaX extends HotShardRca {


### PR DESCRIPTION
*Description of changes:* NodeSummary has been made to support 1:n summary, incorporating the same within Hot Shard RCA
Other Minor changes include : 
1. Adding `HotShardClusterRca` to be query-able by RCA APIs
2. Fixing broken tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
