### PR TITLE
Removing the min and the max shard calculations.

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/NodeLevelDimensionalSummary.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/NodeLevelDimensionalSummary.java
@@ -21,12 +21,15 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.ShardStore;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.SQLiteQueryUtils;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.protobuf.GeneratedMessageV3;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -97,6 +100,11 @@ public class NodeLevelDimensionalSummary extends GenericSummary {
 
     public double getTotalUsage() {
         return totalUsage;
+    }
+
+    @VisibleForTesting
+    public List<ShardProfileSummary> getShardsForZoneInReverseTemperatureOrder(HeatZoneAssigner.Zone zone) {
+        return zoneProfiles[zone.ordinal()].getShardsInReverseTemperatureOrder();
     }
 
     @Override
@@ -255,14 +263,9 @@ public class NodeLevelDimensionalSummary extends GenericSummary {
 
     public class NodeLevelZoneSummary extends GenericSummary {
         public static final String ZONE_KEY = "zone";
-        public static final String MIN_KEY = "min";
-        public static final String MAX_KEY = "max";
         public static final String ALL_KEY = "all_shards";
 
         List<ShardProfileSummary> shardProfileSummaries;
-        ShardProfileSummary minShard;
-        ShardProfileSummary maxShard;
-
         private final HeatZoneAssigner.Zone myZone;
 
         NodeLevelZoneSummary(HeatZoneAssigner.Zone myZone) {
@@ -272,37 +275,11 @@ public class NodeLevelDimensionalSummary extends GenericSummary {
 
         void addShard(ShardProfileSummary shard) {
             shardProfileSummaries.add(shard);
-            if (minShard == null) {
-                minShard = shard;
-            } else {
-                if (getMinTemperature().isGreaterThan(shard.getHeatInDimension(profileForDimension))) {
-                    minShard = shard;
-                }
-            }
-
-            if (maxShard == null) {
-                maxShard = shard;
-            } else {
-                if (shard.getHeatInDimension(profileForDimension).isGreaterThan(getMaxTemperature())) {
-                    maxShard = shard;
-                }
-            }
         }
 
-        @Nullable
-        TemperatureVector.NormalizedValue getMinTemperature() {
-            if (minShard != null) {
-                return minShard.getHeatInDimension(profileForDimension);
-            }
-            return null;
-        }
-
-        @Nullable
-        TemperatureVector.NormalizedValue getMaxTemperature() {
-            if (maxShard != null) {
-                return maxShard.getHeatInDimension(profileForDimension);
-            }
-            return null;
+        public List<ShardProfileSummary> getShardsInReverseTemperatureOrder() {
+            shardProfileSummaries.sort(new ShardProfileComparator());
+            return Collections.unmodifiableList(shardProfileSummaries);
         }
 
         @Override
@@ -329,15 +306,13 @@ public class NodeLevelDimensionalSummary extends GenericSummary {
         public List<Field<?>> getSqlSchema() {
             List<Field<?>> schema = new ArrayList<>();
             schema.add(DSL.field(DSL.name(ZONE_KEY), String.class));
-            schema.add(DSL.field(DSL.name(MIN_KEY), String.class));
-            schema.add(DSL.field(DSL.name(MAX_KEY), String.class));
             schema.add(DSL.field(DSL.name(ALL_KEY), String.class));
             return schema;
         }
 
         public List<GenericSummary> getNestedSummaryList() {
             List<GenericSummary> shardSummaries = new ArrayList<>();
-            for (ShardProfileSummary shardProfileSummary : shardProfileSummaries) {
+            for (ShardProfileSummary shardProfileSummary : getShardsInReverseTemperatureOrder()) {
                 shardSummaries.add(shardProfileSummary);
             }
             return shardSummaries;
@@ -347,9 +322,11 @@ public class NodeLevelDimensionalSummary extends GenericSummary {
         public List<Object> getSqlValue() {
             List<Object> values = new ArrayList<>();
             values.add(myZone.name());
-            values.add(minShard == null ? "" : minShard.toJson());
-            values.add(maxShard == null ? "" : maxShard.toJson());
             JsonArray array = new JsonArray();
+
+            // The reason we are not getting shards ordered by temperature as
+            // we don't want to pay the cost of sorting while writes. We do writes
+            // more often than reads and therefore, we would rather sort on reads.
             for (ShardProfileSummary shard : shardProfileSummaries) {
                 if (shard != null) {
                     array.add(shard.toJson());
@@ -364,13 +341,6 @@ public class NodeLevelDimensionalSummary extends GenericSummary {
             JsonObject summaryObj = new JsonObject();
             summaryObj.addProperty(ZONE_KEY, myZone.name());
 
-            // Min and the max makes sense only if there are more than 2, or else they don't
-            //carry meaningful information.
-            if (shardProfileSummaries.size() > 2) {
-                summaryObj.add(MIN_KEY, minShard == null ? new JsonObject() : minShard.toJson());
-                summaryObj.add(MAX_KEY, maxShard == null ? new JsonObject() : maxShard.toJson());
-            }
-
             JsonArray array = new JsonArray();
             getNestedSummaryList().forEach(
                     summary -> {
@@ -379,6 +349,13 @@ public class NodeLevelDimensionalSummary extends GenericSummary {
             );
             summaryObj.add(ALL_KEY, array);
             return summaryObj;
+        }
+    }
+
+    private class ShardProfileComparator implements Comparator<ShardProfileSummary> {
+        @Override
+        public int compare(ShardProfileSummary o1, ShardProfileSummary o2) {
+            return o2.getHeatInDimension(profileForDimension).getPOINTS() - o1.getHeatInDimension(profileForDimension).getPOINTS();
         }
     }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/NodeLevelDimensionalSummary.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/NodeLevelDimensionalSummary.java
@@ -355,6 +355,10 @@ public class NodeLevelDimensionalSummary extends GenericSummary {
     private class ShardProfileComparator implements Comparator<ShardProfileSummary> {
         @Override
         public int compare(ShardProfileSummary o1, ShardProfileSummary o2) {
+            return reverseSort(o1, o2);
+        }
+
+        private int reverseSort(ShardProfileSummary o1, ShardProfileSummary o2) {
             return o2.getHeatInDimension(profileForDimension).getPOINTS() - o1.getHeatInDimension(profileForDimension).getPOINTS();
         }
     }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/NodeLevelDimensionalSummaryTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/NodeLevelDimensionalSummaryTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.HeatZoneAssigner;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NodeLevelDimensionalSummaryTest {
+  @Test
+  public void getShardsInReverseTemperatureOrder() {
+    final HeatZoneAssigner.Zone ZONE = HeatZoneAssigner.Zone.HOT;
+    final TemperatureVector.Dimension DIMENSION = TemperatureVector.Dimension.CPU_Utilization;
+    final int SHARD_COUNT = 10;
+
+    NodeLevelDimensionalSummary nodeSummary =
+        new NodeLevelDimensionalSummary(DIMENSION,
+            new TemperatureVector.NormalizedValue((short) 2),
+            12.0);
+
+    // The list of shards so obtained is shards ordered in ascending order of temperature
+    // along the Dimension = DIMENSION.
+    for (ShardProfileSummary shard : getShards(DIMENSION, SHARD_COUNT)) {
+      nodeSummary.addShardToZone(shard, ZONE);
+    }
+
+    List<ShardProfileSummary> shards = nodeSummary.getShardsForZoneInReverseTemperatureOrder(HeatZoneAssigner.Zone.HOT);
+
+    // Although the shards were inserted in the ascending order of temperature,
+    // the getShardsForZoneInReverseTemperatureOrder should return them in the
+    // descending order of temperature.
+    for (int i = 0; i < shards.size(); i++) {
+      ShardProfileSummary shard = shards.get(i);
+      Assert.assertEquals(SHARD_COUNT - i - 1, shard.getHeatInDimension(DIMENSION).getPOINTS());
+    }
+  }
+
+  private List<ShardProfileSummary> getShards(TemperatureVector.Dimension dimension, int count) {
+    List<ShardProfileSummary> shards = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      ShardProfileSummary shard = new ShardProfileSummary("test-index", i);
+      shard.addTemperatureForDimension(dimension,
+          new TemperatureVector.NormalizedValue((short) i));
+      shards.add(shard);
+    }
+    return shards;
+  }
+}


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
Instead of calculating min and the max shards in a zone, we return the list of shards sorted by temperature for the dimension in question. 

*Tests:*
Added unit tests for coverage. Also tested on docker.

*Code coverage percentage for this patch:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
