### PR TITLE
Adding Raw Metrics to the Shard, Node and Cluster Summaries

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/ClusterTemperatureSummary.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/ClusterTemperatureSummary.java
@@ -17,6 +17,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.ap
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.SQLiteQueryUtils;
 import com.google.gson.JsonArray;
@@ -53,16 +54,18 @@ public class ClusterTemperatureSummary extends GenericSummary {
     public ClusterTemperatureSummary(int numberOfNodes) {
         this.numberOfNodes = numberOfNodes;
         this.nodeDimensionalTemperatureSummaries =
-                new ClusterDimensionalSummary[TemperatureVector.Dimension.values().length];
+                new ClusterDimensionalSummary[TemperatureDimension.values().length];
         this.nodes = new CompactClusterLevelNodeSummary[this.numberOfNodes];
     }
 
-    public void createClusterDimensionalTemperature(TemperatureVector.Dimension dimension,
+    public void createClusterDimensionalTemperature(TemperatureDimension dimension,
                                                     TemperatureVector.NormalizedValue mean,
-                                                    double totalUsage) {
+                                                    double avgMetricValueUsedOverShards,
+                                                    double totalMetricValueUsedOverCluster) {
         ClusterDimensionalSummary summary = new ClusterDimensionalSummary(dimension);
         summary.setMeanTemperature(mean);
-        summary.setTotalUsage(totalUsage);
+        summary.setAvgMetricValueOverShards(avgMetricValueUsedOverShards);
+        summary.setTotalMetricsValueUsed(totalMetricValueUsedOverCluster);
         nodeDimensionalTemperatureSummaries[dimension.ordinal()] = summary;
     }
 
@@ -71,7 +74,7 @@ public class ClusterTemperatureSummary extends GenericSummary {
         int i = 0;
         for (CompactClusterLevelNodeSummary nodeTemperatureSummaryVal :
                 nodeTemperatureSummaries.values()) {
-            for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
+            for (TemperatureDimension dimension : TemperatureDimension.values()) {
                 nodeDimensionalTemperatureSummaries[dimension.ordinal()].addNodeToZone(nodeTemperatureSummaryVal);
             }
             nodes[i] = nodeTemperatureSummaryVal;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/CompactClusterLevelNodeSummary.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/CompactClusterLevelNodeSummary.java
@@ -18,6 +18,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.ap
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary.SQL_SCHEMA_CONSTANTS.HOST_IP_ADDRESS_COL_NAME;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary.SQL_SCHEMA_CONSTANTS.NODE_ID_COL_NAME;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -53,7 +54,7 @@ public class CompactClusterLevelNodeSummary extends CompactNodeSummary {
 
         CompactClusterLevelNodeSummary summary = new CompactClusterLevelNodeSummary(nodeId, hostIp);
 
-        for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
+        for (TemperatureDimension dimension : TemperatureDimension.values()) {
             try {
                 Short mean = record.get(dimension.NAME + MEAN_SUFFIX_KEY, Short.class);
                 double total = record.get(dimension.NAME + TOTAL_SUFFIX_KEY, Double.class);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/ShardProfileSummary.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/ShardProfileSummary.java
@@ -17,10 +17,14 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.ap
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.RawMetricsVector;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import com.google.gson.JsonObject;
 import com.google.protobuf.GeneratedMessageV3;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.jooq.Field;
@@ -31,17 +35,20 @@ public class ShardProfileSummary extends GenericSummary {
     public static final String SUMMARY_TABLE_NAME = "ShardProfileSummary";
     public static final String INDEX_NAME_KEY = "index_name";
     public static final String SHARD_ID_KEY = "shard_id";
+    public static final String RAW_METRIC_KEY = "raw_metric";
     public static final String TEMPERATURE_KEY = "temperature";
 
     private final String indexName;
     private final int shardId;
 
     private final TemperatureVector temperatureVector;
+    private final RawMetricsVector perShardMetricsVector;
 
 
     public ShardProfileSummary(String indexName, int shardId) {
         this.indexName = indexName;
         this.shardId = shardId;
+        this.perShardMetricsVector = new RawMetricsVector();
         this.temperatureVector = new TemperatureVector();
     }
 
@@ -74,8 +81,11 @@ public class ShardProfileSummary extends GenericSummary {
         List<Field<?>> schema = new ArrayList<>();
         schema.add(DSL.field(DSL.name(INDEX_NAME_KEY), String.class));
         schema.add(DSL.field(DSL.name(SHARD_ID_KEY), Integer.class));
-        for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
-            schema.add(DSL.field(DSL.name(dimension.NAME), Short.class));
+        for (TemperatureDimension dimension : TemperatureDimension.values()) {
+            schema.add(DSL.field(DSL.name(TEMPERATURE_KEY + dimension.NAME), Short.class));
+        }
+        for (TemperatureDimension dimension : TemperatureDimension.values()) {
+            schema.add(DSL.field(DSL.name(RAW_METRIC_KEY + dimension.NAME), Short.class));
         }
         return schema;
     }
@@ -85,8 +95,11 @@ public class ShardProfileSummary extends GenericSummary {
         List<Object> values = new ArrayList<>();
         values.add(indexName);
         values.add(shardId);
-        for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
+        for (TemperatureDimension dimension : TemperatureDimension.values()) {
             values.add(temperatureVector.getTemperatureFor(dimension));
+        }
+        for (TemperatureDimension dimension : TemperatureDimension.values()) {
+            values.add(perShardMetricsVector.getMetricsFor(dimension));
         }
         return values;
     }
@@ -96,18 +109,24 @@ public class ShardProfileSummary extends GenericSummary {
         summaryObj.addProperty(INDEX_NAME_KEY, indexName);
         summaryObj.addProperty(SHARD_ID_KEY, shardId);
         summaryObj.add(TEMPERATURE_KEY, temperatureVector.toJson());
+        summaryObj.add(RAW_METRIC_KEY, perShardMetricsVector.toJson());
         return summaryObj;
     }
 
     @Nullable
-    public TemperatureVector.NormalizedValue getHeatInDimension(TemperatureVector.Dimension dimension) {
+    public TemperatureVector.NormalizedValue getHeatInDimension(TemperatureDimension dimension) {
         return temperatureVector.getTemperatureFor(dimension);
     }
 
-    public void addTemperatureForDimension(TemperatureVector.Dimension dimension,
+    public void addTemperatureForDimension(TemperatureDimension dimension,
                                            TemperatureVector.NormalizedValue value) {
         // TODO: Need to handle rcas updating heat profile of a shard along a dimension multiple
         //  times per tick.
         temperatureVector.updateTemperatureForDimension(dimension, value);
+    }
+
+    public void addRawMetricForDimension(TemperatureDimension dimension,
+                                         double value) {
+        perShardMetricsVector.updateRawMetricsForDimension(dimension, value);
     }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/temperature/RawMetricsVector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/temperature/RawMetricsVector.java
@@ -1,0 +1,52 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import javax.annotation.Nullable;
+
+public class RawMetricsVector {
+    public static final String DIMENSION_KEY = "metrics_dimension";
+    public static final String VALUE_KEY = "metrics_value";
+
+    public static double[] metricsValues;
+
+    public RawMetricsVector() {
+        metricsValues = new double[TemperatureDimension.values().length];
+    }
+
+    @Override
+    public String toString() {
+        return toJson().toString();
+    }
+
+    public JsonArray toJson() {
+        JsonArray array = new JsonArray();
+        for (TemperatureDimension dim : TemperatureDimension.values()) {
+            double val = metricsValues[dim.ordinal()];
+            if (val != 0) {
+                JsonObject jsonObject = new JsonObject();
+                jsonObject.addProperty(DIMENSION_KEY, dim.NAME);
+                jsonObject.addProperty(VALUE_KEY, val);
+                array.add(jsonObject);
+            }
+        }
+        return array;
+    }
+
+    /**
+     * This can be used to get raw metrics along a dimension.
+     *
+     * @param dimension one of the dimensions
+     * @return The raw metrics value along that dimension.
+     */
+    @Nullable
+    public double getMetricsFor(TemperatureDimension dimension) {
+        return metricsValues[dimension.ordinal()];
+    }
+
+    public void updateRawMetricsForDimension(TemperatureDimension dimension,
+                                             double metricsValue) {
+        metricsValues[dimension.ordinal()] = metricsValue;
+    }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/temperature/TemperatureDimension.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/temperature/TemperatureDimension.java
@@ -1,0 +1,13 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature;
+
+public enum TemperatureDimension {
+        CPU_Utilization(com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.CPU_Utilization.NAME),
+        Heap_AllocRate(com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_AllocRate.NAME),
+        Shard_Size_In_Bytes(com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ShardSizeInBytes.NAME);
+
+        public final String NAME;
+
+        TemperatureDimension(String name) {
+            this.NAME = name;
+        }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/temperature/TemperatureVector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/temperature/TemperatureVector.java
@@ -24,18 +24,6 @@ public class TemperatureVector {
     public static final String DIMENSION_KEY = "dimension";
     public static final String VALUE_KEY = "value";
 
-    public enum Dimension {
-        CPU_Utilization(com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.CPU_Utilization.NAME),
-        Heap_AllocRate(com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_AllocRate.NAME),
-        Shard_Size_In_Bytes(com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ShardSizeInBytes.NAME);
-
-        public final String NAME;
-
-        Dimension(String name) {
-            this.NAME = name;
-        }
-    }
-
     public static class NormalizedValue {
         public static final int MIN = 0;
         public static final int MAX = 10;
@@ -89,7 +77,7 @@ public class TemperatureVector {
     private NormalizedValue[] normalizedValues;
 
     public TemperatureVector() {
-        normalizedValues = new NormalizedValue[Dimension.values().length];
+        normalizedValues = new NormalizedValue[TemperatureDimension.values().length];
     }
 
     @Override
@@ -99,7 +87,7 @@ public class TemperatureVector {
 
     public JsonArray toJson() {
         JsonArray array = new JsonArray();
-        for (Dimension dim : Dimension.values()) {
+        for (TemperatureDimension dim : TemperatureDimension.values()) {
             NormalizedValue val = normalizedValues[dim.ordinal()];
             if (val != null) {
                 JsonObject jsonObject = new JsonObject();
@@ -118,11 +106,11 @@ public class TemperatureVector {
      * @return The normalized temperature value along that dimension.
      */
     @Nullable
-    public NormalizedValue getTemperatureFor(Dimension dimension) {
+    public NormalizedValue getTemperatureFor(TemperatureDimension dimension) {
         return normalizedValues[dimension.ordinal()];
     }
 
-    public void updateTemperatureForDimension(Dimension dimension,
+    public void updateTemperatureForDimension(TemperatureDimension dimension,
                                               NormalizedValue normalizedValue) {
         normalizedValues[dimension.ordinal()] = normalizedValue;
     }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/pyrometer/Api.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/pyrometer/Api.java
@@ -18,6 +18,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.pyrometer;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.CompactNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.ShardProfileSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.HeatZoneAssigner;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -80,7 +81,7 @@ public class Api {
      * @param dimension The dimension to consider.
      * @return The difference in temperature of the
      */
-    public static boolean isClusterImbalanceAlongDimension(TemperatureVector.Dimension dimension) {
+    public static boolean isClusterImbalanceAlongDimension(TemperatureDimension dimension) {
         failIfNotElectedMaster("getClusterImbalanceAlongDimension");
         // TODO: Calculate this
         return true;
@@ -97,7 +98,7 @@ public class Api {
      * @return An ordered list of nodes.
      */
     public static @Nonnull
-    List<CompactNodeSummary> getNodesForGivenZone(final TemperatureVector.Dimension dimension,
+    List<CompactNodeSummary> getNodesForGivenZone(final TemperatureDimension dimension,
                                                   final HeatZoneAssigner.Zone zone,
                                                   final Count count,
                                                   final SortOrder order) {
@@ -112,7 +113,7 @@ public class Api {
      * @return A list of nodes ordered by the temperature Zone by the ordinal of    the enum.
      */
     public static @Nonnull
-    Map<HeatZoneAssigner.Zone, List<CompactNodeSummary>> getNodesForAllZones(final TemperatureVector.Dimension dimension,
+    Map<HeatZoneAssigner.Zone, List<CompactNodeSummary>> getNodesForAllZones(final TemperatureDimension dimension,
                                                                              final Count count,
                                                                              final SortOrder order) {
         failIfNotElectedMaster("getNodes");
@@ -142,7 +143,7 @@ public class Api {
     public static @Nonnull
     List<ShardProfileSummary> getShards(
             final CompactNodeSummary node,
-            final TemperatureVector.Dimension dimension,
+            final TemperatureDimension dimension,
             final HeatZoneAssigner.Zone zone,
             final Count count,
             final SortOrder sortOrder) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
@@ -198,7 +198,7 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
   }
 
   protected void constructResourceHeatMapGraph() {
-    LOG.info("Constructing temperature profile RCA components");
+    LOG.error("Constructing temperature profile RCA components");
     ShardStore shardStore = new ShardStore();
 
     HeapAllocRateByShardTemperatureCalculator heapAllocByShard =
@@ -223,6 +223,7 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
     ShardSizeAvgTemperatureCalculator shardSizeAvg =
             new ShardSizeAvgTemperatureCalculator();
 
+    LOG.error("Metrics Gathered");
     // heat map is developed only for data nodes.
     cpuUtilByShard.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
     avgCpuUtilByShards.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
@@ -236,6 +237,7 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
 
     shardSizeByShard.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
     shardSizeAvg.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
+    LOG.error("Locus Added");
 
     addLeaf(cpuUtilByShard);
     addLeaf(avgCpuUtilByShards);
@@ -249,6 +251,7 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
 
     addLeaf(shardSizeByShard);
     addLeaf(shardSizeAvg);
+    LOG.error("Leafs Added");
 
     CpuUtilDimensionTemperatureRca cpuUtilHeat = new CpuUtilDimensionTemperatureRca(shardStore,
             cpuUtilByShard,
@@ -270,13 +273,16 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
             shardSizeByShard, shardSizeAvg);
     shardSizeHeat.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
     shardSizeHeat.addAllUpstreams(Arrays.asList(shardSizeByShard, shardSizeAvg));
+    LOG.error("Added All Upstreams Added");
 
     NodeTemperatureRca nodeTemperatureRca = new NodeTemperatureRca(cpuUtilHeat, heapAllocRateHeat, shardSizeHeat);
     nodeTemperatureRca.addTag(TAG_LOCUS, LOCUS_DATA_NODE);
     nodeTemperatureRca.addAllUpstreams(Arrays.asList(cpuUtilHeat, heapAllocRateHeat, shardSizeHeat));
+    LOG.error("Node RCA Added");
 
     ClusterTemperatureRca clusterTemperatureRca = new ClusterTemperatureRca(nodeTemperatureRca);
     clusterTemperatureRca.addTag(TAG_LOCUS, LOCUS_MASTER_NODE);
     clusterTemperatureRca.addAllUpstreams(Collections.singletonList(nodeTemperatureRca));
+    LOG.error("Cluster RCA Added");
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/TemperatureMetricsBase.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/TemperatureMetricsBase.java
@@ -17,6 +17,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.AggregateMetric;
 import java.util.Arrays;
@@ -51,7 +52,7 @@ public abstract class TemperatureMetricsBase extends AggregateMetric {
     public static final String AGGR_OVER_AGGR_NAME =
             AGGR_TYPE_OVER_METRICS_DB_COLUMN + "_of_" + METRICS_DB_AGG_COLUMN_USED;
 
-    public TemperatureMetricsBase(TemperatureVector.Dimension metricType,
+    public TemperatureMetricsBase(TemperatureDimension metricType,
                                   String[] groupByDimensions) {
         // The temperature intendeds to spread the temperature around the cluster by re-allocating shards
         // from the hottest of nodes to the nodes that are relatively cold (with some randomness

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/AvgCpuUtilByShardsMetricBasedTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/AvgCpuUtilByShardsMetricBasedTemperatureCalculator.java
@@ -15,11 +15,12 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.calculators.AvgShardBasedTemperatureCalculator;
 
 public class AvgCpuUtilByShardsMetricBasedTemperatureCalculator extends AvgShardBasedTemperatureCalculator {
     public AvgCpuUtilByShardsMetricBasedTemperatureCalculator() {
-        super(TemperatureVector.Dimension.CPU_Utilization);
+        super(TemperatureDimension.CPU_Utilization);
     }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/CpuUtilByShardsMetricBasedTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/CpuUtilByShardsMetricBasedTemperatureCalculator.java
@@ -15,12 +15,13 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.calculators.ShardBasedTemperatureCalculator;
 
 public class CpuUtilByShardsMetricBasedTemperatureCalculator extends ShardBasedTemperatureCalculator {
 
     public CpuUtilByShardsMetricBasedTemperatureCalculator() {
-        super(TemperatureVector.Dimension.CPU_Utilization);
+        super(TemperatureDimension.CPU_Utilization);
     }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/HeapAllocRateByShardAvgTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/HeapAllocRateByShardAvgTemperatureCalculator.java
@@ -1,12 +1,12 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard;
 
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector.Dimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.calculators.AvgShardBasedTemperatureCalculator;
 
 public class HeapAllocRateByShardAvgTemperatureCalculator extends
     AvgShardBasedTemperatureCalculator {
 
   public HeapAllocRateByShardAvgTemperatureCalculator() {
-    super(Dimension.Heap_AllocRate);
+    super(TemperatureDimension.Heap_AllocRate);
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/HeapAllocRateByShardTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/HeapAllocRateByShardTemperatureCalculator.java
@@ -1,11 +1,11 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard;
 
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector.Dimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.calculators.ShardBasedTemperatureCalculator;
 
 public class HeapAllocRateByShardTemperatureCalculator extends ShardBasedTemperatureCalculator {
 
   public HeapAllocRateByShardTemperatureCalculator() {
-    super(Dimension.Heap_AllocRate);
+    super(TemperatureDimension.Heap_AllocRate);
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/ShardSizeAvgTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/ShardSizeAvgTemperatureCalculator.java
@@ -1,6 +1,6 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard;
 
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector.Dimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.calculators.AvgShardBasedTemperatureCalculator;
 
 /*
@@ -10,6 +10,6 @@ public class ShardSizeAvgTemperatureCalculator extends
     AvgShardBasedTemperatureCalculator {
 
   public ShardSizeAvgTemperatureCalculator() {
-    super(Dimension.Shard_Size_In_Bytes);
+    super(TemperatureDimension.Shard_Size_In_Bytes);
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/ShardSizeByShardTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/ShardSizeByShardTemperatureCalculator.java
@@ -1,6 +1,6 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard;
 
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector.Dimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.calculators.ShardBasedTemperatureCalculator;
 
 /*
@@ -9,6 +9,6 @@ Class for returning the Shard Size Metric for individual shards held by the node
 public class ShardSizeByShardTemperatureCalculator extends ShardBasedTemperatureCalculator {
 
     public ShardSizeByShardTemperatureCalculator() {
-        super(Dimension.Shard_Size_In_Bytes);
+        super(TemperatureDimension.Shard_Size_In_Bytes);
     }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/calculators/AvgShardBasedTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/calculators/AvgShardBasedTemperatureCalculator.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.calculators;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import java.util.List;
 import org.jooq.DSLContext;
@@ -29,7 +30,7 @@ import org.jooq.impl.DSL;
  * It calculates the average over all index,shard groups.
  */
 public class AvgShardBasedTemperatureCalculator extends ShardBasedTemperatureCalculator {
-    public AvgShardBasedTemperatureCalculator(TemperatureVector.Dimension metricType) {
+    public AvgShardBasedTemperatureCalculator(TemperatureDimension metricType) {
         super(metricType);
     }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/calculators/ShardBasedTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/byShard/calculators/ShardBasedTemperatureCalculator.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.calculators;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.TemperatureMetricsBase;
 import java.util.List;
@@ -39,7 +40,7 @@ public class ShardBasedTemperatureCalculator extends TemperatureMetricsBase {
             AllMetrics.CommonDimension.SHARD_ID.toString()
     };
 
-    public ShardBasedTemperatureCalculator(TemperatureVector.Dimension metricType) {
+    public ShardBasedTemperatureCalculator(TemperatureDimension metricType) {
         // The temperature intendeds to spread the temperature around the cluster by re-allocating shards
         // from the hottest of nodes to the nodes that are relatively cold (with some randomness
         // so that it does not overwhelm the coldest node). Pyrometer also wants to size for peak

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/capacity/HeapAllocRateTotalTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/capacity/HeapAllocRateTotalTemperatureCalculator.java
@@ -1,11 +1,11 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.capacity;
 
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector.Dimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.capacity.calculators.TotalNodeTemperatureCalculator;
 
 public class HeapAllocRateTotalTemperatureCalculator extends TotalNodeTemperatureCalculator {
 
   public HeapAllocRateTotalTemperatureCalculator() {
-    super(Dimension.Heap_AllocRate);
+    super(TemperatureDimension.Heap_AllocRate);
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/capacity/ShardSizePeakUsageTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/capacity/ShardSizePeakUsageTemperatureCalculator.java
@@ -1,11 +1,12 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.capacity;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.capacity.calculators.TotalNodeTemperatureCalculator;
 
 public class ShardSizePeakUsageTemperatureCalculator extends TotalNodeTemperatureCalculator {
 
     public ShardSizePeakUsageTemperatureCalculator() {
-        super(TemperatureVector.Dimension.Shard_Size_In_Bytes);
+        super(TemperatureDimension.Shard_Size_In_Bytes);
     }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/capacity/TotalCpuUtilForTotalNodeMetric.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/capacity/TotalCpuUtilForTotalNodeMetric.java
@@ -15,12 +15,13 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.capacity;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.capacity.calculators.TotalNodeTemperatureCalculator;
 
 public class TotalCpuUtilForTotalNodeMetric extends TotalNodeTemperatureCalculator {
 
     public TotalCpuUtilForTotalNodeMetric() {
-        super(TemperatureVector.Dimension.CPU_Utilization);
+        super(TemperatureDimension.CPU_Utilization);
     }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/capacity/calculators/TotalNodeTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/capacity/calculators/TotalNodeTemperatureCalculator.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.capacity.calculators;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.TemperatureMetricsBase;
 import java.util.List;
@@ -32,7 +33,7 @@ public class TotalNodeTemperatureCalculator extends TemperatureMetricsBase {
     // For peak usage there is no group by clause used, therefore this is empty.
     private static final String[] dimensions = {};
 
-    public TotalNodeTemperatureCalculator(TemperatureVector.Dimension metricType) {
+    public TotalNodeTemperatureCalculator(TemperatureDimension metricType) {
         super(metricType, dimensions);
     }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/shardIndependent/DiskUsageShardIndependentTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/shardIndependent/DiskUsageShardIndependentTemperatureCalculator.java
@@ -1,11 +1,12 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.shardIndependent;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.shardIndependent.calculators.ShardIndependentTemperatureCalculator;
 
 public class DiskUsageShardIndependentTemperatureCalculator extends
         ShardIndependentTemperatureCalculator {
     public DiskUsageShardIndependentTemperatureCalculator() {
-        super(TemperatureVector.Dimension.Shard_Size_In_Bytes);
+        super(TemperatureDimension.Shard_Size_In_Bytes);
     }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/shardIndependent/HeapAllocRateShardIndependentTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/shardIndependent/HeapAllocRateShardIndependentTemperatureCalculator.java
@@ -1,12 +1,12 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.shardIndependent;
 
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector.Dimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.shardIndependent.calculators.ShardIndependentTemperatureCalculator;
 
 public class HeapAllocRateShardIndependentTemperatureCalculator extends
     ShardIndependentTemperatureCalculator {
 
   public HeapAllocRateShardIndependentTemperatureCalculator() {
-    super(Dimension.Heap_AllocRate);
+    super(TemperatureDimension.Heap_AllocRate);
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/shardIndependent/ShardIndependentTemperatureCalculatorCpuUtilMetric.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/shardIndependent/ShardIndependentTemperatureCalculatorCpuUtilMetric.java
@@ -15,12 +15,13 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.shardIndependent;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.shardIndependent.calculators.ShardIndependentTemperatureCalculator;
 
 public class ShardIndependentTemperatureCalculatorCpuUtilMetric extends ShardIndependentTemperatureCalculator {
 
     public ShardIndependentTemperatureCalculatorCpuUtilMetric() {
-        super(TemperatureVector.Dimension.CPU_Utilization);
+        super(TemperatureDimension.CPU_Utilization);
     }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/shardIndependent/calculators/ShardIndependentTemperatureCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/metric/temperature/shardIndependent/calculators/ShardIndependentTemperatureCalculator.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.shardIndependent.calculators;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.AggregateMetric;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.TemperatureMetricsBase;
@@ -58,7 +59,7 @@ public class ShardIndependentTemperatureCalculator extends TemperatureMetricsBas
             AllMetrics.CommonDimension.OPERATION.toString()
     };
 
-    public ShardIndependentTemperatureCalculator(TemperatureVector.Dimension metricType) {
+    public ShardIndependentTemperatureCalculator(TemperatureDimension metricType) {
         super(metricType, dimensions);
     }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/ClusterTemperatureRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/ClusterTemperatureRca.java
@@ -23,6 +23,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.ClusterTemperatureSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.CompactClusterLevelNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.CompactNodeSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import java.util.HashMap;
@@ -63,7 +64,7 @@ public class ClusterTemperatureRca extends Rca<ClusterTemperatureFlowUnit> {
         // level. Note that temperature is a normalized value, normalized by total usage. At node
         // level, the total usage is at the node level (over all shards and shard-independent
         // factors), at the master the total usage is the sum over all nodes.
-        for (TemperatureVector.Dimension dimension : TemperatureVector.Dimension.values()) {
+        for (TemperatureDimension dimension : TemperatureDimension.values()) {
             double totalForDimension = 0.0;
             for (CompactNodeTemperatureFlowUnit nodeFlowUnit : flowUnits) {
                 CompactNodeSummary summary = nodeFlowUnit.getCompactNodeTemperatureSummary();
@@ -74,7 +75,7 @@ public class ClusterTemperatureRca extends Rca<ClusterTemperatureFlowUnit> {
                     TemperatureVector.NormalizedValue.calculate(nodeAverageForDimension, totalForDimension);
 
             clusterTemperatureSummary.createClusterDimensionalTemperature(dimension,
-                    normalizedAvgForDimension, totalForDimension);
+                    normalizedAvgForDimension, nodeAverageForDimension, totalForDimension);
 
             recalibrateNodeTemperaturesAtClusterLevelUsage(flowUnits, nodeTemperatureSummaryMap,
                     dimension, totalForDimension, nodeAverageForDimension);
@@ -87,7 +88,7 @@ public class ClusterTemperatureRca extends Rca<ClusterTemperatureFlowUnit> {
     private void recalibrateNodeTemperaturesAtClusterLevelUsage(List<CompactNodeTemperatureFlowUnit> flowUnits,
                                                                 Map<String,
                                                                         CompactClusterLevelNodeSummary> nodeTemperatureSummaryMap,
-                                                                TemperatureVector.Dimension dimension,
+                                                                TemperatureDimension dimension,
                                                                 double totalForDimension,
                                                                 double avgForTheDimension) {
         for (CompactNodeTemperatureFlowUnit nodeFlowUnit : flowUnits) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/dimension/CpuUtilDimensionTemperatureRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/dimension/CpuUtilDimensionTemperatureRca.java
@@ -19,6 +19,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaController
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Rca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.temperature.DimensionalTemperatureFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.ShardStore;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.AvgCpuUtilByShardsMetricBasedTemperatureCalculator;
@@ -65,7 +66,7 @@ public class CpuUtilDimensionTemperatureRca extends Rca<DimensionalTemperatureFl
         LOG.error("executing: {}", name());
         DimensionalTemperatureFlowUnit flowUnit = DimensionalTemperatureCalculator.getTemperatureForDimension(
                 shardStore,
-                TemperatureVector.Dimension.CPU_Utilization,
+                TemperatureDimension.CPU_Utilization,
                 CPU_UTIL_BY_SHARD,
                 AVG_CPU_UTIL_BY_SHARD, CPU_UTIL_SHARD_INDEPENDENT, CPU_UTIL_PEAK_USAGE,
                 THRESHOLD_NORMALIZED_VAL_FOR_HEAT_ZONE_ASSIGNMENT);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/dimension/HeapAllocRateTemperatureRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/dimension/HeapAllocRateTemperatureRca.java
@@ -3,8 +3,8 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.te
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Rca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.temperature.DimensionalTemperatureFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.ShardStore;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector.Dimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector.NormalizedValue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.HeapAllocRateByShardAvgTemperatureCalculator;
@@ -52,7 +52,7 @@ public class HeapAllocRateTemperatureRca extends Rca<DimensionalTemperatureFlowU
     LOG.debug("executing : {}", name());
     DimensionalTemperatureFlowUnit heapAllocRateTemperatureFlowUnit =
         DimensionalTemperatureCalculator.getTemperatureForDimension(SHARD_STORE,
-            Dimension.Heap_AllocRate, HEAP_ALLOC_RATE_BY_SHARD, HEAP_ALLOC_RATE_BY_SHARD_AVG,
+                TemperatureDimension.Heap_AllocRate, HEAP_ALLOC_RATE_BY_SHARD, HEAP_ALLOC_RATE_BY_SHARD_AVG,
             HEAP_ALLOC_RATE_SHARD_INDEPENDENT, HEAP_ALLOC_RATE_TOTAL, THRESHOLD);
     LOG.info("Heap allocation rate temperature calculated: {}",
         heapAllocRateTemperatureFlowUnit.getNodeDimensionProfile());

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/dimension/ShardSizeDimensionTemperatureRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/dimension/ShardSizeDimensionTemperatureRca.java
@@ -3,6 +3,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.te
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Rca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.temperature.DimensionalTemperatureFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.ShardStore;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.temperature.byShard.ShardSizeAvgTemperatureCalculator;
@@ -46,7 +47,7 @@ public class ShardSizeDimensionTemperatureRca extends Rca<DimensionalTemperature
         LOG.debug("executing : {}", name());
         DimensionalTemperatureFlowUnit shardSizeTemperatureFlowUnit =
                 DimensionalTemperatureCalculator.getTemperatureForDimension(SHARD_STORE,
-                        TemperatureVector.Dimension.Shard_Size_In_Bytes, SHARD_SIZE_BY_SHARD, SHARD_SIZE_AVG, THRESHOLD);
+                        TemperatureDimension.Shard_Size_In_Bytes, SHARD_SIZE_BY_SHARD, SHARD_SIZE_AVG, THRESHOLD);
         LOG.debug("Shard Size temperature calculated: {}",
                 shardSizeTemperatureFlowUnit.getNodeDimensionProfile());
         return shardSizeTemperatureFlowUnit;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/NodeLevelDimensionalSummaryTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/temperature/NodeLevelDimensionalSummaryTest.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.HeatZoneAssigner;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,13 +27,12 @@ public class NodeLevelDimensionalSummaryTest {
   @Test
   public void getShardsInReverseTemperatureOrder() {
     final HeatZoneAssigner.Zone ZONE = HeatZoneAssigner.Zone.HOT;
-    final TemperatureVector.Dimension DIMENSION = TemperatureVector.Dimension.CPU_Utilization;
+    final TemperatureDimension DIMENSION = TemperatureDimension.CPU_Utilization;
     final int SHARD_COUNT = 10;
 
     NodeLevelDimensionalSummary nodeSummary =
-        new NodeLevelDimensionalSummary(DIMENSION,
-            new TemperatureVector.NormalizedValue((short) 2),
-            12.0);
+        new NodeLevelDimensionalSummary(DIMENSION, new TemperatureVector.NormalizedValue((short) 2),
+                12.0,20);
 
     // The list of shards so obtained is shards ordered in ascending order of temperature
     // along the Dimension = DIMENSION.
@@ -51,7 +51,7 @@ public class NodeLevelDimensionalSummaryTest {
     }
   }
 
-  private List<ShardProfileSummary> getShards(TemperatureVector.Dimension dimension, int count) {
+  private List<ShardProfileSummary> getShards(TemperatureDimension dimension, int count) {
     List<ShardProfileSummary> shards = new ArrayList<>();
     for (int i = 0; i < count; i++) {
       ShardProfileSummary shard = new ShardProfileSummary("test-index", i);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ResourceHeatMapGraphTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ResourceHeatMapGraphTest.java
@@ -44,6 +44,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Stats;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.HeatZoneAssigner;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.TemperatureVector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaUtil;
@@ -701,7 +702,7 @@ public class ResourceHeatMapGraphTest {
 
     for (JsonElement elem : json) {
       JsonObject object = elem.getAsJsonObject();
-      switch (TemperatureVector.Dimension.valueOf(object.get("dimension").getAsString())) {
+      switch (TemperatureDimension.valueOf(object.get("dimension").getAsString())) {
         case CPU_Utilization:
           verifyCpuDimension(object);
           break;


### PR DESCRIPTION
*Issue #, if available: Add Raw Metrics to the Summaries #222

*Description of changes:  We should have raw metrics as well persisted to the summaries so as to make a comparison and check if the algorithm is correctly classifying shards

*Tests: UTs and Manual testing in progress.

*Code coverage percentage for this patch:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
