### PR TITLE
Refactoring : Add generic type to ResourceFlowUnit. 

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/temperature/ClusterTemperatureFlowUnit.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/temperature/ClusterTemperatureFlowUnit.java
@@ -20,7 +20,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.ClusterTemperatureSummary;
 
-public class ClusterTemperatureFlowUnit extends ResourceFlowUnit {
+public class ClusterTemperatureFlowUnit extends ResourceFlowUnit<ClusterTemperatureSummary> {
     private final ClusterTemperatureSummary clusterTemperatureSummary;
 
     public ClusterTemperatureFlowUnit(long timeStamp, ResourceContext context,

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/temperature/CompactNodeTemperatureFlowUnit.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/temperature/CompactNodeTemperatureFlowUnit.java
@@ -27,7 +27,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
  * temperatures at the granularity of shards. As, some of our largest instances can have multiple
  * shards, it would be sending too many bytes over the wire.
  */
-public class CompactNodeTemperatureFlowUnit extends ResourceFlowUnit {
+public class CompactNodeTemperatureFlowUnit extends ResourceFlowUnit<CompactNodeSummary> {
     private final CompactNodeSummary compactNodeTemperatureSummary;
 
     public CompactNodeTemperatureFlowUnit(long timeStamp, ResourceContext context,

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/temperature/DimensionalTemperatureFlowUnit.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/temperature/DimensionalTemperatureFlowUnit.java
@@ -26,7 +26,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
  * Elasticsearch node (or in other words, are not transferred over the wire). Therefore, the
  * protobuf message generation is not really required.
  */
-public class DimensionalTemperatureFlowUnit extends ResourceFlowUnit {
+public class DimensionalTemperatureFlowUnit extends ResourceFlowUnit<NodeLevelDimensionalSummary> {
     private final NodeLevelDimensionalSummary nodeDimensionProfile;
 
     public DimensionalTemperatureFlowUnit(long timeStamp,

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistorBase.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistorBase.java
@@ -18,7 +18,6 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.response.RcaResponse;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import java.io.File;
@@ -236,7 +235,7 @@ public abstract class PersistorBase implements Persistable {
 
     if (flowUnit.hasResourceSummary() && flowUnit.isSummaryPersistable()) {
       writeSummary(
-              flowUnit.getResourceSummary(),
+              flowUnit.getPersistableSummary(),
               tableName,
               getPrimaryKeyColumnName(tableName),
               lastPrimaryKey);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
@@ -47,6 +47,9 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.TermVectors_Memory;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Terms_Memory;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.VersionMap_Memory;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotClusterSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.ShardStore;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.AggregateMetric;
@@ -108,35 +111,35 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
     //add node stats metrics
     List<Metric> nodeStatsMetrics = constructNodeStatsMetrics();
 
-    Rca<ResourceFlowUnit> highHeapUsageOldGenRca = new HighHeapUsageOldGenRca(12, heapUsed, gcEvent,
+    Rca<ResourceFlowUnit<HotResourceSummary>> highHeapUsageOldGenRca = new HighHeapUsageOldGenRca(12, heapUsed, gcEvent,
             heapMax, nodeStatsMetrics);
     highHeapUsageOldGenRca.addTag(TAG_LOCUS, LOCUS_DATA_MASTER_NODE);
     List<Node<?>> upstream = new ArrayList<>(Arrays.asList(heapUsed, gcEvent, heapMax));
     upstream.addAll(nodeStatsMetrics);
     highHeapUsageOldGenRca.addAllUpstreams(upstream);
 
-    Rca<ResourceFlowUnit> highHeapUsageYoungGenRca = new HighHeapUsageYoungGenRca(12, heapUsed,
+    Rca<ResourceFlowUnit<HotResourceSummary>> highHeapUsageYoungGenRca = new HighHeapUsageYoungGenRca(12, heapUsed,
             gc_Collection_Time);
     highHeapUsageYoungGenRca.addTag(TAG_LOCUS, LOCUS_DATA_MASTER_NODE);
     highHeapUsageYoungGenRca.addAllUpstreams(Arrays.asList(heapUsed, gc_Collection_Time));
 
-    Rca<ResourceFlowUnit> highCpuRca = new HighCpuRca(12, cpuUtilizationGroupByOperation);
+    Rca<ResourceFlowUnit<HotResourceSummary>> highCpuRca = new HighCpuRca(12, cpuUtilizationGroupByOperation);
     highCpuRca.addTag(TAG_LOCUS, LOCUS_DATA_MASTER_NODE);
     highCpuRca.addAllUpstreams(Collections.singletonList(cpuUtilizationGroupByOperation));
 
-    Rca<ResourceFlowUnit> hotJVMNodeRca = new HotNodeRca(12, highHeapUsageOldGenRca,
+    Rca<ResourceFlowUnit<HotNodeSummary>> hotJVMNodeRca = new HotNodeRca(12, highHeapUsageOldGenRca,
             highHeapUsageYoungGenRca, highCpuRca);
     hotJVMNodeRca.addTag(TAG_LOCUS, LOCUS_DATA_MASTER_NODE);
     hotJVMNodeRca.addAllUpstreams(
             Arrays.asList(highHeapUsageOldGenRca, highHeapUsageYoungGenRca, highCpuRca));
 
-    Rca<ResourceFlowUnit> highHeapUsageClusterRca =
+    Rca<ResourceFlowUnit<HotClusterSummary>> highHeapUsageClusterRca =
             new HighHeapUsageClusterRca(12, hotJVMNodeRca);
     highHeapUsageClusterRca.addTag(TAG_LOCUS, LOCUS_MASTER_NODE);
     highHeapUsageClusterRca.addAllUpstreams(Collections.singletonList(hotJVMNodeRca));
     highHeapUsageClusterRca.addTag(TAG_AGGREGATE_UPSTREAM, LOCUS_DATA_NODE);
 
-    Rca<ResourceFlowUnit> hotNodeClusterRca =
+    Rca<ResourceFlowUnit<HotClusterSummary>> hotNodeClusterRca =
             new HotNodeClusterRca(12, hotJVMNodeRca);
     hotNodeClusterRca.addTag(TAG_LOCUS, LOCUS_MASTER_NODE);
     hotNodeClusterRca.addAllUpstreams(Collections.singletonList(hotJVMNodeRca));

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HotNodeClusterRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HotNodeClusterRca.java
@@ -45,13 +45,13 @@ import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class HotNodeClusterRca extends Rca<ResourceFlowUnit> {
+public class HotNodeClusterRca extends Rca<ResourceFlowUnit<HotClusterSummary>> {
 
   public static final String RCA_TABLE_NAME = HotNodeClusterRca.class.getSimpleName();
   private static final Logger LOG = LogManager.getLogger(HotNodeClusterRca.class);
   private static final double NODE_COUNT_THRESHOLD = 0.8;
   private static final long TIMESTAMP_EXPIRATION_IN_MINS = 5;
-  private final Rca hotNodeRca;
+  private final Rca<ResourceFlowUnit<HotNodeSummary>> hotNodeRca;
   private final Table<String, ResourceType, NodeResourceUsage> nodeTable;
   private final int rcaPeriod;
   private int counter;
@@ -60,7 +60,7 @@ public class HotNodeClusterRca extends Rca<ResourceFlowUnit> {
   private double resourceUsageLowerBoundThreshold;
   protected Clock clock;
 
-  public <R extends Rca> HotNodeClusterRca(final int rcaPeriod,
+  public <R extends Rca<ResourceFlowUnit<HotNodeSummary>>> HotNodeClusterRca(final int rcaPeriod,
       final R hotNodeRca) {
     super(5);
     this.rcaPeriod = rcaPeriod;
@@ -73,16 +73,12 @@ public class HotNodeClusterRca extends Rca<ResourceFlowUnit> {
   }
 
   //add Resource Summary to the corresponding cell in NodeTable
-  private void addSummaryToNodeMap(List<ResourceFlowUnit> hotNodeRcaFlowUnits) {
-    for (ResourceFlowUnit hotNodeRcaFlowUnit : hotNodeRcaFlowUnits) {
+  private void addSummaryToNodeMap(List<ResourceFlowUnit<HotNodeSummary>> hotNodeRcaFlowUnits) {
+    for (ResourceFlowUnit<HotNodeSummary> hotNodeRcaFlowUnit : hotNodeRcaFlowUnits) {
       if (hotNodeRcaFlowUnit.isEmpty()) {
         continue;
       }
-      if (!(hotNodeRcaFlowUnit.getResourceSummary() instanceof HotNodeSummary)) {
-        LOG.error("RCA : Receive flowunit from unexpected rca node");
-        continue;
-      }
-      HotNodeSummary nodeSummary = (HotNodeSummary) hotNodeRcaFlowUnit.getResourceSummary();
+      HotNodeSummary nodeSummary = hotNodeRcaFlowUnit.getSummary();
       if (nodeSummary.getNestedSummaryList() == null || nodeSummary.getNestedSummaryList().isEmpty()) {
         continue;
       }
@@ -113,7 +109,7 @@ public class HotNodeClusterRca extends Rca<ResourceFlowUnit> {
    * most recent resource summary from this nodeId indexed by resourceType
    </p>
    */
-  private ResourceFlowUnit checkUnbalancedNode() {
+  private ResourceFlowUnit<HotClusterSummary> checkUnbalancedNode() {
     // NodeID -> HotNodeSummary, store the HotNodeSummary that is generated for each node
     Map<String, HotNodeSummary> nodeSummaryMap = new HashMap<>();
 
@@ -189,7 +185,7 @@ public class HotNodeClusterRca extends Rca<ResourceFlowUnit> {
         summary.addNestedSummaryList(entry.getValue());
       }
     }
-    return new ResourceFlowUnit(System.currentTimeMillis(), context, summary, true);
+    return new ResourceFlowUnit<>(System.currentTimeMillis(), context, summary, true);
   }
 
   //TODO : we might need to change this function later to use EventListener
@@ -208,11 +204,11 @@ public class HotNodeClusterRca extends Rca<ResourceFlowUnit> {
   }
 
   @Override
-  public ResourceFlowUnit operate() {
+  public ResourceFlowUnit<HotClusterSummary> operate() {
     dataNodesDetails = ClusterDetailsEventProcessor.getDataNodesDetails();
     //skip this RCA if the cluster has only single data node
     if (dataNodesDetails.size() <= 1) {
-      return new ResourceFlowUnit(System.currentTimeMillis());
+      return new ResourceFlowUnit<>(System.currentTimeMillis());
     }
 
     counter += 1;
@@ -223,7 +219,7 @@ public class HotNodeClusterRca extends Rca<ResourceFlowUnit> {
       removeInactiveNodeFromTable();
       return checkUnbalancedNode();
     } else {
-      return new ResourceFlowUnit(System.currentTimeMillis());
+      return new ResourceFlowUnit<>(System.currentTimeMillis());
     }
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hot_node/GenericResourceRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hot_node/GenericResourceRca.java
@@ -40,7 +40,7 @@ import org.jooq.exception.DataTypeException;
  * Generic resource type RCA. ideally this RCA can be extended to any resource type
  * and calculate the total resource usage & top consumers.
  */
-public class GenericResourceRca extends Rca<ResourceFlowUnit> {
+public class GenericResourceRca extends Rca<ResourceFlowUnit<HotResourceSummary>> {
 
   private static final Logger LOG = LogManager.getLogger(GenericResourceRca.class);
   private static final int SLIDING_WINDOW_IN_MIN = 10;
@@ -108,7 +108,7 @@ public class GenericResourceRca extends Rca<ResourceFlowUnit> {
   }
 
   @Override
-  public ResourceFlowUnit operate() {
+  public ResourceFlowUnit<HotResourceSummary> operate() {
     counter += 1;
 
     for (MetricFlowUnit flowunit : resourceUsageGroupByConsumer.getFlowUnits()) {
@@ -162,10 +162,10 @@ public class GenericResourceRca extends Rca<ResourceFlowUnit> {
             avgCpuUsage, SLIDING_WINDOW_IN_MIN * 60);
         addTopConsumerSummary(summary);
       }
-      return new ResourceFlowUnit(clock.millis(), context, summary);
+      return new ResourceFlowUnit<>(clock.millis(), context, summary);
     } else {
       // we return an empty FlowUnit RCA for now. Can change to healthy (or previous known RCA state)
-      return new ResourceFlowUnit(clock.millis());
+      return new ResourceFlowUnit<>(clock.millis());
     }
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotheap/HighHeapUsageOldGenRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotheap/HighHeapUsageOldGenRca.java
@@ -67,7 +67,7 @@ import org.apache.logging.log4j.Logger;
  * Points_Memory / DocValues_Memory / IndexWriter_Memory / Bitset_Memory / VersionMap_Memory
  </p>
  */
-public class HighHeapUsageOldGenRca extends Rca<ResourceFlowUnit> {
+public class HighHeapUsageOldGenRca extends Rca<ResourceFlowUnit<HotResourceSummary>> {
 
   private static final Logger LOG = LogManager.getLogger(HighHeapUsageOldGenRca.class);
   private int counter;
@@ -127,7 +127,7 @@ public class HighHeapUsageOldGenRca extends Rca<ResourceFlowUnit> {
   }
 
   @Override
-  public ResourceFlowUnit operate() {
+  public ResourceFlowUnit<HotResourceSummary> operate() {
     List<MetricFlowUnit> heapUsedMetrics = heap_Used.getFlowUnits();
     List<MetricFlowUnit> gcEventMetrics = gc_event.getFlowUnits();
     List<MetricFlowUnit> heapMaxMetrics = heap_Max.getFlowUnits();
@@ -220,12 +220,12 @@ public class HighHeapUsageOldGenRca extends Rca<ResourceFlowUnit> {
       }
 
       LOG.debug("High Heap Usage RCA Context = " + context.toString());
-      return new ResourceFlowUnit(this.clock.millis(), context, summary);
+      return new ResourceFlowUnit<>(this.clock.millis(), context, summary);
     } else {
       // we return an empty FlowUnit RCA for now. Can change to healthy (or previous known RCA
       // state)
       LOG.debug("Empty FlowUnit returned for High Heap Usage RCA");
-      return new ResourceFlowUnit(this.clock.millis());
+      return new ResourceFlowUnit<>(this.clock.millis());
     }
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotheap/HighHeapUsageYoungGenRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotheap/HighHeapUsageYoungGenRca.java
@@ -52,7 +52,7 @@ import org.apache.logging.log4j.Logger;
  * gen during the last time interval and then use it to calculate its moving average. If both the
  * promotion rate and young gen GC time reach the threshold, this node is marked as unhealthy.
  */
-public class HighHeapUsageYoungGenRca extends Rca<ResourceFlowUnit> {
+public class HighHeapUsageYoungGenRca extends Rca<ResourceFlowUnit<HotResourceSummary>> {
 
   private static final Logger LOG = LogManager.getLogger(HighHeapUsageYoungGenRca.class);
   private static final int PROMOTION_RATE_SLIDING_WINDOW_IN_MINS = 10;
@@ -124,7 +124,7 @@ public class HighHeapUsageYoungGenRca extends Rca<ResourceFlowUnit> {
   }
 
   @Override
-  public ResourceFlowUnit operate() {
+  public ResourceFlowUnit<HotResourceSummary> operate() {
     long currTimeStamp = this.clock.millis();
     counter += 1;
 
@@ -188,11 +188,11 @@ public class HighHeapUsageYoungGenRca extends Rca<ResourceFlowUnit> {
       }
 
       LOG.debug("@@: Young Gen RCA Context = " + context.toString());
-      return new ResourceFlowUnit(this.clock.millis(), context, summary);
+      return new ResourceFlowUnit<>(this.clock.millis(), context, summary);
     } else {
       // we return an empty FlowUnit RCA for now. Can change to healthy (or previous known RCA state)
       LOG.debug("RCA: Empty FlowUnit returned for Young Gen RCA");
-      return new ResourceFlowUnit(this.clock.millis());
+      return new ResourceFlowUnit<>(this.clock.millis());
     }
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotshard/HotShardRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotshard/HotShardRca.java
@@ -66,7 +66,7 @@ import org.jooq.Record;
  * 2. Paging_RSS
  *
  */
-public class HotShardRca extends Rca<ResourceFlowUnit> {
+public class HotShardRca extends Rca<ResourceFlowUnit<HotNodeSummary>> {
 
     private static final Logger LOG = LogManager.getLogger(HotShardRca.class);
     private static final int SLIDING_WINDOW_IN_SECONDS =  60;
@@ -156,7 +156,7 @@ public class HotShardRca extends Rca<ResourceFlowUnit> {
      *
      */
     @Override
-    public ResourceFlowUnit operate() {
+    public ResourceFlowUnit<HotNodeSummary> operate() {
         counter += 1;
 
         // Populate the Resource HashMaps
@@ -205,10 +205,10 @@ public class HotShardRca extends Rca<ResourceFlowUnit> {
             //check if the current node is data node. If it is the data node
             //then HotNodeRca is the top level RCA on this node and we want to persist summaries in flowunit.
             boolean isDataNode = !currentNode.getIsMasterNode();
-            return new ResourceFlowUnit(this.clock.millis(), context, summary, isDataNode);
+            return new ResourceFlowUnit<>(this.clock.millis(), context, summary, isDataNode);
         } else {
             LOG.debug("Empty FlowUnit returned for Hot Shard RCA");
-            return new ResourceFlowUnit(this.clock.millis());
+            return new ResourceFlowUnit<>(this.clock.millis());
         }
     }
 
@@ -228,7 +228,7 @@ public class HotShardRca extends Rca<ResourceFlowUnit> {
     public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {
         final List<FlowUnitMessage> flowUnitMessages =
                 args.getWireHopper().readFromWire(args.getNode());
-        List<ResourceFlowUnit> flowUnitList = new ArrayList<>();
+        List<ResourceFlowUnit<HotNodeSummary>> flowUnitList = new ArrayList<>();
         LOG.debug("rca: Executing fromWire: {}", this.getClass().getSimpleName());
         for (FlowUnitMessage flowUnitMessage : flowUnitMessages) {
             flowUnitList.add(ResourceFlowUnit.buildFlowUnitFromWrapper(flowUnitMessage));

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/RcaTestHelper.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/RcaTestHelper.java
@@ -21,27 +21,28 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotShardSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class RcaTestHelper extends Rca<ResourceFlowUnit> {
+public class RcaTestHelper<T extends GenericSummary> extends Rca<ResourceFlowUnit<T>> {
   public RcaTestHelper() {
     super(5);
   }
 
-  public void mockFlowUnit(ResourceFlowUnit flowUnit) {
+  public void mockFlowUnit(ResourceFlowUnit<T> flowUnit) {
     this.flowUnits = Collections.singletonList(flowUnit);
   }
 
-  public void mockFlowUnits(List<ResourceFlowUnit> flowUnitList) {
+  public void mockFlowUnits(List<ResourceFlowUnit<T>> flowUnitList) {
     this.flowUnits = flowUnitList;
   }
 
   @Override
-  public ResourceFlowUnit operate() {
+  public ResourceFlowUnit<T> operate() {
     return null;
   }
 
@@ -49,16 +50,16 @@ public class RcaTestHelper extends Rca<ResourceFlowUnit> {
   public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {
   }
 
-  public static ResourceFlowUnit generateFlowUnit(ResourceType type, String nodeID, Resources.State healthy) {
+  public static ResourceFlowUnit<HotNodeSummary> generateFlowUnit(ResourceType type, String nodeID, Resources.State healthy) {
     HotResourceSummary resourceSummary = new HotResourceSummary(type,
         10, 5, 60);
     HotNodeSummary nodeSummary = new HotNodeSummary(nodeID, "127.0.0.0");
     nodeSummary.addNestedSummaryList(resourceSummary);
-    return new ResourceFlowUnit(System.currentTimeMillis(), new ResourceContext(healthy), nodeSummary);
+    return new ResourceFlowUnit<>(System.currentTimeMillis(), new ResourceContext(healthy), nodeSummary);
   }
 
-  public static ResourceFlowUnit generateFlowUnitForHotShard(String indexName, String shardId, String nodeID, double cpu_utilization,
-                                                             double io_throughput, double io_sys_callrate, Resources.State health) {
+  public static ResourceFlowUnit<HotNodeSummary> generateFlowUnitForHotShard(String indexName, String shardId, String nodeID,
+      double cpu_utilization, double io_throughput, double io_sys_callrate, Resources.State health) {
     HotShardSummary hotShardSummary = new HotShardSummary(indexName, shardId, nodeID, 60);
     hotShardSummary.setcpuUtilization(cpu_utilization);
     hotShardSummary.setCpuUtilizationThreshold(0.50);
@@ -68,6 +69,6 @@ public class RcaTestHelper extends Rca<ResourceFlowUnit> {
     hotShardSummary.setIoSysCallrateThreshold(0.50);
     HotNodeSummary nodeSummary = new HotNodeSummary(nodeID, "127.0.0.0");
     nodeSummary.addNestedSummaryList(Arrays.asList(hotShardSummary));
-    return new ResourceFlowUnit(System.currentTimeMillis(), new ResourceContext(health), nodeSummary);
+    return new ResourceFlowUnit<>(System.currentTimeMillis(), new ResourceContext(health), nodeSummary);
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistFlowUnitAndSummaryTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistFlowUnitAndSummaryTest.java
@@ -28,6 +28,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.contexts.ResourceContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Used;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotClusterSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Queryable;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
@@ -58,18 +60,18 @@ import org.junit.experimental.categories.Category;
 public class PersistFlowUnitAndSummaryTest {
   Queryable queryable;
 
-  static class DummyYoungGenRca extends Rca<ResourceFlowUnit> {
+  static class DummyYoungGenRca extends Rca<ResourceFlowUnit<HotResourceSummary>> {
     public <M extends Metric> DummyYoungGenRca(M metric) {
       super(1);
     }
 
     @Override
-    public ResourceFlowUnit operate() {
+    public ResourceFlowUnit<HotResourceSummary> operate() {
       ResourceContext context = new ResourceContext(Resources.State.UNHEALTHY);
       HotResourceSummary summary = new HotResourceSummary(
           ResourceType.newBuilder().setJVM(JvmEnum.YOUNG_GEN).build(),
           400, 100, 60);
-      return new ResourceFlowUnit(System.currentTimeMillis(), context, summary);
+      return new ResourceFlowUnit<>(System.currentTimeMillis(), context, summary);
     }
 
     @Override
@@ -78,7 +80,7 @@ public class PersistFlowUnitAndSummaryTest {
   }
 
   static class HotNodeRcaX extends HotNodeRca {
-    public <R extends Rca> HotNodeRcaX(final int rcaPeriod, R... hotResourceRcas) {
+    public <R extends Rca<ResourceFlowUnit<HotResourceSummary>>> HotNodeRcaX(final int rcaPeriod, R... hotResourceRcas) {
       super(rcaPeriod, hotResourceRcas);
       this.evaluationIntervalSeconds = 1;
     }
@@ -97,11 +99,11 @@ public class PersistFlowUnitAndSummaryTest {
     public void construct() {
       Metric heapUsed = new Heap_Used(5);
       addLeaf(heapUsed);
-      Rca<ResourceFlowUnit> dummyYoungGenRca = new DummyYoungGenRca(heapUsed);
+      Rca<ResourceFlowUnit<HotResourceSummary>> dummyYoungGenRca = new DummyYoungGenRca(heapUsed);
       dummyYoungGenRca.addAllUpstreams(Collections.singletonList(heapUsed));
       dummyYoungGenRca.addTag(RcaTagConstants.TAG_LOCUS, RcaTagConstants.LOCUS_DATA_NODE);
 
-      Rca<ResourceFlowUnit> nodeRca = new HotNodeRcaX(1, dummyYoungGenRca);
+      Rca<ResourceFlowUnit<HotNodeSummary>> nodeRca = new HotNodeRcaX(1, dummyYoungGenRca);
       nodeRca.addTag(RcaTagConstants.TAG_LOCUS, RcaTagConstants.LOCUS_DATA_NODE);
       nodeRca.addAllUpstreams(Collections.singletonList(dummyYoungGenRca));
     }
@@ -114,15 +116,15 @@ public class PersistFlowUnitAndSummaryTest {
       Metric heapUsed = new Heap_Used(5);
       heapUsed.addTag(RcaTagConstants.TAG_LOCUS, RcaTagConstants.LOCUS_MASTER_NODE);
       addLeaf(heapUsed);
-      Rca<ResourceFlowUnit> dummyYoungGenRca = new DummyYoungGenRca(heapUsed);
+      Rca<ResourceFlowUnit<HotResourceSummary>> dummyYoungGenRca = new DummyYoungGenRca(heapUsed);
       dummyYoungGenRca.addAllUpstreams(Collections.singletonList(heapUsed));
       dummyYoungGenRca.addTag(RcaTagConstants.TAG_LOCUS, RcaTagConstants.LOCUS_MASTER_NODE);
 
-      Rca<ResourceFlowUnit> nodeRca = new HotNodeRcaX(1, dummyYoungGenRca);
+      Rca<ResourceFlowUnit<HotNodeSummary>> nodeRca = new HotNodeRcaX(1, dummyYoungGenRca);
       nodeRca.addTag(RcaTagConstants.TAG_LOCUS, RcaTagConstants.LOCUS_MASTER_NODE);
       nodeRca.addAllUpstreams(Collections.singletonList(dummyYoungGenRca));
 
-      Rca<ResourceFlowUnit> highHeapUsageClusterRca =
+      Rca<ResourceFlowUnit<HotClusterSummary>> highHeapUsageClusterRca =
           new HighHeapUsageClusterRcaX(1, nodeRca);
       highHeapUsageClusterRca.addTag(RcaTagConstants.TAG_LOCUS, RcaTagConstants.LOCUS_MASTER_NODE);
       highHeapUsageClusterRca.addAllUpstreams(Collections.singletonList(nodeRca));

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/HotNodeClusterRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/HotNodeClusterRcaTest.java
@@ -28,7 +28,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotClusterSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HotNodeClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
 import java.sql.SQLException;
@@ -93,7 +92,7 @@ public class HotNodeClusterRcaTest {
     fu = clusterRca.operate();
     Assert.assertTrue(fu.getResourceContext().isUnhealthy());
     Assert.assertTrue(fu.hasResourceSummary());
-    HotClusterSummary clusterSummary = (HotClusterSummary) fu.getResourceSummary();
+    HotClusterSummary clusterSummary = (HotClusterSummary) fu.getSummary();
     Assert.assertTrue(clusterSummary.getNumOfUnhealthyNodes() == 1);
     Assert.assertTrue(clusterSummary.getNestedSummaryList().size() > 0);
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotheap/HighHeapUsageOldGenRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotheap/HighHeapUsageOldGenRcaTest.java
@@ -28,8 +28,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.MetricTestHelper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.TopConsumerSummary;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HighHeapUsageClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotheap.HighHeapUsageOldGenRca;
 import java.time.Clock;
 import java.time.Duration;
@@ -134,8 +132,8 @@ public class HighHeapUsageOldGenRcaTest {
     Assert.assertTrue(flowUnit.getResourceContext().isUnhealthy());
 
     Assert.assertTrue(flowUnit.hasResourceSummary());
-    Assert.assertTrue(flowUnit.getResourceSummary() instanceof HotResourceSummary);
-    HotResourceSummary resourceSummary = (HotResourceSummary) flowUnit.getResourceSummary();
+    Assert.assertTrue(flowUnit.getSummary() instanceof HotResourceSummary);
+    HotResourceSummary resourceSummary = (HotResourceSummary) flowUnit.getSummary();
     Assert.assertEquals(3, resourceSummary.getNestedSummaryList().size());
     for (int i = 0; i < 3; i++) {
       Assert.assertTrue(resourceSummary.getNestedSummaryList().get(i) instanceof TopConsumerSummary);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotshard/HotShardClusterRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotshard/HotShardClusterRcaTest.java
@@ -21,6 +21,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskFor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.RcaTestHelper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Resources;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceTypeUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotshard.HotShardClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
@@ -70,7 +71,7 @@ public class HotShardClusterRcaTest {
     public void setup() {
         //setup cluster details
         try {
-            hotShardRca = new RcaTestHelper();
+            hotShardRca = new RcaTestHelper<HotNodeSummary>();
             hotShardClusterRca = new HotShardClusterRca(1, hotShardRca);
             clusterDetailsEventProcessorTestHelper = new ClusterDetailsEventProcessorTestHelper();
             clusterDetailsEventProcessorTestHelper.addNodeDetails("node1", "127.0.0.0", false);
@@ -116,7 +117,7 @@ public class HotShardClusterRcaTest {
 
         ResourceFlowUnit flowUnit = hotShardClusterRca.operate();
         Assert.assertFalse(flowUnit.getResourceContext().isUnhealthy());
-        Assert.assertTrue(flowUnit.getResourceSummary().getNestedSummaryList().isEmpty());
+        Assert.assertTrue(flowUnit.getSummary().getNestedSummaryList().isEmpty());
 
 
         // 3.2 FlowUnits received from both nodes
@@ -147,7 +148,7 @@ public class HotShardClusterRcaTest {
 
         ResourceFlowUnit flowUnit1 = hotShardClusterRca.operate();
         Assert.assertFalse(flowUnit1.getResourceContext().isUnhealthy());
-        Assert.assertTrue(flowUnit1.getResourceSummary().getNestedSummaryList().isEmpty());
+        Assert.assertTrue(flowUnit1.getSummary().getNestedSummaryList().isEmpty());
 
         // 4.2  hot shards across an index as per CPU Utilization, ie. : CPU_UTILIZATION >= CPU_UTILIZATION_threshold
         hotShardRca.mockFlowUnits(Arrays.asList(
@@ -170,9 +171,9 @@ public class HotShardClusterRcaTest {
         ResourceFlowUnit flowUnit2 = hotShardClusterRca.operate();
         Assert.assertTrue(flowUnit2.getResourceContext().isUnhealthy());
 
-        Assert.assertEquals(2, flowUnit2.getResourceSummary().getNestedSummaryList().size());
-        List<Object> hotShard1 = flowUnit2.getResourceSummary().getNestedSummaryList().get(0).getSqlValue();
-        List<Object> hotShard2 = flowUnit2.getResourceSummary().getNestedSummaryList().get(1).getSqlValue();
+        Assert.assertEquals(2, flowUnit2.getSummary().getNestedSummaryList().size());
+        List<Object> hotShard1 = flowUnit2.getSummary().getNestedSummaryList().get(0).getSqlValue();
+        List<Object> hotShard2 = flowUnit2.getSummary().getNestedSummaryList().get(1).getSqlValue();
 
         // verify the resource type, cpu utilization value, node ID, Index Name, shard ID
         Assert.assertEquals(ResourceTypeUtil.getResourceTypeName(cpuResourceType), hotShard1.get(0));
@@ -215,9 +216,9 @@ public class HotShardClusterRcaTest {
         ResourceFlowUnit flowUnit3 = hotShardClusterRca.operate();
         Assert.assertTrue(flowUnit3.getResourceContext().isUnhealthy());
 
-        Assert.assertEquals(2, flowUnit3.getResourceSummary().getNestedSummaryList().size());
-        List<Object> hotShard3 = flowUnit3.getResourceSummary().getNestedSummaryList().get(0).getSqlValue();
-        List<Object> hotShard4 = flowUnit3.getResourceSummary().getNestedSummaryList().get(1).getSqlValue();
+        Assert.assertEquals(2, flowUnit3.getSummary().getNestedSummaryList().size());
+        List<Object> hotShard3 = flowUnit3.getSummary().getNestedSummaryList().get(0).getSqlValue();
+        List<Object> hotShard4 = flowUnit3.getSummary().getNestedSummaryList().get(1).getSqlValue();
 
         // verify the resource type, IO total throughput, node ID, Index Name, shard ID
         Assert.assertEquals(ResourceTypeUtil.getResourceTypeName(ioTotalThroughputResourceType), hotShard3.get(0));
@@ -257,9 +258,9 @@ public class HotShardClusterRcaTest {
         ResourceFlowUnit flowUnit4 = hotShardClusterRca.operate();
         Assert.assertTrue(flowUnit4.getResourceContext().isUnhealthy());
 
-        Assert.assertEquals(2, flowUnit4.getResourceSummary().getNestedSummaryList().size());
-        List<Object> hotShard5 = flowUnit4.getResourceSummary().getNestedSummaryList().get(0).getSqlValue();
-        List<Object> hotShard6 = flowUnit4.getResourceSummary().getNestedSummaryList().get(1).getSqlValue();
+        Assert.assertEquals(2, flowUnit4.getSummary().getNestedSummaryList().size());
+        List<Object> hotShard5 = flowUnit4.getSummary().getNestedSummaryList().get(0).getSqlValue();
+        List<Object> hotShard6 = flowUnit4.getSummary().getNestedSummaryList().get(1).getSqlValue();
 
         // verify the resource type, IO total sys callrate, node ID, Index Name, shard ID
         Assert.assertEquals(ResourceTypeUtil.getResourceTypeName(ioTotalSysCallRateResourceType), hotShard5.get(0));
@@ -303,10 +304,10 @@ public class HotShardClusterRcaTest {
         ResourceFlowUnit flowUnit2 = hotShardClusterRca.operate();
         Assert.assertTrue(flowUnit2.getResourceContext().isUnhealthy());
 
-        Assert.assertEquals(3, flowUnit2.getResourceSummary().getNestedSummaryList().size());
-        List<Object> hotShard1 = flowUnit2.getResourceSummary().getNestedSummaryList().get(0).getSqlValue();
-        List<Object> hotShard2 = flowUnit2.getResourceSummary().getNestedSummaryList().get(1).getSqlValue();
-        List<Object> hotShard3 = flowUnit2.getResourceSummary().getNestedSummaryList().get(2).getSqlValue();
+        Assert.assertEquals(3, flowUnit2.getSummary().getNestedSummaryList().size());
+        List<Object> hotShard1 = flowUnit2.getSummary().getNestedSummaryList().get(0).getSqlValue();
+        List<Object> hotShard2 = flowUnit2.getSummary().getNestedSummaryList().get(1).getSqlValue();
+        List<Object> hotShard3 = flowUnit2.getSummary().getNestedSummaryList().get(2).getSqlValue();
 
         Assert.assertEquals(ResourceTypeUtil.getResourceTypeName(cpuResourceType), hotShard1.get(0));
         Assert.assertEquals(ResourceTypeUtil.getResourceTypeName(ioTotalThroughputResourceType), hotShard2.get(0));

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotshard/HotShardRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotshard/HotShardRcaTest.java
@@ -126,7 +126,7 @@ public class HotShardRcaTest {
 
         hotShardRcaX.setClock(Clock.offset(constantClock, Duration.ofSeconds(2)));
         flowUnit = hotShardRcaX.operate();
-        HotNodeSummary summary1 = (HotNodeSummary) flowUnit.getResourceSummary();
+        HotNodeSummary summary1 = (HotNodeSummary) flowUnit.getSummary();
         List<GenericSummary> hotShardSummaryList1 = summary1.getNestedSummaryList();
 
         Assert.assertTrue(flowUnit.getResourceContext().isUnhealthy());
@@ -162,7 +162,7 @@ public class HotShardRcaTest {
 
         hotShardRcaX.setClock(Clock.offset(constantClock, Duration.ofSeconds(4)));
         flowUnit = hotShardRcaX.operate();
-        HotNodeSummary summary2 = (HotNodeSummary) flowUnit.getResourceSummary();
+        HotNodeSummary summary2 = (HotNodeSummary) flowUnit.getSummary();
         List<GenericSummary> hotShardSummaryList2 = summary2.getNestedSummaryList();
 
         Assert.assertTrue(flowUnit.getResourceContext().isUnhealthy());


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add generic type to ResourceFlowUnit and now we can specify the type of summary within each flowunit. 
This will help us to remove the instanceof when fetching summary from flowunit.

*Tests:*
tested on docker

*Code coverage percentage for this patch:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
