### PR TITLE
Enable spotbugs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,6 +108,11 @@ spotbugsTest {
     ignoreFailures = true
 }
 
+check {
+    dependsOn spotbugsMain
+    dependsOn spotbugsTest
+}
+
 jacoco {
     toolVersion = "0.8.5"
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotheap/NodeStatAggregator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotheap/NodeStatAggregator.java
@@ -98,12 +98,12 @@ public class NodeStatAggregator {
   // in either case, we need to write a function to clean up this hashtable on reader periodically
   // to remove node stats of inactive shards
   private void purgeHashTable(final long timestamp) {
-    Iterator<IndexShardKey> iterator = this.shardKeyMap.keySet().iterator();
+    Iterator<NodeStatValue> iterator = this.shardKeyMap.values().iterator();
     while (iterator.hasNext()) {
-      IndexShardKey key = iterator.next();
-      long timestampDiff = timestamp - this.shardKeyMap.get(key).getTimestamp();
+      NodeStatValue value = iterator.next();
+      long timestampDiff = timestamp - value.getTimestamp();
       if (TimeUnit.MILLISECONDS.toMinutes(timestampDiff) > PURGE_HASH_TABLE_INTERVAL_IN_MINS) {
-        this.sum -= this.shardKeyMap.get(key).getValue();
+        this.sum -= value.getValue();
         iterator.remove();
       }
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Enable spotbugs. NodeStatAggregator.java was modified to address the spotbugs warning below.
```
WMI com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotheap.NodeStatAggregator.purgeHashTable(long)  makes inefficient use of keySet iterator instead of entrySet iterator

Bug type WMI_WRONG_MAP_ITERATOR (click for details)
    In class com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotheap.NodeStatAggregator
    In method com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotheap.NodeStatAggregator.purgeHashTable(long)
    Field com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotheap.NodeStatAggregator.shardKeyMap
    At NodeStatAggregator.java:[line 104]

WMI_WRONG_MAP_ITERATOR: Inefficient use of keySet iterator instead of entrySet iterator
This method accesses the value of a Map entry, using a key that was retrieved from a keySet iterator. It is more efficient to use an iterator on the entrySet of the map, to avoid the Map.get(key) lookup.
```

*Tests:*

*Code coverage percentage for this patch:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
