### PR TITLE
Set configFilePath to performance-analyzer.properties in the reader.

### DIFF
--- a/pa_bin/performance-analyzer-agent
+++ b/pa_bin/performance-analyzer-agent
@@ -24,11 +24,11 @@ else
 fi
 
 if ! echo $* | grep -E '(^-d |-d$| -d |--daemonize$|--daemonize )' > /dev/null; then
-    export JAVA_OPTS=-Des.path.home=$ES_HOME\ -Dlog4j.configurationFile=$ES_HOME/performance-analyzer-rca/pa_config/log4j2.xml
+    export JAVA_OPTS=-Des.path.home=$ES_HOME\ -Dlog4j.configurationFile=$ES_HOME/performance-analyzer-rca/pa_config/log4j2.xml\ -DconfigFilePath=$ES_HOME/performance-analyzer-rca/pa_config/performance-analyzer.properties
     exec $ES_HOME/performance-analyzer-rca/bin/performance-analyzer-rca
 else
     echo 'Starting deamon'
-    export JAVA_OPTS=-Des.path.home=$ES_HOME\ -Dlog4j.configurationFile=$ES_HOME/performance-analyzer-rca/pa_config/log4j2.xml
+    export JAVA_OPTS=-Des.path.home=$ES_HOME\ -Dlog4j.configurationFile=$ES_HOME/performance-analyzer-rca/pa_config/log4j2.xml\ -DconfigFilePath=$ES_HOME/performance-analyzer-rca/pa_config/performance-analyzer.properties
     exec $ES_HOME/performance-analyzer-rca/bin/performance-analyzer-rca &
 
     pid=$!


### PR DESCRIPTION
Set the configFilePath sysProp for picking the right performance-analyzer.properties in Docker.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
