### PR TITLE
Fix performance-analyzer-agent configFilePath

### DIFF
--- a/pa_bin/performance-analyzer-agent
+++ b/pa_bin/performance-analyzer-agent
@@ -24,11 +24,11 @@ else
 fi
 
 if ! echo $* | grep -E '(^-d |-d$| -d |--daemonize$|--daemonize )' > /dev/null; then
-    export JAVA_OPTS=-Des.path.home=$ES_HOME\ -Dlog4j.configurationFile=$ES_HOME/performance-analyzer-rca/pa_config/log4j2.xml\ -DconfigFilePath=$ES_HOME/performance-analyzer-rca/pa_config/performance-analyzer.properties
+    export JAVA_OPTS=-Des.path.home=$ES_HOME\ -Dlog4j.configurationFile=$ES_HOME/performance-analyzer-rca/pa_config/log4j2.xml\ -DconfigFilePath=pa_config/performance-analyzer.properties
     exec $ES_HOME/performance-analyzer-rca/bin/performance-analyzer-rca
 else
     echo 'Starting deamon'
-    export JAVA_OPTS=-Des.path.home=$ES_HOME\ -Dlog4j.configurationFile=$ES_HOME/performance-analyzer-rca/pa_config/log4j2.xml\ -DconfigFilePath=$ES_HOME/performance-analyzer-rca/pa_config/performance-analyzer.properties
+    export JAVA_OPTS=-Des.path.home=$ES_HOME\ -Dlog4j.configurationFile=$ES_HOME/performance-analyzer-rca/pa_config/log4j2.xml\ -DconfigFilePath=pa_config/performance-analyzer.properties
     exec $ES_HOME/performance-analyzer-rca/bin/performance-analyzer-rca &
 
     pid=$!


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* 
We have a class Util.java which we use to look up the location of the
performance-analyzer.properties file. The Util class prepends a prefix
to the Java property we pass in as -DconfigFilePath. This prefix
resulted in a FileNotFoundException error when attempting to locate the
config file inside our Docker environment.

This commit fixes the issue by updating the -DconfigFilePath variable in
the performance-analyzer-agent script file. This is a stopgap measure.
We should strive to refactor the Util class so that it's configurable
and working across all supported platforms.

*Tests:* Tested manually using enableRca

*Code coverage percentage for this patch:* N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
