### PR TITLE
Remove publishing circuit breaking error by default

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerApp.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerApp.java
@@ -107,7 +107,6 @@ public class PerformanceAnalyzerApp {
     StatsCollector.STATS_TYPE = "agent-stats-metadata";
     METRIC_COLLECTOR_EXECUTOR.addScheduledMetricCollector(StatsCollector.instance());
     StatsCollector.instance().addDefaultExceptionCode(StatExceptionCode.READER_RESTART_PROCESSING);
-    StatsCollector.instance().addDefaultExceptionCode(StatExceptionCode.CIRCUIT_BREAKING_ERROR);
     METRIC_COLLECTOR_EXECUTOR.setEnabled(true);
     METRIC_COLLECTOR_EXECUTOR.start();
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
@@ -45,7 +45,6 @@ public enum StatExceptionCode {
   RCA_SCHEDULER_THREAD_STOPPED("RcaSchedulerThreadStopped"),
   JVM_THREAD_ID_NO_LONGER_EXISTS("JVM_THREAD_ID_NO_LONGER_EXISTS"),
   ES_REQUEST_INTERCEPTOR_ERROR("ES_REQUEST_INTERCEPTOR_ERROR"),
-  CIRCUIT_BREAKING_ERROR("CircuitBreakingError"),
   OTHER("Other");
 
   private final String value;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removing publishing circuit breaking error to pa agent logs by default.
This change was made to emit the circuit breaking exception count. 
Presently, this value is not populated and more thought is required to update this value.

*Tests:*

*Code coverage percentage for this patch:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
