### PR TITLE
Move RCA files to subdir owned by elasticsearch user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -110,7 +110,7 @@ RUN mkdir /usr/share/elasticsearch && \
     chmod 0775 /usr/share/elasticsearch && \
     chgrp 0 /usr/share/elasticsearch
 
-RUN mkdir /usr/share/supervisor
+RUN mkdir -p /usr/share/supervisor/performance_analyzer
 
 WORKDIR /usr/share/elasticsearch
 COPY --from=prep_es_files --chown=1000:0 /usr/share/elasticsearch /usr/share/elasticsearch

--- a/pa_config/supervisord.conf
+++ b/pa_config/supervisord.conf
@@ -1,13 +1,13 @@
 ; supervisor config file
 
 [unix_http_server]
-file=/usr/share/supervisor/supervisord.sock
+file=/usr/share/supervisor/performance_analyzer/supervisord.sock
 chmod=0770
 
 [supervisord]
-logfile=/usr/share/supervisor/supervisord.log ; (main log file;default $CWD/supervisord.log)
-pidfile=/usr/share/supervisor/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
-childlogdir=/usr/share/supervisor            ; ('AUTO' child log dir, default $TEMP)
+logfile=/usr/share/supervisor/performance_analyzer/supervisord.log ; (main log file;default $CWD/supervisord.log)
+pidfile=/usr/share/supervisor/performance_analyzer/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+childlogdir=/usr/share/supervisor/performance_analyzer            ; ('AUTO' child log dir, default $TEMP)
 
 ; the below section must remain in the config file for RPC
 ; (supervisorctl/web interface) to work, additional interfaces may be


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/opendistro-build/issues/34
https://github.com/opendistro-for-elasticsearch/opendistro-build/pull/320

*Description of changes:*
 Move RCA files to subdir owned by elasticsearch user

*Tests:*
[image](https://user-images.githubusercontent.com/65193828/87365444-3d975f80-c544-11ea-8ad0-4a2d4d81320a.png)

*Code coverage percentage for this patch:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
