### PR TITLE
Make WireHopperTest runnable alongside Docker containers

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/net/GRPCConnectionManager.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/net/GRPCConnectionManager.java
@@ -60,9 +60,16 @@ public class GRPCConnectionManager {
    * Flag that controls if we need to use a secure or an insecure channel.
    */
   private final boolean shouldUseHttps;
+  private final int port;
 
   public GRPCConnectionManager(final boolean shouldUseHttps) {
     this.shouldUseHttps = shouldUseHttps;
+    this.port = Util.RPC_PORT;
+  }
+
+  public GRPCConnectionManager(final boolean shouldUseHttps, int port) {
+    this.shouldUseHttps = shouldUseHttps;
+    this.port = port;
   }
 
   @VisibleForTesting
@@ -140,12 +147,12 @@ public class GRPCConnectionManager {
   }
 
   private ManagedChannel buildInsecureChannel(final String remoteHost) {
-    return ManagedChannelBuilder.forAddress(remoteHost, Util.RPC_PORT).usePlaintext().build();
+    return ManagedChannelBuilder.forAddress(remoteHost, this.port).usePlaintext().build();
   }
 
   private ManagedChannel buildSecureChannel(final String remoteHost) {
     try {
-      return NettyChannelBuilder.forAddress(remoteHost, Util.RPC_PORT)
+      return NettyChannelBuilder.forAddress(remoteHost, this.port)
                                 .sslContext(
                                     GrpcSslContexts.forClient()
                                                    .trustManager(

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopperTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopperTest.java
@@ -1,7 +1,6 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.core.Util;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.GRPCConnectionManager;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetClient;
@@ -69,6 +68,7 @@ public class WireHopperTest {
     private static final String LOCUS = "data-node";
     private static final long EVAL_INTERVAL_S = 5L;
     private static final long TIMESTAMP = 66L;
+    private static final int TEST_PORT = 12936;
     private static final ExecutorService rejectingExecutor = new RejectingExecutor();
 
     private static NetClient netClient;
@@ -86,12 +86,12 @@ public class WireHopperTest {
 
     @BeforeClass
     public static void setupClass() throws Exception {
-        connectionManager = new GRPCConnectionManager(PluginSettings.instance().getHttpsEnabled());
+        connectionManager = new GRPCConnectionManager(PluginSettings.instance().getHttpsEnabled(), TEST_PORT);
         netClient = new NetClient(connectionManager);
         executorService = Executors.newSingleThreadExecutor();
         clientExecutor = new AtomicReference<>(null);
         serverExecutor = new AtomicReference<>(Executors.newSingleThreadExecutor());
-        netServer = new TestNetServer(Util.RPC_PORT, 1, false);
+        netServer = new TestNetServer(TEST_PORT, 1, false);
         netServerExecutor = Executors.newSingleThreadExecutor();
         netServerExecutor.execute(netServer);
         // Wait for the TestNetServer to start


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

WireHopperTest used to spin up a testing server on port 9650, which is
used by the Docker container to host our GRPC server. This meant that if
you had your Docker containers running, WireHopperTest would always
fail.

This commit modifies WireHopperTest to use a different port for
testing.

*Tests:* WireHopperTest

*Code coverage percentage for this patch:* N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
