### PR TITLE
Make RCA framework NOT use ClusterDetailsEventProcessor

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/AppContext.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/AppContext.java
@@ -92,9 +92,11 @@ public class AppContext {
   }
 
   public List<String> getPeerInstanceIps() {
-    return getAllClusterInstances().stream()
-        .skip(1)  // Skipping the first instance as it is self.
-        .map(InstanceDetails::getInstanceIp)
-        .collect(Collectors.toList());
+    return ImmutableList.copyOf(
+        getAllClusterInstances()
+            .stream()
+            .skip(1)  // Skipping the first instance as it is self.
+            .map(InstanceDetails::getInstanceIp)
+            .collect(Collectors.toList()));
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/AppContext.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/AppContext.java
@@ -64,7 +64,7 @@ public class AppContext {
    * Can be used to get all the nodes in the cluster.
    *
    * @return Returns an empty list of the details are not available or else it provides the immutable list of nodes in
-   * the cluster.
+   *     the cluster.
    */
   public List<InstanceDetails> getAllClusterInstances() {
     return getInstanceDetailsFromNodeDetails(clusterDetailsEventProcessor.getNodesDetails());

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/AppContext.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/AppContext.java
@@ -18,7 +18,6 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/AppContext.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/AppContext.java
@@ -21,6 +21,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDet
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -33,9 +34,6 @@ import java.util.stream.Collectors;
 public class AppContext {
   private volatile ClusterDetailsEventProcessor clusterDetailsEventProcessor;
 
-  @VisibleForTesting
-  private volatile List<InstanceDetails> instances;
-
   public AppContext() {
     this.clusterDetailsEventProcessor = null;
   }
@@ -45,12 +43,10 @@ public class AppContext {
   }
 
   public InstanceDetails getMyInstanceDetails() {
-    ClusterDetailsEventProcessor.NodeDetails nodeDetails = clusterDetailsEventProcessor.getCurrentNodeDetails();
+    InstanceDetails ret = new InstanceDetails(AllMetrics.NodeRole.UNKNOWN);
 
-    InstanceDetails ret;
-    if (nodeDetails == null) {
-      ret = new InstanceDetails(AllMetrics.NodeRole.UNKNOWN);
-    } else {
+    if (clusterDetailsEventProcessor != null && clusterDetailsEventProcessor.getCurrentNodeDetails() != null) {
+      ClusterDetailsEventProcessor.NodeDetails nodeDetails = clusterDetailsEventProcessor.getCurrentNodeDetails();
       ret = new InstanceDetails(
           AllMetrics.NodeRole.valueOf(nodeDetails.getRole()),
           nodeDetails.getId(),
@@ -67,11 +63,20 @@ public class AppContext {
    *     the cluster.
    */
   public List<InstanceDetails> getAllClusterInstances() {
-    return getInstanceDetailsFromNodeDetails(clusterDetailsEventProcessor.getNodesDetails());
+    List<InstanceDetails> ret = Collections.EMPTY_LIST;
+
+    if (clusterDetailsEventProcessor != null) {
+      ret = getInstanceDetailsFromNodeDetails(clusterDetailsEventProcessor.getNodesDetails());
+    }
+    return ret;
   }
 
   public List<InstanceDetails> getDataNodeInstances() {
-    return getInstanceDetailsFromNodeDetails(clusterDetailsEventProcessor.getDataNodesDetails());
+    List<InstanceDetails> ret = Collections.EMPTY_LIST;
+    if (clusterDetailsEventProcessor != null) {
+      ret = getInstanceDetailsFromNodeDetails(clusterDetailsEventProcessor.getDataNodesDetails());
+    }
+    return ret;
   }
 
   private static List<InstanceDetails> getInstanceDetailsFromNodeDetails(

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/AppContext.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/AppContext.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
+
+/**
+ * The PA agent process is composed of multiple components. The PA Reader and RCA are two such components that are
+ * independent in a way they process information but also share some information such as the node and the cluster
+ * details. Today, some of these information is accessed by calling static methods and members. This is a bad idea.
+ * This class encapsulates such information and is created right at the start in the {@code PerformanceAnalyzerApp}.
+ */
+public class AppContext {
+  private volatile ClusterDetailsEventProcessor clusterDetailsEventProcessor;
+
+  public AppContext() {
+    this.clusterDetailsEventProcessor = null;
+  }
+
+  public void setClusterDetailsEventProcessor(final ClusterDetailsEventProcessor clusterDetailsEventProcessor) {
+    this.clusterDetailsEventProcessor = clusterDetailsEventProcessor;
+  }
+
+  public ClusterDetailsEventProcessor getClusterDetailsEventProcessor() {
+    return clusterDetailsEventProcessor;
+  }
+
+  public InstanceDetails getMyInstanceDetails() {
+    ClusterDetailsEventProcessor.NodeDetails nodeDetails = clusterDetailsEventProcessor.getCurrentNodeDetails();
+
+    InstanceDetails ret;
+    if (nodeDetails == null) {
+      ret = new InstanceDetails(AllMetrics.NodeRole.UNKNOWN);
+    } else {
+      ret = new InstanceDetails(
+          AllMetrics.NodeRole.valueOf(nodeDetails.getRole()),
+          nodeDetails.getId(),
+          nodeDetails.getHostAddress(),
+          nodeDetails.getIsMasterNode());
+    }
+    return ret;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -177,7 +177,7 @@ public class RcaController {
               thresholdMain,
               persistable,
               net,
-              appContext.getMyInstanceDetails());
+              appContext);
 
       rcaNetServer.setSendDataHandler(new PublishRequestHandler(
           nodeStateManager, receivedFlowUnitStore, networkThreadPoolReference));

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -50,8 +50,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.P
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.PersistenceFactory;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.RCAScheduler;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.RcaSchedulerState;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor.NodeDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rest.QueryRcaRequestHandler;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.threads.ThreadProvider;
 import com.google.common.annotations.VisibleForTesting;
@@ -69,7 +67,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -17,6 +17,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca;
 
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts.RCA_MUTE_ERROR_METRIC;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.ClientServers;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerThreads;
@@ -35,6 +36,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Stats;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.ThresholdMain;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaRuntimeMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.NodeStateManager;
@@ -52,6 +54,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDet
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor.NodeDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rest.QueryRcaRequestHandler;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.threads.ThreadProvider;
+import com.google.common.annotations.VisibleForTesting;
 import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -120,6 +123,8 @@ public class RcaController {
   private AtomicReference<ExecutorService> networkThreadPoolReference = new AtomicReference<>();
   private ReceivedFlowUnitStore receivedFlowUnitStore;
 
+  private final AppContext appContext;
+
   public RcaController(
       final ThreadProvider threadProvider,
       final ScheduledExecutorService netOpsExecutorService,
@@ -127,8 +132,10 @@ public class RcaController {
       final ClientServers clientServers,
       final String rca_enabled_conf_location,
       final long rcaStateCheckIntervalMillis,
-      final long nodeRoleCheckPeriodicityMillis) {
+      final long nodeRoleCheckPeriodicityMillis,
+      final AppContext appContext) {
     this.threadProvider = threadProvider;
+    this.appContext = appContext;
     this.netOpsExecutorService = netOpsExecutorService;
     this.rcaNetClient = clientServers.getNetClient();
     this.rcaNetServer = clientServers.getNetServer();
@@ -138,7 +145,7 @@ public class RcaController {
     this.useHttps = PluginSettings.instance().getHttpsEnabled();
     subscriptionManager = new SubscriptionManager(grpcConnectionManager);
     nodeStateManager = new NodeStateManager();
-    queryRcaRequestHandler = new QueryRcaRequestHandler();
+    queryRcaRequestHandler = new QueryRcaRequestHandler(this.appContext);
     this.rcaScheduler = null;
     this.rcaStateCheckIntervalMillis = rcaStateCheckIntervalMillis;
     this.roleCheckPeriodicity = nodeRoleCheckPeriodicityMillis;
@@ -162,16 +169,21 @@ public class RcaController {
       receivedFlowUnitStore = new ReceivedFlowUnitStore(rcaConf.getPerVertexBufferLength());
       WireHopper net =
           new WireHopper(nodeStateManager, rcaNetClient, subscriptionManager,
-              networkThreadPoolReference, receivedFlowUnitStore);
+              networkThreadPoolReference, receivedFlowUnitStore, appContext);
       this.rcaScheduler =
-          new RCAScheduler(connectedComponents, db, rcaConf, thresholdMain, persistable, net);
+          new RCAScheduler(connectedComponents,
+              db,
+              rcaConf,
+              thresholdMain,
+              persistable,
+              net,
+              appContext.getMyInstanceDetails());
 
       rcaNetServer.setSendDataHandler(new PublishRequestHandler(
           nodeStateManager, receivedFlowUnitStore, networkThreadPoolReference));
       rcaNetServer.setSubscribeHandler(
           new SubscribeServerHandler(subscriptionManager, networkThreadPoolReference));
 
-      rcaScheduler.setRole(currentRole);
       Thread rcaSchedulerThread = threadProvider.createThreadForRunnable(() -> rcaScheduler.start(),
           PerformanceAnalyzerThreads.RCA_SCHEDULER);
 
@@ -223,8 +235,8 @@ public class RcaController {
         readRcaEnabledFromConf();
         if (rcaEnabled && tick % nodeRoleCheckInTicks == 0) {
           tick = 0;
-          final NodeDetails nodeDetails = ClusterDetailsEventProcessor.getCurrentNodeDetails();
-          if (nodeDetails != null) {
+          final InstanceDetails nodeDetails = appContext.getMyInstanceDetails();
+          if (nodeDetails.getRole() !=  NodeRole.UNKNOWN) {
             checkUpdateNodeRole(nodeDetails);
           }
         }
@@ -250,9 +262,9 @@ public class RcaController {
     }
   }
 
-  private void checkUpdateNodeRole(final NodeDetails currentNode) {
-    final NodeRole currentNodeRole = NodeRole.valueOf(currentNode.getRole());
-    boolean isMasterNode = currentNode.getIsMasterNode();
+  private void checkUpdateNodeRole(final InstanceDetails currentNode) {
+    final NodeRole currentNodeRole = currentNode.getRole();
+    boolean isMasterNode = currentNode.getIsMaster();
     currentRole = isMasterNode ? NodeRole.ELECTED_MASTER : currentNodeRole;
   }
 
@@ -398,6 +410,11 @@ public class RcaController {
 
   public NodeRole getCurrentRole() {
     return currentRole;
+  }
+
+  @VisibleForTesting
+  public AppContext getAppContext() {
+    return this.appContext;
   }
 
   public RCAScheduler getRcaScheduler() {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -144,7 +144,7 @@ public class RcaController {
     netPersistor = new NetPersistor();
     this.useHttps = PluginSettings.instance().getHttpsEnabled();
     subscriptionManager = new SubscriptionManager(grpcConnectionManager);
-    nodeStateManager = new NodeStateManager();
+    nodeStateManager = new NodeStateManager(this.appContext);
     queryRcaRequestHandler = new QueryRcaRequestHandler(this.appContext);
     this.rcaScheduler = null;
     this.rcaStateCheckIntervalMillis = rcaStateCheckIntervalMillis;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Node.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Node.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import com.google.common.annotations.VisibleForTesting;
@@ -200,14 +201,27 @@ public abstract class Node<T extends GenericFlowUnit> {
   }
 
   public InstanceDetails getInstanceDetails() {
-    return this.appContext.getMyInstanceDetails();
+    InstanceDetails ret = new InstanceDetails(AllMetrics.NodeRole.UNKNOWN);
+    if (this.appContext != null) {
+      ret = this.appContext.getMyInstanceDetails();
+    }
+    return ret;
   }
 
   public List<InstanceDetails> getAllClusterInstances() {
-    return this.appContext.getAllClusterInstances();
+    List<InstanceDetails> ret = Collections.EMPTY_LIST;
+
+    if (this.appContext != null) {
+      ret = this.appContext.getAllClusterInstances();
+    }
+    return ret;
   }
 
   public List<InstanceDetails> getDataNodeInstances() {
-    return this.appContext.getDataNodeInstances();
+    List<InstanceDetails> ret = Collections.EMPTY_LIST;
+    if (this.appContext != null) {
+      return this.appContext.getDataNodeInstances();
+    }
+    return ret;
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Node.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Node.java
@@ -206,4 +206,8 @@ public abstract class Node<T extends GenericFlowUnit> {
   public List<InstanceDetails> getAllClusterInstances() {
     return this.appContext.getAllClusterInstances();
   }
+
+  public List<InstanceDetails> getDataNodeInstances() {
+    return this.appContext.getDataNodeInstances();
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Node.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Node.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
@@ -65,6 +66,11 @@ public abstract class Node<T extends GenericFlowUnit> {
    * location.
    */
   private Map<String, String> tags;
+
+  /**
+   * A view of the instanceDetails that the RCAs can have access to.
+   */
+  private InstanceDetails instanceDetails;
 
   Node(int level, long evaluationIntervalSeconds) {
     this.downStreams = new ArrayList<>();
@@ -186,5 +192,13 @@ public abstract class Node<T extends GenericFlowUnit> {
    */
   public void readRcaConf(RcaConf conf) {
     return;
+  }
+
+  public void setInstanceDetails(InstanceDetails instanceDetails) {
+    this.instanceDetails = instanceDetails;
+  }
+
+  public InstanceDetails getInstanceDetails() {
+    return this.instanceDetails;
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Node.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Node.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import com.google.common.annotations.VisibleForTesting;
@@ -70,7 +71,7 @@ public abstract class Node<T extends GenericFlowUnit> {
   /**
    * A view of the instanceDetails that the RCAs can have access to.
    */
-  private InstanceDetails instanceDetails;
+  private AppContext appContext;
 
   Node(int level, long evaluationIntervalSeconds) {
     this.downStreams = new ArrayList<>();
@@ -194,11 +195,15 @@ public abstract class Node<T extends GenericFlowUnit> {
     return;
   }
 
-  public void setInstanceDetails(InstanceDetails instanceDetails) {
-    this.instanceDetails = instanceDetails;
+  public void setAppContext(final AppContext appContext) {
+    this.appContext = appContext;
   }
 
   public InstanceDetails getInstanceDetails() {
-    return this.instanceDetails;
+    return this.appContext.getMyInstanceDetails();
+  }
+
+  public List<InstanceDetails> getAllClusterInstances() {
+    return this.appContext.getAllClusterInstances();
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/InstanceDetails.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/InstanceDetails.java
@@ -16,8 +16,6 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
-import com.google.common.annotations.VisibleForTesting;
 
 public class InstanceDetails {
   private final AllMetrics.NodeRole role;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/InstanceDetails.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/InstanceDetails.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
+import com.google.common.annotations.VisibleForTesting;
+
+public class InstanceDetails {
+  private final AllMetrics.NodeRole role;
+  private final String InstanceId;
+  private final String instanceIp;
+  private final boolean isMaster;
+
+  public InstanceDetails(AllMetrics.NodeRole role, String instanceId, String instanceIp, boolean isMaster) {
+    this.role = role;
+    InstanceId = instanceId;
+    this.instanceIp = instanceIp;
+    this.isMaster = isMaster;
+  }
+
+  public InstanceDetails(AllMetrics.NodeRole role) {
+    this(role, "", "", false);
+  }
+
+  public AllMetrics.NodeRole getRole() {
+    return role;
+  }
+
+  public String getInstanceId() {
+    return InstanceId;
+  }
+
+  public String getInstanceIp() {
+    return instanceIp;
+  }
+
+  public boolean getIsMaster() {
+    return isMaster;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/NodeStateManager.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/NodeStateManager.java
@@ -138,4 +138,9 @@ public class NodeStateManager {
 
     return ImmutableList.copyOf(hostsToSubscribeTo);
   }
+
+  @VisibleForTesting
+  public AppContext getAppContext() {
+    return appContext;
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/NodeStateManager.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/NodeStateManager.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeResponse.SubscriptionStatus;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.util.ClusterUtils;
 import com.google.common.annotations.VisibleForTesting;
@@ -43,6 +44,12 @@ public class NodeStateManager {
    */
   private final ConcurrentMap<String, AtomicReference<SubscriptionStatus>> subscriptionStatusMap =
       new ConcurrentHashMap<>();
+
+  private final AppContext appContext;
+
+  public NodeStateManager(final AppContext appContext) {
+    this.appContext = appContext;
+  }
 
   /**
    * Updates the timestamp for the composite key: (host, vertex) marking when the last successful
@@ -114,12 +121,12 @@ public class NodeStateManager {
     for (final String publisher : publishers) {
       long lastRxTimestamp = getLastReceivedTimestamp(graphNode, publisher);
       if (lastRxTimestamp > 0 && currentTime - lastRxTimestamp > maxIdleDuration && ClusterUtils
-          .isHostAddressInCluster(publisher)) {
+          .isHostAddressInCluster(publisher, appContext.getAllClusterInstances())) {
         hostsToSubscribeTo.add(publisher);
       }
     }
 
-    final List<String> peers = ClusterUtils.getAllPeerHostAddresses();
+    final List<String> peers = appContext.getPeerInstanceIps();
     if (peers != null) {
       for (final String peerHost : peers) {
         String compositeKey = graphNode + SEPARATOR + peerHost;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopper.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopper.java
@@ -15,11 +15,13 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatExceptionCode;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetClient;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.DataMsg;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.IntentMsg;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.UnicastIntentMsg;
@@ -46,18 +48,21 @@ public class WireHopper {
   private final NodeStateManager nodeStateManager;
   private final AtomicReference<ExecutorService> executorReference;
   private final ReceivedFlowUnitStore receivedFlowUnitStore;
+  private final AppContext appContext;
 
   public WireHopper(
       final NodeStateManager nodeStateManager,
       final NetClient netClient,
       final SubscriptionManager subscriptionManager,
       final AtomicReference<ExecutorService> executorReference,
-      final ReceivedFlowUnitStore receivedFlowUnitStore) {
+      final ReceivedFlowUnitStore receivedFlowUnitStore,
+      final AppContext appContext) {
     this.netClient = netClient;
     this.subscriptionManager = subscriptionManager;
     this.nodeStateManager = nodeStateManager;
     this.executorReference = executorReference;
     this.receivedFlowUnitStore = receivedFlowUnitStore;
+    this.appContext = appContext;
   }
 
   public void sendIntent(IntentMsg msg) {
@@ -78,7 +83,7 @@ public class WireHopper {
     ExecutorService executor = executorReference.get();
     if (executor != null) {
       try {
-        executor.execute(new FlowUnitTxTask(netClient, subscriptionManager, msg));
+        executor.execute(new FlowUnitTxTask(netClient, subscriptionManager, msg, appContext));
       } catch (final RejectedExecutionException ree) {
         LOG.warn("Dropped sending flow unit because the threadpool queue is full");
         StatsCollector.instance()

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopper.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopper.java
@@ -104,7 +104,7 @@ public class WireHopper {
     final Set<String> publisherSet = subscriptionManager.getPublishersForNode(nodeName);
 
     for (final String publisher : publisherSet) {
-      if (!ClusterUtils.isHostAddressInCluster(publisher)) {
+      if (!ClusterUtils.isHostAddressInCluster(publisher, appContext.getAllClusterInstances())) {
         subscriptionManager.unsubscribeAndTerminateConnection(nodeName, publisher);
       }
     }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopper.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopper.java
@@ -29,6 +29,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.tasks.Bro
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.tasks.FlowUnitTxTask;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.tasks.UnicastSubscriptionTxTask;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.util.ClusterUtils;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Set;
@@ -94,6 +95,11 @@ public class WireHopper {
                       .logException(StatExceptionCode.RCA_NETWORK_THREADPOOL_QUEUE_FULL_ERROR);
       }
     }
+  }
+
+  @VisibleForTesting
+  public AppContext getAppContext() {
+    return appContext;
   }
 
   public List<FlowUnitMessage> readFromWire(Node<?> node) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopper.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopper.java
@@ -69,8 +69,12 @@ public class WireHopper {
     ExecutorService executor = executorReference.get();
     if (executor != null) {
       try {
-        executor.execute(new BroadcastSubscriptionTxTask(netClient, msg, subscriptionManager,
-            nodeStateManager));
+        executor.execute(new BroadcastSubscriptionTxTask(
+            netClient,
+            msg,
+            subscriptionManager,
+            nodeStateManager,
+            appContext));
       } catch (final RejectedExecutionException ree) {
         LOG.warn("Dropped sending subscription because the threadpool queue is full");
         StatsCollector.instance()
@@ -113,9 +117,12 @@ public class WireHopper {
       final ExecutorService executor = executorReference.get();
       if (executor != null) {
         try {
-          executor.execute(new UnicastSubscriptionTxTask(netClient, new UnicastIntentMsg("",
-              nodeName, node.getTags(), host),
-              subscriptionManager, nodeStateManager));
+          executor.execute(new UnicastSubscriptionTxTask(
+              netClient,
+              new UnicastIntentMsg("", nodeName, node.getTags(), host),
+              subscriptionManager,
+              nodeStateManager,
+              appContext));
         } catch (final RejectedExecutionException ree) {
           LOG.warn("Dropped sending subscription request because the threadpool queue is "
               + "full");

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/BroadcastSubscriptionTxTask.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/BroadcastSubscriptionTxTask.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.tasks;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetClient;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.IntentMsg;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.NodeStateManager;
@@ -26,13 +27,13 @@ import java.util.Map;
  * Task that broadcasts a subscription request to the current node's peers.
  */
 public class BroadcastSubscriptionTxTask extends SubscriptionTxTask {
-
   public BroadcastSubscriptionTxTask(
       NetClient netClient,
       IntentMsg intentMsg,
       SubscriptionManager subscriptionManager,
-      NodeStateManager nodeStateManager) {
-    super(netClient, intentMsg, subscriptionManager, nodeStateManager);
+      NodeStateManager nodeStateManager,
+      final AppContext appContext) {
+    super(netClient, intentMsg, subscriptionManager, nodeStateManager, appContext);
   }
 
   /**

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/BroadcastSubscriptionTxTask.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/BroadcastSubscriptionTxTask.java
@@ -47,7 +47,7 @@ public class BroadcastSubscriptionTxTask extends SubscriptionTxTask {
     final String destinationVertex = intentMsg.getDestinationNode();
     final Map<String, String> tags = intentMsg.getRcaConfTags();
 
-    for (final String remoteHost : ClusterUtils.getAllPeerHostAddresses()) {
+    for (final String remoteHost : getPeerIps()) {
       sendSubscribeRequest(remoteHost, requesterVertex, destinationVertex, tags);
     }
   }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/FlowUnitTxTask.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/FlowUnitTxTask.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.tasks;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatExceptionCode;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
@@ -53,13 +54,17 @@ public class FlowUnitTxTask implements Runnable {
    */
   private final DataMsg dataMsg;
 
+  private final AppContext appContext;
+
   public FlowUnitTxTask(
       final NetClient client,
       final SubscriptionManager subscriptionManager,
-      final DataMsg dataMsg) {
+      final DataMsg dataMsg,
+      final AppContext appContext) {
     this.client = client;
     this.subscriptionManager = subscriptionManager;
     this.dataMsg = dataMsg;
+    this.appContext = appContext;
   }
 
   /**
@@ -70,7 +75,8 @@ public class FlowUnitTxTask implements Runnable {
   @Override
   public void run() {
     final String sourceNode = dataMsg.getSourceNode();
-    final String esNode = ClusterUtils.getCurrentNodeHostAddress();
+    final String esNode = appContext.getMyInstanceDetails().getInstanceIp();
+
     if (subscriptionManager.isNodeSubscribed(sourceNode)) {
       final Set<String> downstreamHostAddresses = subscriptionManager
           .getSubscribersFor(sourceNode);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/SubscriptionTxTask.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/SubscriptionTxTask.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.tasks;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetClient;
@@ -55,15 +56,19 @@ public abstract class SubscriptionTxTask implements Runnable {
    */
   protected final NodeStateManager nodeStateManager;
 
+  private final AppContext appContext;
+
   public SubscriptionTxTask(
       final NetClient netClient,
       final IntentMsg intentMsg,
       final SubscriptionManager subscriptionManager,
-      final NodeStateManager nodeStateManager) {
+      final NodeStateManager nodeStateManager,
+      final AppContext appContext) {
     this.netClient = netClient;
     this.intentMsg = intentMsg;
     this.subscriptionManager = subscriptionManager;
     this.nodeStateManager = nodeStateManager;
+    this.appContext = appContext;
   }
 
   protected void sendSubscribeRequest(final String remoteHost, final String requesterVertex,
@@ -73,9 +78,9 @@ public abstract class SubscriptionTxTask implements Runnable {
                                                               .setDestinationNode(destinationVertex)
                                                               .setRequesterNode(requesterVertex)
                                                               .putTags("locus", tags.get("locus"))
-                                                              .putTags("requester",
-                                                                  ClusterUtils
-                                                                      .getCurrentNodeHostAddress())
+                                                              .putTags(
+                                                                  "requester",
+                                                                  appContext.getMyInstanceDetails().getInstanceIp())
                                                               .build();
     netClient.subscribe(remoteHost, subscribeMessage,
         new SubscribeResponseHandler(subscriptionManager, nodeStateManager, remoteHost,

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/SubscriptionTxTask.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/SubscriptionTxTask.java
@@ -25,6 +25,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.NodeState
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.SubscribeResponseHandler;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.SubscriptionManager;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.util.ClusterUtils;
+import java.util.List;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -88,5 +89,9 @@ public abstract class SubscriptionTxTask implements Runnable {
     PerformanceAnalyzerApp.RCA_GRAPH_METRICS_AGGREGATOR
         .updateStat(RcaGraphMetrics.RCA_NODES_SUB_REQ_COUNT,
             requesterVertex + ":" + destinationVertex, 1);
+  }
+
+  public List<String> getPeerIps() {
+    return appContext.getPeerInstanceIps();
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/UnicastSubscriptionTxTask.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/UnicastSubscriptionTxTask.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.tasks;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetClient;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.UnicastIntentMsg;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.NodeStateManager;
@@ -35,8 +36,9 @@ public class UnicastSubscriptionTxTask extends SubscriptionTxTask {
       NetClient netClient,
       UnicastIntentMsg intentMsg,
       SubscriptionManager subscriptionManager,
-      NodeStateManager nodeStateManager) {
-    super(netClient, intentMsg, subscriptionManager, nodeStateManager);
+      NodeStateManager nodeStateManager,
+      final AppContext appContext) {
+    super(netClient, intentMsg, subscriptionManager, nodeStateManager, appContext);
     this.destinationHostAddress = intentMsg.getUnicastDestinationHostAddress();
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCAScheduler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCAScheduler.java
@@ -103,8 +103,14 @@ public class RCAScheduler {
       schedulerState = RcaSchedulerState.STATE_STARTED;
 
       final RCASchedulerTask task = new RCASchedulerTask(
-          10000, rcaSchedulerPeriodicExecutor, connectedComponents, db, persistable, rcaConf, net,
-          new InstanceDetails(role));
+          10000,
+          rcaSchedulerPeriodicExecutor,
+          connectedComponents,
+          db,
+          persistable,
+          rcaConf,
+          net,
+          instanceDetails);
       while (schedulerState == RcaSchedulerState.STATE_STARTED) {
         try {
           long startTime = System.currentTimeMillis();

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCAScheduler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCAScheduler.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.NodeRole;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.ConnectedComponent;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Queryable;
@@ -51,7 +52,7 @@ public class RCAScheduler {
   private boolean shutdownRequested;
   private volatile RcaSchedulerState schedulerState = RcaSchedulerState.STATE_NOT_STARTED;
   private final NodeRole role;
-  private final InstanceDetails instanceDetails;
+  private final AppContext appContext;
 
   final ThreadFactory schedThreadFactory =
       new ThreadFactoryBuilder().setNameFormat("sched-%d").setDaemon(true).build();
@@ -70,7 +71,6 @@ public class RCAScheduler {
   Persistable persistable;
   static final int PERIODICITY_SECONDS = 1;
   static final int PERIODICITY_IN_MS = PERIODICITY_SECONDS * 1000;
-  ScheduledFuture<?> futureHandle;
 
   private static final Logger LOG = LogManager.getLogger(RCAScheduler.class);
 
@@ -81,7 +81,7 @@ public class RCAScheduler {
       ThresholdMain thresholdMain,
       Persistable persistable,
       WireHopper net,
-      InstanceDetails instanceDetails) {
+      final AppContext appContext) {
     this.connectedComponents = connectedComponents;
     this.db = db;
     this.rcaConf = rcaConf;
@@ -89,8 +89,8 @@ public class RCAScheduler {
     this.persistable = persistable;
     this.net = net;
     this.shutdownRequested = false;
-    this.instanceDetails = instanceDetails;
-    this.role = this.instanceDetails.getRole();
+    this.appContext = appContext;
+    this.role = this.appContext.getMyInstanceDetails().getRole();
   }
 
   public void start() {
@@ -110,7 +110,7 @@ public class RCAScheduler {
           persistable,
           rcaConf,
           net,
-          instanceDetails);
+          appContext);
       while (schedulerState == RcaSchedulerState.STATE_STARTED) {
         try {
           long startTime = System.currentTimeMillis();

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCASchedulerTask.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCASchedulerTask.java
@@ -15,15 +15,14 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.ConnectedComponent;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Queryable;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Stats;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts.RcaTagConstants;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.IntentMsg;
@@ -104,7 +103,7 @@ public class RCASchedulerTask implements Runnable {
       final Persistable persistable,
       final RcaConf conf,
       final WireHopper hopper,
-      final InstanceDetails instanceDetails) {
+      final AppContext appContext) {
     this.maxTicks = maxTicks;
     this.executorPool = executorPool;
     this.remotelyDesirableNodeSet = new HashMap<>();
@@ -120,7 +119,7 @@ public class RCASchedulerTask implements Runnable {
               db,
               persistable,
               nodeTaskletMap,
-              instanceDetails);
+              appContext);
 
       // Merge the list across connected components.
       dependencyOrderedLocallyExecutables =
@@ -183,7 +182,7 @@ public class RCASchedulerTask implements Runnable {
       final Queryable db,
       final Persistable persistable,
       final Map<Node<?>, Tasklet> nodeTaskletMap,
-      final  InstanceDetails instanceDetails) {
+      final AppContext appContext) {
     // This is just used for membership check in the createTaskletAndSendIntent. If a node is
     // present here, then the tasklet corresponding to it will be doing local evaluation or else,
     // the tasklet will read data from the read API provided by the wirehopper.
@@ -195,7 +194,7 @@ public class RCASchedulerTask implements Runnable {
     for (List<Node<?>> levelNodes : orderedNodes) {
       List<Tasklet> locallyExecutableInThisLevel = new ArrayList<>();
       for (Node<?> node : levelNodes) {
-        node.setInstanceDetails(instanceDetails);
+        node.setAppContext(appContext);
 
         if (RcaUtil.shouldExecuteLocally(node, conf)) {
           // This node will be executed locally, so add it to the set to keep track of this.

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HighHeapUsageClusterRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HighHeapUsageClusterRca.java
@@ -25,6 +25,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaVerticesMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.google.common.cache.CacheBuilder;
@@ -80,9 +81,8 @@ public class HighHeapUsageClusterRca extends Rca<ResourceFlowUnit<HotClusterSumm
     List<HotNodeSummary> unhealthyNodeList = new ArrayList<>();
     ConcurrentMap<String, ImmutableList<ResourceFlowUnit<HotNodeSummary>>> currentMap =
         this.nodeStateCache.asMap();
-    for (ClusterDetailsEventProcessor.NodeDetails nodeDetails : ClusterDetailsEventProcessor
-        .getDataNodesDetails()) {
-      ImmutableList<ResourceFlowUnit<HotNodeSummary>> nodeStateList = currentMap.get(nodeDetails.getId());
+    for (InstanceDetails nodeDetails : getDataNodeInstances()) {
+      ImmutableList<ResourceFlowUnit<HotNodeSummary>> nodeStateList = currentMap.get(nodeDetails.getInstanceId());
       if (nodeStateList != null) {
         List<HotResourceSummary> oldGenSummaries = new ArrayList<>();
         List<HotResourceSummary> youngGenSummaries = new ArrayList<>();
@@ -102,7 +102,7 @@ public class HighHeapUsageClusterRca extends Rca<ResourceFlowUnit<HotClusterSumm
         // youngGenSummaries can have multiple elements but we will only consider it as unhealthy if
         // three consecutive summaries are all unhealthy and we will then pick the first element as the summary for output.
         if (youngGenSummaries.size() >= UNHEALTHY_FLOWUNIT_THRESHOLD || oldGenSummaries.size() >= UNHEALTHY_FLOWUNIT_THRESHOLD) {
-          HotNodeSummary nodeSummary = new HotNodeSummary(nodeDetails.getId(), nodeDetails.getHostAddress());
+          HotNodeSummary nodeSummary = new HotNodeSummary(nodeDetails.getInstanceId(), nodeDetails.getInstanceIp());
           if (youngGenSummaries.size() >= UNHEALTHY_FLOWUNIT_THRESHOLD) {
             nodeSummary.appendNestedSummary(youngGenSummaries.get(0));
           }
@@ -150,7 +150,8 @@ public class HighHeapUsageClusterRca extends Rca<ResourceFlowUnit<HotClusterSumm
       LOG.debug("Unhealthy node id list : {}", unhealthyNodeList);
       if (unhealthyNodeList.size() > 0) {
         context = new ResourceContext(Resources.State.UNHEALTHY);
-        summary = new HotClusterSummary(ClusterDetailsEventProcessor.getNodesDetails().size(),
+        summary = new HotClusterSummary(
+            getAllClusterInstances().size(),
             unhealthyNodeList.size());
         for (HotNodeSummary unhealthyNodeSummary : unhealthyNodeList) {
           summary.appendNestedSummary(unhealthyNodeSummary);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HighHeapUsageClusterRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HighHeapUsageClusterRca.java
@@ -27,7 +27,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaVerticesMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HotNodeClusterRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HotNodeClusterRca.java
@@ -27,12 +27,9 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor.NodeDetails;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Table;
-
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Comparator;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HotNodeRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HotNodeRca.java
@@ -22,10 +22,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HotNodeRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HotNodeRca.java
@@ -23,6 +23,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import java.util.ArrayList;
@@ -78,9 +79,9 @@ public class HotNodeRca extends Rca<ResourceFlowUnit<HotNodeSummary>> {
 
     if (counter == rcaPeriod) {
       ResourceContext context;
-      ClusterDetailsEventProcessor.NodeDetails currentNode = ClusterDetailsEventProcessor
-          .getCurrentNodeDetails();
-      HotNodeSummary summary = new HotNodeSummary(currentNode.getId(), currentNode.getHostAddress());
+
+      InstanceDetails instanceDetails = getInstanceDetails();
+      HotNodeSummary summary = new HotNodeSummary(instanceDetails.getInstanceId(), instanceDetails.getInstanceIp());
 
       for (HotResourceSummary hotResourceSummary : hotResourceSummaryList) {
         summary.appendNestedSummary(hotResourceSummary);
@@ -97,7 +98,7 @@ public class HotNodeRca extends Rca<ResourceFlowUnit<HotNodeSummary>> {
       hasUnhealthyFlowUnit = false;
       //check if the current node is data node. If it is the data node
       //then HotNodeRca is the top level RCA on this node and we want to persist summaries in flowunit.
-      boolean isDataNode = !currentNode.getIsMasterNode();
+      boolean isDataNode = !instanceDetails.getIsMaster();
       return new ResourceFlowUnit<>(System.currentTimeMillis(), context, summary, isDataNode);
     } else {
       return new ResourceFlowUnit<>(System.currentTimeMillis());

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/cluster/BaseClusterRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/cluster/BaseClusterRca.java
@@ -24,8 +24,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor.NodeDetails;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/cluster/BaseClusterRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/cluster/BaseClusterRca.java
@@ -22,6 +22,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotClusterSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor.NodeDetails;
@@ -115,12 +116,12 @@ public class BaseClusterRca extends Rca<ResourceFlowUnit<HotClusterSummary>> {
     }
   }
 
-  private List<NodeDetails> getClusterNodesDetails() {
+  private List<InstanceDetails> getClusterNodesDetails() {
     if (collectFromMasterNode) {
-      return ClusterDetailsEventProcessor.getNodesDetails();
+      return getAllClusterInstances();
     }
     else {
-      return ClusterDetailsEventProcessor.getDataNodesDetails();
+      return getDataNodeInstances();
     }
   }
 
@@ -130,8 +131,8 @@ public class BaseClusterRca extends Rca<ResourceFlowUnit<HotClusterSummary>> {
   private void removeInactiveNodeFromNodeMap() {
     Set<String> nodeIdSet = new HashSet<>();
     List<NodeKey> inactiveNodes = new ArrayList<>();
-    for (NodeDetails nodeDetail : getClusterNodesDetails()) {
-      nodeIdSet.add(nodeDetail.getId());
+    for (InstanceDetails nodeDetail : getClusterNodesDetails()) {
+      nodeIdSet.add(nodeDetail.getInstanceId());
     }
     for (NodeKey nodeKey : nodeTable.rowKeySet()) {
       if (!nodeIdSet.contains(nodeKey.getNodeId())) {
@@ -151,10 +152,10 @@ public class BaseClusterRca extends Rca<ResourceFlowUnit<HotClusterSummary>> {
   private ResourceFlowUnit<HotClusterSummary> generateFlowUnit() {
     List<HotNodeSummary> unhealthyNodeSummaries = new ArrayList<>();
     long timestamp = clock.millis();
-    List<NodeDetails> clusterNodesDetails = getClusterNodesDetails();
+    List<InstanceDetails> clusterNodesDetails = getClusterNodesDetails();
     // iterate through this table
-    for (NodeDetails nodeDetails : clusterNodesDetails) {
-      NodeKey nodeKey = new NodeKey(nodeDetails.getId(), nodeDetails.getHostAddress());
+    for (InstanceDetails nodeDetails : clusterNodesDetails) {
+      NodeKey nodeKey = new NodeKey(nodeDetails.getInstanceId(), nodeDetails.getInstanceIp());
       // skip if the node is not found in table
       if (!nodeTable.containsRow(nodeKey)) {
         continue;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotshard/HotShardClusterRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotshard/HotShardClusterRca.java
@@ -185,7 +185,7 @@ public class HotShardClusterRca extends Rca<ResourceFlowUnit<HotClusterSummary>>
             List<HotResourceSummary> hotShardSummaryList = new ArrayList<>();
             ResourceContext context;
             HotClusterSummary summary = new HotClusterSummary(
-                    ClusterDetailsEventProcessor.getNodesDetails().size(), unhealthyNodes.size());
+                getAllClusterInstances().size(), unhealthyNodes.size());
 
             // We evaluate hot shards individually on all the 3 dimensions
             findHotShardAndCreateSummary(

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotshard/HotShardClusterRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotshard/HotShardClusterRca.java
@@ -30,7 +30,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 import java.util.ArrayList;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotshard/HotShardClusterRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotshard/HotShardClusterRca.java
@@ -28,6 +28,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.google.common.collect.HashBasedTable;
@@ -203,8 +204,10 @@ public class HotShardClusterRca extends Rca<ResourceFlowUnit<HotClusterSummary>>
                 context = new ResourceContext(Resources.State.HEALTHY);
             } else {
                 context = new ResourceContext(Resources.State.UNHEALTHY);
-                ClusterDetailsEventProcessor.NodeDetails currentNode = ClusterDetailsEventProcessor.getCurrentNodeDetails();
-                HotNodeSummary nodeSummary = new HotNodeSummary(currentNode.getId(), currentNode.getHostAddress());
+
+                InstanceDetails instanceDetails = getInstanceDetails();
+                HotNodeSummary nodeSummary = new HotNodeSummary(instanceDetails.getInstanceId(),
+                    instanceDetails.getInstanceIp());
                 for (HotResourceSummary hotResourceSummary : hotShardSummaryList) {
                     nodeSummary.appendNestedSummary(hotResourceSummary);
                 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotshard/HotShardRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotshard/HotShardRca.java
@@ -21,9 +21,6 @@ import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framew
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.MetricEnum;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.Resource;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.configs.HotShardRcaConfig;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
@@ -39,7 +36,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/NodeTemperatureRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/NodeTemperatureRca.java
@@ -24,6 +24,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.CompactNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.FullNodeTemperatureSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.NodeLevelDimensionalSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.dimension.CpuUtilDimensionTemperatureRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.dimension.HeapAllocRateTemperatureRca;
@@ -128,11 +129,11 @@ public class NodeTemperatureRca extends Rca<CompactNodeTemperatureFlowUnit> {
 
   private FullNodeTemperatureSummary buildNodeProfile(
       List<NodeLevelDimensionalSummary> dimensionProfiles) {
-    ClusterDetailsEventProcessor.NodeDetails currentNodeDetails =
-        ClusterDetailsEventProcessor.getCurrentNodeDetails();
+
+    InstanceDetails instanceDetails = getInstanceDetails();
     FullNodeTemperatureSummary nodeProfile = new FullNodeTemperatureSummary(
-        currentNodeDetails.getId(),
-        currentNodeDetails.getHostAddress());
+        instanceDetails.getInstanceId(),
+        instanceDetails.getInstanceIp());
     for (NodeLevelDimensionalSummary profile : dimensionProfiles) {
       nodeProfile.updateNodeDimensionProfile(profile);
     }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/NodeTemperatureRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/NodeTemperatureRca.java
@@ -29,7 +29,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.Flo
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.dimension.CpuUtilDimensionTemperatureRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.dimension.HeapAllocRateTemperatureRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.dimension.ShardSizeDimensionTemperatureRca;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/threadpool/QueueRejectionRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/threadpool/QueueRejectionRca.java
@@ -18,9 +18,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.th
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolDimension.THREAD_POOL_TYPE;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.MetricEnum;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.Resource;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolType;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
@@ -35,7 +33,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.google.common.annotations.VisibleForTesting;
 import java.time.Clock;
 import java.util.ArrayList;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/threadpool/QueueRejectionRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/threadpool/QueueRejectionRca.java
@@ -33,6 +33,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.google.common.annotations.VisibleForTesting;
@@ -87,14 +88,15 @@ public class QueueRejectionRca extends Rca<ResourceFlowUnit<HotNodeSummary>> {
     }
     if (counter == rcaPeriod) {
       counter = 0;
-      ClusterDetailsEventProcessor.NodeDetails currentNode = ClusterDetailsEventProcessor
-          .getCurrentNodeDetails();
+
+      InstanceDetails instanceDetails = getInstanceDetails();
+
       HotNodeSummary nodeSummary = null;
       for (QueueRejectionCollector collector : queueRejectionCollectors) {
         // if we've see thread pool rejection in the last 5 mins, the thread pool is considered as contended
         if (collector.isUnhealthy(currTimestamp)) {
           if (nodeSummary == null) {
-            nodeSummary = new HotNodeSummary(currentNode.getId(), currentNode.getHostAddress());
+            nodeSummary = new HotNodeSummary(instanceDetails.getInstanceId(), instanceDetails.getInstanceIp());
           }
           nodeSummary.appendNestedSummary(collector.generateSummary(currTimestamp));
         }
@@ -106,7 +108,7 @@ public class QueueRejectionRca extends Rca<ResourceFlowUnit<HotNodeSummary>> {
       else {
         context = new ResourceContext(Resources.State.UNHEALTHY);
       }
-      boolean isDataNode = !currentNode.getIsMasterNode();
+      boolean isDataNode = !instanceDetails.getIsMaster();
       return new ResourceFlowUnit<>(currTimestamp, context, nodeSummary, isDataNode);
     }
     else {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtils.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtils.java
@@ -1,5 +1,6 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.util;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor.NodeDetails;
 import com.google.common.annotations.VisibleForTesting;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtils.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtils.java
@@ -1,5 +1,6 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.util;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor.NodeDetails;
 import com.google.common.annotations.VisibleForTesting;
@@ -10,40 +11,14 @@ import java.util.stream.Collectors;
  * Utility class to get details about the nodes in the cluster.
  */
 public class ClusterUtils {
-
-  @VisibleForTesting
-  static final String EMPTY_STRING = "";
-
-  /**
-   * Get host addresses for all the other nodes in the cluster.
-   *
-   * @return List of host addresses.
-   */
-  public static List<String> getAllPeerHostAddresses() {
-    return ClusterDetailsEventProcessor.getNodesDetails().stream()
-                                       .skip(1)
-                                       .map(NodeDetails::getHostAddress)
-                                       .collect(Collectors.toList());
-  }
-
-  /**
-   * Checks if the given host address is part of the cluster.
-   *
-   * @param hostAddress The host address to check membership for.
-   * @return true if the host address is part of the cluster, false otherwise.
-   */
-  public static boolean isHostAddressInCluster(final String hostAddress) {
-    final List<NodeDetails> nodes = ClusterDetailsEventProcessor.getNodesDetails();
-
-    if (nodes.size() > 0) {
-      for (NodeDetails node : nodes) {
-        if (node.getHostAddress()
-                .equals(hostAddress)) {
+  public static boolean isHostAddressInCluster(final String hostAddress, final List<InstanceDetails> clusterInstances) {
+    if (clusterInstances.size() > 0) {
+      for (InstanceDetails node : clusterInstances) {
+        if (node.getInstanceIp().equals(hostAddress)) {
           return true;
         }
       }
     }
-
     return false;
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtils.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtils.java
@@ -1,10 +1,8 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.util;
 
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor.NodeDetails;
 import com.google.common.annotations.VisibleForTesting;
-
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -15,21 +13,6 @@ public class ClusterUtils {
 
   @VisibleForTesting
   static final String EMPTY_STRING = "";
-
-
-  /**
-   * Get the current host's ip address.
-   *
-   * @return The host address for the current node.
-   */
-  public static String getCurrentNodeHostAddress() {
-    final NodeDetails currentNodeDetails = ClusterDetailsEventProcessor.getCurrentNodeDetails();
-    if (currentNodeDetails != null) {
-      return currentNodeDetails.getHostAddress();
-    }
-
-    return EMPTY_STRING;
-  }
 
   /**
    * Get host addresses for all the other nodes in the cluster.

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtils.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtils.java
@@ -1,11 +1,7 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.util;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor.NodeDetails;
-import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Utility class to get details about the nodes in the cluster.

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessor.java
@@ -20,6 +20,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.Performan
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaControllerHelper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.util.JsonConverter;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -139,6 +140,14 @@ public class ClusterDetailsEventProcessor implements EventProcessor {
       role = (String) map.get(AllMetrics.NodeDetailColumns.ROLE.toString());
       Object isMasterNodeObject = map.get(AllMetrics.NodeDetailColumns.IS_MASTER_NODE.toString());
       isMasterNode = isMasterNodeObject != null ? (Boolean) isMasterNodeObject : null;
+    }
+
+    @VisibleForTesting
+    public NodeDetails(AllMetrics.NodeRole role, String id, String hostAddress, boolean isMaster) {
+      this.id = id;
+      this.hostAddress = hostAddress;
+      this.isMasterNode = isMaster;
+      this.role = role.toString();
     }
 
     @Override

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessor.java
@@ -114,6 +114,7 @@ public class ClusterDetailsEventProcessor implements EventProcessor {
     }
   }
 
+  @Deprecated
   public static NodeDetails getCurrentNodeDetails() {
     List<NodeDetails> allNodes = getNodesDetails();
     if (allNodes.size() > 0) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessor.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatExceptionCode;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
@@ -66,6 +67,8 @@ public class ReaderMetricsProcessor implements Runnable {
   private static final Map<String, Double> TIMING_STATS = new HashMap<>();
   private static final Map<String, String> STATS_DATA = new HashMap<>();
 
+  private final AppContext appContext;
+
   static {
     STATS_DATA.put("MethodName", "ProcessMetrics");
   }
@@ -83,10 +86,10 @@ public class ReaderMetricsProcessor implements Runnable {
   }
 
   public ReaderMetricsProcessor(String rootLocation) throws Exception {
-    this(rootLocation, false);
+    this(rootLocation, false, null);
   }
 
-  public ReaderMetricsProcessor(String rootLocation, boolean processNewFormat) throws Exception {
+  public ReaderMetricsProcessor(String rootLocation, boolean processNewFormat, final AppContext appContext) throws Exception {
     conn = DriverManager.getConnection(DB_URL);
     create = DSL.using(conn, SQLDialect.SQLITE);
     metricsDBMap = new ConcurrentSkipListMap<>();
@@ -103,6 +106,7 @@ public class ReaderMetricsProcessor implements Runnable {
     }
     eventLogFileHandler = new EventLogFileHandler(new EventLog(), rootLocation);
     this.processNewFormat = processNewFormat;
+    this.appContext = appContext;
   }
 
   @Override
@@ -433,6 +437,9 @@ public class ReaderMetricsProcessor implements Runnable {
         NodeMetricsEventProcessor.buildNodeMetricEventsProcessor(
             currWindowStartTime, conn, nodeMetricsMap);
     EventProcessor clusterDetailsEventsProcessor = new ClusterDetailsEventProcessor();
+    if (appContext != null) {
+      appContext.setClusterDetailsEventProcessor((ClusterDetailsEventProcessor) clusterDetailsEventsProcessor);
+    }
 
     // The event dispatcher dispatches events to each of the registered event processors.
     // In addition to event processing each processor has an initialize/finalize function that is

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryMetricsRequestHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryMetricsRequestHandler.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rest;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatExceptionCode;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.core.Util;
@@ -25,6 +26,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.Metrics
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.model.MetricAttributes;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.model.MetricsModel;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetClient;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ReaderMetricsProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.util.JsonConverter;
@@ -62,10 +64,12 @@ public class QueryMetricsRequestHandler extends MetricsHandler implements HttpHa
   private static final TimeUnit TIME_OUT_UNIT = TimeUnit.SECONDS;
   private NetClient netClient;
   MetricsRestUtil metricsRestUtil;
+  private final AppContext appContext;
 
-  public QueryMetricsRequestHandler(NetClient netClient, MetricsRestUtil metricsRestUtil) {
+  public QueryMetricsRequestHandler(NetClient netClient, MetricsRestUtil metricsRestUtil, final AppContext appContext) {
     this.netClient = netClient;
     this.metricsRestUtil = metricsRestUtil;
+    this.appContext = appContext;
   }
 
   @Override
@@ -148,11 +152,10 @@ public class QueryMetricsRequestHandler extends MetricsHandler implements HttpHa
         String localResponseWithTimestamp =
             String.format("{\"timestamp\": %d, \"data\": %s}", dbTimestamp, localResponse);
         ConcurrentHashMap<String, String> nodeResponses = new ConcurrentHashMap<>();
-        final List<ClusterDetailsEventProcessor.NodeDetails> allNodes = ClusterDetailsEventProcessor
-            .getNodesDetails();
+        final List<InstanceDetails> allNodes = appContext.getAllClusterInstances();
         String localNodeId = "local";
         if (allNodes.size() != 0) {
-          localNodeId = allNodes.get(0).getId();
+          localNodeId = allNodes.get(0).getInstanceId();
         }
         nodeResponses.put(localNodeId, localResponseWithTimestamp);
         String response = metricsRestUtil.nodeJsonBuilder(nodeResponses);
@@ -162,14 +165,14 @@ public class QueryMetricsRequestHandler extends MetricsHandler implements HttpHa
         } else if (nodes.equals("all")) {
           CountDownLatch doneSignal = new CountDownLatch(allNodes.size() - 1);
           for (int i = 1; i < allNodes.size(); i++) {
-            ClusterDetailsEventProcessor.NodeDetails node = allNodes.get(i);
+            InstanceDetails node = allNodes.get(i);
             LOG.debug("Collecting remote stats");
             try {
               collectRemoteStats(node, metricList, aggList, dimList, nodeResponses, doneSignal);
             } catch (Exception e) {
               LOG.error(
                   "Unable to collect stats for node, addr:{}, exception: {} ExceptionCode: {}",
-                  node.getHostAddress(),
+                  node.getInstanceIp(),
                   e,
                   StatExceptionCode.REQUEST_REMOTE_ERROR.toString());
               StatsCollector.instance().logException(StatExceptionCode.REQUEST_REMOTE_ERROR);
@@ -216,14 +219,12 @@ public class QueryMetricsRequestHandler extends MetricsHandler implements HttpHa
   }
 
   void collectRemoteStats(
-      ClusterDetailsEventProcessor.NodeDetails node,
+      InstanceDetails node,
       List<String> metricList,
       List<String> aggList,
       List<String> dimList,
       final ConcurrentHashMap<String, String> nodeResponses,
-      final CountDownLatch doneSignal)
-      throws Exception {
-    // create a request
+      final CountDownLatch doneSignal) {
     MetricsRequest request =
         MetricsRequest.newBuilder()
             .addAllMetricList(metricList)
@@ -233,7 +234,7 @@ public class QueryMetricsRequestHandler extends MetricsHandler implements HttpHa
     ThreadSafeStreamObserver responseObserver =
         new ThreadSafeStreamObserver(node, nodeResponses, doneSignal);
     try {
-      this.netClient.getMetrics(node.getHostAddress(), request, responseObserver);
+      this.netClient.getMetrics(node.getInstanceIp(), request, responseObserver);
     } catch (Exception e) {
       LOG.error("Metrics : Exception occurred while getting Metrics {}", e.getCause());
     }
@@ -319,10 +320,10 @@ public class QueryMetricsRequestHandler extends MetricsHandler implements HttpHa
   private static class ThreadSafeStreamObserver implements StreamObserver<MetricsResponse> {
     private final CountDownLatch doneSignal;
     private final ConcurrentHashMap<String, String> nodeResponses;
-    private final ClusterDetailsEventProcessor.NodeDetails node;
+    private final InstanceDetails node;
 
     ThreadSafeStreamObserver(
-        ClusterDetailsEventProcessor.NodeDetails node,
+        InstanceDetails node,
         ConcurrentHashMap<String, String> nodeResponses,
         CountDownLatch doneSignal) {
       this.node = node;
@@ -331,12 +332,12 @@ public class QueryMetricsRequestHandler extends MetricsHandler implements HttpHa
     }
 
     public void onNext(MetricsResponse value) {
-      nodeResponses.putIfAbsent(node.getId(), value.getMetricsResult());
+      nodeResponses.putIfAbsent(node.getInstanceId(), value.getMetricsResult());
     }
 
     @Override
     public void onError(Throwable t) {
-      LOG.info("Metrics : Error occurred while getting Metrics for " + node.getHostAddress());
+      LOG.info("Metrics : Error occurred while getting Metrics for " + node.getInstanceIp());
       doneSignal.countDown();
     }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryMetricsRequestHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryMetricsRequestHandler.java
@@ -27,7 +27,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.model.MetricAttri
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.model.MetricsModel;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetClient;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ReaderMetricsProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.util.JsonConverter;
 import com.sun.net.httpserver.HttpExchange;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryRcaRequestHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryRcaRequestHandler.java
@@ -22,7 +22,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.Version;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Stats;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.SQLiteQueryUtils;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.Persistable;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryRcaRequestHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryRcaRequestHandler.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rest;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatExceptionCode;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsRestUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.Version;
@@ -96,8 +97,10 @@ public class QueryRcaRequestHandler extends MetricsHandler implements HttpHandle
   public static final String NAME_PARAM = "name";
   private Persistable persistable;
   private MetricsRestUtil metricsRestUtil;
+  private AppContext appContext;
 
-  public QueryRcaRequestHandler() {
+  public QueryRcaRequestHandler(final AppContext appContext) {
+    this.appContext = appContext;
     metricsRestUtil = new MetricsRestUtil();
   }
 
@@ -239,9 +242,7 @@ public class QueryRcaRequestHandler extends MetricsHandler implements HttpHandle
 
   // check if we are querying from elected master
   private boolean validNodeRole() {
-    ClusterDetailsEventProcessor.NodeDetails currentNode = ClusterDetailsEventProcessor
-        .getCurrentNodeDetails();
-    return currentNode.getIsMasterNode();
+    return appContext.getMyInstanceDetails().getIsMaster();
   }
 
   private JsonElement getRcaData(Persistable persistable, List<String> rcaList) {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/RcaStatsCollectorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/RcaStatsCollectorTest.java
@@ -31,7 +31,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.JvmMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.RCASchedulerTask;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/RcaStatsCollectorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/RcaStatsCollectorTest.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaTestHelper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.AnalysisGraph;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
@@ -29,6 +30,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.JvmMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.RCASchedulerTask;
@@ -106,7 +108,8 @@ public class RcaStatsCollectorTest {
             new MetricsDBProviderTestHelper(true),
             null,
             rcaConf,
-            null);
+            null,
+            new InstanceDetails(AllMetrics.NodeRole.UNKNOWN));
     rcaSchedulerTask.run();
     StatsCollector statsCollector = new StatsCollector("test-stats", 0, new HashMap<>());
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/RcaStatsCollectorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/RcaStatsCollectorTest.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaTestHelper;
@@ -36,8 +37,10 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.uti
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.RCASchedulerTask;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.spec.MetricsDBProviderTestHelper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -100,6 +103,17 @@ public class RcaStatsCollectorTest {
         RcaUtil.getAnalysisGraphComponents(new FaultyAnalysisGraph());
     RcaConf rcaConf = new RcaConf(Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca.conf").toString());
 
+    ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
+    clusterDetailsEventProcessor.setNodesDetails(
+        Collections.singletonList(new ClusterDetailsEventProcessor.NodeDetails(
+            AllMetrics.NodeRole.UNKNOWN,
+            "node1",
+            "127.0.0.1",
+            false))
+    );
+    AppContext appContext = new AppContext();
+    appContext.setClusterDetailsEventProcessor(clusterDetailsEventProcessor);
+
     RCASchedulerTask rcaSchedulerTask =
         new RCASchedulerTask(
             1000,
@@ -109,7 +123,7 @@ public class RcaStatsCollectorTest {
             null,
             rcaConf,
             null,
-            new InstanceDetails(AllMetrics.NodeRole.UNKNOWN));
+            appContext);
     rcaSchedulerTask.run();
     StatsCollector statsCollector = new StatsCollector("test-stats", 0, new HashMap<>());
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/QueueHealthDeciderTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/QueueHealthDeciderTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.Action;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.NodeRole;
@@ -27,29 +28,49 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.QueueRejectionClusterRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
 public class QueueHealthDeciderTest {
+  AppContext appContext;
 
   @Before
-  public void setupCluster() throws SQLException, ClassNotFoundException {
-    ClusterDetailsEventProcessorTestHelper clusterDetailsEventProcessorTestHelper = new ClusterDetailsEventProcessorTestHelper();
-    clusterDetailsEventProcessorTestHelper.addNodeDetails("node1", "127.0.0.1", false);
-    clusterDetailsEventProcessorTestHelper.addNodeDetails("node2", "127.0.0.2", false);
-    clusterDetailsEventProcessorTestHelper.addNodeDetails("node3", "127.0.0.3", false);
-    clusterDetailsEventProcessorTestHelper.addNodeDetails("node4", "127.0.0.4", false);
-    clusterDetailsEventProcessorTestHelper.addNodeDetails("master", "127.0.0.9", NodeRole.ELECTED_MASTER, true);
-    clusterDetailsEventProcessorTestHelper.generateClusterDetailsEvent();
+  public void setupCluster() {
+    ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
+    ClusterDetailsEventProcessor.NodeDetails node1 =
+        new ClusterDetailsEventProcessor.NodeDetails(NodeRole.DATA, "node1", "127.0.0.1", false);
+    ClusterDetailsEventProcessor.NodeDetails node2 =
+        new ClusterDetailsEventProcessor.NodeDetails(NodeRole.DATA, "node2", "127.0.0.2", false);
+    ClusterDetailsEventProcessor.NodeDetails node3 =
+        new ClusterDetailsEventProcessor.NodeDetails(NodeRole.DATA, "node3", "127.0.0.3", false);
+    ClusterDetailsEventProcessor.NodeDetails node4 =
+        new ClusterDetailsEventProcessor.NodeDetails(NodeRole.DATA, "node3", "127.0.0.4", false);
+    ClusterDetailsEventProcessor.NodeDetails master =
+        new ClusterDetailsEventProcessor.NodeDetails(NodeRole.ELECTED_MASTER, "master", "127.0.0.9", true);
+
+    List<ClusterDetailsEventProcessor.NodeDetails> nodes = new ArrayList<>();
+    nodes.add(node1);
+    nodes.add(node2);
+    nodes.add(node3);
+    nodes.add(node4);
+    nodes.add(master);
+    clusterDetailsEventProcessor.setNodesDetails(nodes);
+
+    appContext = new AppContext();
+    appContext.setClusterDetailsEventProcessor(clusterDetailsEventProcessor);
   }
 
   @Test
   public void testHighRejectionRemediation() {
     RcaTestHelper<HotNodeSummary> nodeRca = new RcaTestHelper<>("QueueRejectionNodeRca");
+    nodeRca.setAppContext(appContext);
     // node1: Both write and search queues unhealthy
     // node2: Only write unhealthy
     // node3: Only search unhealthy
@@ -63,6 +84,7 @@ public class QueueHealthDeciderTest {
     );
 
     QueueRejectionClusterRca queueClusterRca = new QueueRejectionClusterRca(1, nodeRca);
+    queueClusterRca.setAppContext(appContext);
     queueClusterRca.generateFlowUnitListFromLocal(null);
     QueueHealthDecider decider = new QueueHealthDecider(5, 12, queueClusterRca);
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/QueueHealthDeciderTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/QueueHealthDeciderTest.java
@@ -29,8 +29,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.QueueRejectionClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
@@ -2,6 +2,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca;
 
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaTestHelper.updateConfFileForMutedRcas;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.ClientServers;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerThreads;
@@ -14,6 +15,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.RCAScheduler;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.RcaSchedulerState;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.spec.MetricsDBProviderTestHelper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.threads.ThreadProvider;
@@ -112,7 +114,8 @@ public class RcaControllerTest {
             clientServers,
             rcaEnabledFileLoc.toString(),
             100,
-            200
+            200,
+            new AppContext()
         );
 
     setMyIp(masterIP, AllMetrics.NodeRole.UNKNOWN);
@@ -200,6 +203,7 @@ public class RcaControllerTest {
     String mutedRcaConfPath = Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca_muted.conf").toString();
     List<String> mutedRcas1 = Arrays.asList("CPU_Utilization", "Heap_AllocRate");
     List<String> mutedRcas2 = Arrays.asList("Paging_MajfltRate");
+
 
     // RCA enabled, mutedRcas1 is muted nodes
     changeRcaRunState(RcaState.RUN);
@@ -368,6 +372,7 @@ public class RcaControllerTest {
     ClusterDetailsEventProcessor eventProcessor = new ClusterDetailsEventProcessor();
     eventProcessor.processEvent(
         new Event("", jtime.toString() + System.lineSeparator() + jNode.toString(), 0));
+    rcaController.getAppContext().setClusterDetailsEventProcessor(eventProcessor);
   }
 
   enum RcaState {
@@ -391,7 +396,7 @@ public class RcaControllerTest {
   private <T> boolean check(IEval eval, T expected) {
     final long SLEEP_TIME_MILLIS = 1000;
 
-    for (int i = 0; i < 2; i++) {
+    for (int i = 0; i < 10; i++) {
       if (eval.evaluateAndCheck(expected)) {
         return true;
       }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
@@ -15,7 +15,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.RCAScheduler;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.RcaSchedulerState;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.spec.MetricsDBProviderTestHelper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.threads.ThreadProvider;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
@@ -204,7 +204,6 @@ public class RcaControllerTest {
     List<String> mutedRcas1 = Arrays.asList("CPU_Utilization", "Heap_AllocRate");
     List<String> mutedRcas2 = Arrays.asList("Paging_MajfltRate");
 
-
     // RCA enabled, mutedRcas1 is muted nodes
     changeRcaRunState(RcaState.RUN);
     setMyIp(masterIP, AllMetrics.NodeRole.MASTER);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
@@ -73,7 +73,7 @@ public class RcaControllerTest {
             3, new ThreadFactoryBuilder().setNameFormat("test-network-thread-%d").build());
     boolean useHttps = PluginSettings.instance().getHttpsEnabled();
     connectionManager = new GRPCConnectionManager(useHttps);
-    clientServers = PerformanceAnalyzerApp.createClientServers(connectionManager);
+    clientServers = PerformanceAnalyzerApp.createClientServers(connectionManager, new AppContext());
     clientServers.getHttpServer().start();
 
     URI uri = URI.create(RcaController.getCatMasterUrl());

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaTestHelper.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaTestHelper.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.ConnectedComponent;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
@@ -129,7 +130,7 @@ public class RcaTestHelper {
     }
   }
 
-  public static void setMyIp(String ip, AllMetrics.NodeRole nodeRole) {
+  public static AppContext setMyIp(String ip, AllMetrics.NodeRole nodeRole) {
     JSONObject jtime = new JSONObject();
     jtime.put("current_time", 1566414001749L);
 
@@ -143,6 +144,9 @@ public class RcaTestHelper {
     ClusterDetailsEventProcessor eventProcessor = new ClusterDetailsEventProcessor();
     eventProcessor.processEvent(
             new Event("", jtime.toString() + System.lineSeparator() + jNode.toString(), 0));
+    AppContext appContext = new AppContext();
+    appContext.setClusterDetailsEventProcessor(eventProcessor);
+    return appContext;
   }
 
   public static void truncate(File file) {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/listener/MisbehavingGraphOperateMethodListenerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/listener/MisbehavingGraphOperateMethodListenerTest.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.listener;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
@@ -106,7 +107,7 @@ public class MisbehavingGraphOperateMethodListenerTest {
             null,
             rcaConf,
             null,
-            new InstanceDetails(AllMetrics.NodeRole.UNKNOWN));
+            new AppContext());
 
     for (int i = 0; i <= MisbehavingGraphOperateMethodListener.TOLERANCE_LIMIT; i++) {
       rcaSchedulerTask.run();

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/listener/MisbehavingGraphOperateMethodListenerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/listener/MisbehavingGraphOperateMethodListenerTest.java
@@ -17,6 +17,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.listener;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaTestHelper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.AnalysisGraph;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
@@ -30,6 +31,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Stats;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.RCASchedulerTask;
@@ -103,7 +105,8 @@ public class MisbehavingGraphOperateMethodListenerTest {
             new MetricsDBProviderTestHelper(true),
             null,
             rcaConf,
-            null);
+            null,
+            new InstanceDetails(AllMetrics.NodeRole.UNKNOWN));
 
     for (int i = 0; i <= MisbehavingGraphOperateMethodListener.TOLERANCE_LIMIT; i++) {
       rcaSchedulerTask.run();

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/NodeStateManagerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/NodeStateManagerTest.java
@@ -56,11 +56,15 @@ public class NodeStateManagerTest {
 
     testNodeStateManager
         .updateSubscriptionState(TEST_NODE_1, TEST_HOST_1, SubscriptionStatus.SUCCESS);
-    ClusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
+
+    ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
+    clusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
             EMPTY_DETAILS,
             ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, TEST_HOST_1, false),
             ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, TEST_HOST_2, false)
     ));
+
+    testNodeStateManager.getAppContext().setClusterDetailsEventProcessor(clusterDetailsEventProcessor);
 
     ImmutableList<String> hostsToSubscribeTo =
         testNodeStateManager.getStaleOrNotSubscribedNodes(TEST_NODE_1, TEN_S_IN_MILLIS,
@@ -82,12 +86,14 @@ public class NodeStateManagerTest {
     testNodeStateManager.updateReceiveTime(TEST_HOST_2, TEST_NODE_1, currentTime);
     testNodeStateManager.updateSubscriptionState(TEST_NODE_1, TEST_HOST_2, SubscriptionStatus.SUCCESS);
 
-    ClusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
+    ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
+    clusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
             EMPTY_DETAILS,
             ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, TEST_HOST_1, false),
             ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, TEST_HOST_2, false),
             ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, TEST_HOST_3, false)
     ));
+    testNodeStateManager.getAppContext().setClusterDetailsEventProcessor(clusterDetailsEventProcessor);
 
     ImmutableList<String> hostsToSubscribeTo =
         testNodeStateManager.getStaleOrNotSubscribedNodes(TEST_NODE_1, TEN_S_IN_MILLIS,

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/NodeStateManagerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/NodeStateManagerTest.java
@@ -1,5 +1,6 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeResponse.SubscriptionStatus;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
@@ -27,7 +28,7 @@ public class NodeStateManagerTest {
 
   @Before
   public void setUp() {
-    this.testNodeStateManager = new NodeStateManager();
+    this.testNodeStateManager = new NodeStateManager(new AppContext());
   }
 
   @Test

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/SubscribeResponseHandlerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/SubscribeResponseHandlerTest.java
@@ -1,5 +1,6 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeResponse;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.GRPCConnectionManager;
 import com.google.common.collect.Sets;
@@ -19,7 +20,7 @@ public class SubscribeResponseHandlerTest {
     public void setup() {
         GRPCConnectionManager grpcConnectionManager = new GRPCConnectionManager(true);
         subscriptionManager = new SubscriptionManager(grpcConnectionManager);
-        nodeStateManager = new NodeStateManager();
+        nodeStateManager = new NodeStateManager(new AppContext());
         uut = new SubscribeResponseHandler(subscriptionManager, nodeStateManager, HOST, NODE);
     }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopperTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopperTest.java
@@ -1,5 +1,6 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.GRPCConnectionManager;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetClient;
@@ -21,7 +22,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.util.WaitFor;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -30,7 +30,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -86,7 +85,8 @@ public class WireHopperTest {
         receivedFlowUnitStore = new ReceivedFlowUnitStore();
         subscriptionManager = new SubscriptionManager(connectionManager);
         clientExecutor.set(null);
-        uut = new WireHopper(nodeStateManager, netClient, subscriptionManager, clientExecutor, receivedFlowUnitStore);
+        uut = new WireHopper(nodeStateManager, netClient, subscriptionManager, clientExecutor, receivedFlowUnitStore,
+            new AppContext());
     }
 
     @AfterClass

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopperTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopperTest.java
@@ -81,7 +81,7 @@ public class WireHopperTest {
 
     @Before
     public void setup() {
-        nodeStateManager = new NodeStateManager();
+        nodeStateManager = new NodeStateManager(new AppContext());
         receivedFlowUnitStore = new ReceivedFlowUnitStore();
         subscriptionManager = new SubscriptionManager(connectionManager);
         clientExecutor.set(null);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopperTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopperTest.java
@@ -81,12 +81,13 @@ public class WireHopperTest {
 
     @Before
     public void setup() {
-        nodeStateManager = new NodeStateManager(new AppContext());
+        AppContext appContext = new AppContext();
+        nodeStateManager = new NodeStateManager(appContext);
         receivedFlowUnitStore = new ReceivedFlowUnitStore();
         subscriptionManager = new SubscriptionManager(connectionManager);
         clientExecutor.set(null);
         uut = new WireHopper(nodeStateManager, netClient, subscriptionManager, clientExecutor, receivedFlowUnitStore,
-            new AppContext());
+            appContext);
     }
 
     @AfterClass
@@ -110,10 +111,13 @@ public class WireHopperTest {
         // verify method generates appropriate task
         clientExecutor.set(executorService);
         subscriptionManager.setCurrentLocus(RcaConsts.RcaTagConstants.LOCUS_DATA_NODE);
-        ClusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
+
+        ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
+        clusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
                 ClusterDetailsEventProcessorTestHelper.newNodeDetails(NODE1, LOCALHOST, false),
                 ClusterDetailsEventProcessorTestHelper.newNodeDetails(node.name(), LOCALHOST, false)
         ));
+        uut.getAppContext().setClusterDetailsEventProcessor(clusterDetailsEventProcessor);
         uut.sendIntent(msg);
         WaitFor.waitFor(() -> subscriptionManager.getSubscribersFor(node.name()).size() == 1, 5,
                 TimeUnit.SECONDS);
@@ -138,10 +142,13 @@ public class WireHopperTest {
         subscriptionManager.setCurrentLocus(LOCUS);
         subscriptionManager.addSubscriber(NODE1, LOCALHOST, LOCUS);
         // verify sendData works
-        ClusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
+        ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
+        clusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
                 ClusterDetailsEventProcessorTestHelper.newNodeDetails(NODE1, LOCALHOST, false),
                 ClusterDetailsEventProcessorTestHelper.newNodeDetails(NODE2, LOCALHOST, false)
         ));
+        uut.getAppContext().setClusterDetailsEventProcessor(clusterDetailsEventProcessor);
+
         uut.sendData(msg);
         WaitFor.waitFor(() -> nodeStateManager.getLastReceivedTimestamp(NODE1, LOCALHOST) != 0, 1,
                 TimeUnit.SECONDS);
@@ -165,9 +172,13 @@ public class WireHopperTest {
         uut.readFromWire(node);
         // Execute test method and verify return value
         clientExecutor.set(executorService);
-        ClusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(
+
+        ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
+        clusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(
                 ClusterDetailsEventProcessorTestHelper.newNodeDetails(
                         node.name(), LOCALHOST, false)));
+        uut.getAppContext().setClusterDetailsEventProcessor(clusterDetailsEventProcessor);
+
         subscriptionManager.setCurrentLocus(RcaConsts.RcaTagConstants.LOCUS_DATA_NODE);
         subscriptionManager.addPublisher(node.name(), LOCALHOST);
         subscriptionManager.addPublisher(node.name(), HOST_NOT_IN_CLUSTER);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistFlowUnitAndSummaryTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistFlowUnitAndSummaryTest.java
@@ -149,7 +149,9 @@ public class PersistFlowUnitAndSummaryTest {
             persistable,
             new WireHopper(null, null, null, null,
                 null, new AppContext()),
-            instanceDetails);
+            new AppContext()
+            //instanceDetails
+            );
     ThreadProvider threadProvider = new ThreadProvider();
     Thread rcaSchedulerThread =
         threadProvider.createThreadForRunnable(scheduler::start, PerformanceAnalyzerThreads.RCA_SCHEDULER);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCASchedulerTaskTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCASchedulerTaskTests.java
@@ -254,7 +254,7 @@ public class RCASchedulerTaskTests {
             null,
             conf,
             wireHopper,
-            new InstanceDetails(AllMetrics.NodeRole.UNKNOWN));
+            new AppContext());
       }
     }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCASchedulerTaskTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCASchedulerTaskTests.java
@@ -17,6 +17,8 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler;
 
 import static org.junit.Assert.assertEquals;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.AnalysisGraph;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
@@ -28,6 +30,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Queryable;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.DataMsg;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.IntentMsg;
@@ -218,7 +221,7 @@ public class RCASchedulerTaskTests {
       }
 
       private WireHopperDerived(List<IntentMsg> intentMsg, DataMsg dataMsg) {
-        super(null, null, null, null, null);
+        super(null, null, null, null, null, new AppContext());
         this.intentMsgs = intentMsg;
         this.dataMsg = dataMsg;
       }
@@ -250,7 +253,8 @@ public class RCASchedulerTaskTests {
             null,
             null,
             conf,
-            wireHopper);
+            wireHopper,
+            new InstanceDetails(AllMetrics.NodeRole.UNKNOWN));
       }
     }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RcaSchedulerAsyncTaskTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RcaSchedulerAsyncTaskTest.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.AnalysisGraph;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Symptom;
@@ -24,6 +25,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Sched_Waittime;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.ConnectedComponent;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.spec.MetricsDBProviderTestHelper;
@@ -122,7 +124,8 @@ public class RcaSchedulerAsyncTaskTest {
           new MetricsDBProviderTestHelper(true),
           null,
           new RcaConf(Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca.conf").toString()),
-          null);
+          null,
+          new InstanceDetails(AllMetrics.NodeRole.UNKNOWN));
     }
 
     @Override

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RcaSchedulerAsyncTaskTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RcaSchedulerAsyncTaskTest.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.AnalysisGraph;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
@@ -29,6 +30,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.uti
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.spec.MetricsDBProviderTestHelper;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -125,7 +127,7 @@ public class RcaSchedulerAsyncTaskTest {
           null,
           new RcaConf(Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca.conf").toString()),
           null,
-          new InstanceDetails(AllMetrics.NodeRole.UNKNOWN));
+          new AppContext());
     }
 
     @Override

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ResourceHeatMapGraphTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ResourceHeatMapGraphTest.java
@@ -188,7 +188,7 @@ public class ResourceHeatMapGraphTest {
             persistable,
             rcaConf,
             wireHopper,
-            instanceDetails);
+            appContext);
 
     RcaTestHelper.setMyIp(instanceDetails.getInstanceIp(), instanceDetails.getRole());
     rcaSchedulerTaskData.run();
@@ -293,7 +293,7 @@ public class ResourceHeatMapGraphTest {
             persistable,
             rcaConf2,
             wireHopper2,
-            instanceDetails);
+            appContext);
     AllMetrics.NodeRole nodeRole2 = instanceDetails.getRole();
     RcaTestHelper.setMyIp(instanceDetails.getInstanceIp(), nodeRole2);
     rcaSchedulerTaskMaster.run();
@@ -1085,7 +1085,7 @@ public class ResourceHeatMapGraphTest {
             persistable,
             rcaConf,
             wireHopper,
-            dataInstance);
+            appContext);
     AllMetrics.NodeRole nodeRole = dataInstance.getRole();
     RcaTestHelper.setMyIp(dataInstance.getInstanceIp(), nodeRole);
     rcaSchedulerTaskData.run();
@@ -1114,7 +1114,7 @@ public class ResourceHeatMapGraphTest {
             persistable,
             rcaConf2,
             wireHopper2,
-            masterInstance);
+            appContextMaster);
     AllMetrics.NodeRole nodeRole2 = masterInstance.getRole();
     RcaTestHelper.setMyIp(masterInstance.getInstanceIp(), nodeRole2);
     rcaSchedulerTaskMaster.run();

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ResourceHeatMapGraphTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ResourceHeatMapGraphTest.java
@@ -132,7 +132,7 @@ public class ResourceHeatMapGraphTest {
     AllMetrics.NodeRole nodeRole2 = AllMetrics.NodeRole.ELECTED_MASTER;
     AppContext appContext = RcaTestHelper.setMyIp("192.168.0.2", nodeRole2);
     connectionManager = new GRPCConnectionManager(false);
-    clientServers = PerformanceAnalyzerApp.createClientServers(connectionManager);
+    clientServers = PerformanceAnalyzerApp.createClientServers(connectionManager, new AppContext());
 
     HttpServer httpServer = clientServers.getHttpServer();
     httpServer.start();

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ResourceHeatMapGraphTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ResourceHeatMapGraphTest.java
@@ -173,7 +173,7 @@ public class ResourceHeatMapGraphTest {
         new SubscriptionManager(new GRPCConnectionManager(false));
     subscriptionManager.setCurrentLocus(rcaConf.getTagMap().get("locus"));
 
-    WireHopper wireHopper = new WireHopper(new NodeStateManager(), clientServers.getNetClient(),
+    WireHopper wireHopper = new WireHopper(new NodeStateManager(new AppContext()), clientServers.getNetClient(),
         subscriptionManager,
         networkThreadPoolReference,
         new ReceivedFlowUnitStore(rcaConf.getPerVertexBufferLength()), appContext);
@@ -278,7 +278,7 @@ public class ResourceHeatMapGraphTest {
     subscriptionManager2.setCurrentLocus(rcaConf2.getTagMap().get("locus"));
 
 
-    WireHopper wireHopper2 = new WireHopper(new NodeStateManager(), clientServers.getNetClient(),
+    WireHopper wireHopper2 = new WireHopper(new NodeStateManager(new AppContext()), clientServers.getNetClient(),
         subscriptionManager2,
         networkThreadPoolReference,
         new ReceivedFlowUnitStore(rcaConf.getPerVertexBufferLength()), appContext);
@@ -1071,7 +1071,7 @@ public class ResourceHeatMapGraphTest {
 
     AppContext appContext = RcaTestHelper.setMyIp("192.168.0.1", AllMetrics.NodeRole.DATA);
 
-    WireHopper wireHopper = new WireHopper(new NodeStateManager(), clientServers.getNetClient(),
+    WireHopper wireHopper = new WireHopper(new NodeStateManager(new AppContext()), clientServers.getNetClient(),
         subscriptionManager,
         networkThreadPoolReference,
         new ReceivedFlowUnitStore(rcaConf.getPerVertexBufferLength()), appContext);
@@ -1099,7 +1099,7 @@ public class ResourceHeatMapGraphTest {
 
     AppContext appContextMaster = RcaTestHelper.setMyIp("192.168.0.4", AllMetrics.NodeRole.ELECTED_MASTER);
 
-    WireHopper wireHopper2 = new WireHopper(new NodeStateManager(), clientServers.getNetClient(),
+    WireHopper wireHopper2 = new WireHopper(new NodeStateManager(new AppContext()), clientServers.getNetClient(),
         subscriptionManager2,
         networkThreadPoolReference,
         new ReceivedFlowUnitStore(rcaConf.getPerVertexBufferLength()), appContextMaster);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtilsTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtilsTest.java
@@ -1,9 +1,13 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.util;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
 import com.google.common.collect.Lists;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -14,39 +18,34 @@ public class ClusterUtilsTest {
     private static final ClusterDetailsEventProcessor.NodeDetails EMPTY_DETAILS =
             ClusterDetailsEventProcessorTestHelper.newNodeDetails("", "", false);
 
+    private List<InstanceDetails> getInstancesFromHost(List<String> hostIps) {
+        List<InstanceDetails> instances = new ArrayList<>();
+        for (String ip: hostIps) {
+            InstanceDetails instance = new InstanceDetails(AllMetrics.NodeRole.UNKNOWN, "", ip, false);
+            instances.add(instance);
+        }
+        return instances;
+    }
+
     @Before
     public void setup() {
         ClusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(EMPTY_DETAILS));
     }
 
     @Test
-    public void testGetAllPeerHostAddresses() {
-        // method should behave when fed an empty list of peers
-        Assert.assertEquals(Collections.emptyList(), ClusterUtils.getAllPeerHostAddresses());
-        // method should not include the current node in the list of peers
-        ClusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
-                ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, HOST, false)
-        ));
-        Assert.assertEquals(Collections.emptyList(), ClusterUtils.getAllPeerHostAddresses());
-        // method should return the appropriate peers when peers exist
-        ClusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
-                ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, HOST, false),
-                ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, HOST2, false)
-        ));
-        Assert.assertEquals(Collections.singletonList(HOST2), ClusterUtils.getAllPeerHostAddresses());
-    }
-
-    @Test
     public void testIsHostAddressInCluster() {
-        // Explicitly reset ClusterDetailsEventProcessor. Test fails on mac otherwise.
-        ClusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(EMPTY_DETAILS));
         // method should return false when there are no peers
-        Assert.assertFalse(ClusterUtils.isHostAddressInCluster(HOST));
+        Assert.assertFalse(ClusterUtils.isHostAddressInCluster(HOST, getInstancesFromHost(Collections.EMPTY_LIST)));
         // method should properly recognize which hosts are peers and which aren't
         ClusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
                 ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, HOST, false)
         ));
-        Assert.assertTrue(ClusterUtils.isHostAddressInCluster(HOST));
-        Assert.assertFalse(ClusterUtils.isHostAddressInCluster(HOST2));
+
+
+
+        List<InstanceDetails> instances = getInstancesFromHost(Collections.singletonList(HOST));
+
+        Assert.assertTrue(ClusterUtils.isHostAddressInCluster(HOST, instances));
+        Assert.assertFalse(ClusterUtils.isHostAddressInCluster(HOST2, instances));
     }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtilsTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtilsTest.java
@@ -20,15 +20,6 @@ public class ClusterUtilsTest {
     }
 
     @Test
-    public void testGetCurrentHostAddress() {
-        Assert.assertEquals(ClusterUtils.EMPTY_STRING, ClusterUtils.getCurrentNodeHostAddress());
-        ClusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(
-                ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, HOST, false)
-        ));
-        Assert.assertEquals(HOST, ClusterUtils.getCurrentNodeHostAddress());
-    }
-
-    @Test
     public void testGetAllPeerHostAddresses() {
         // method should behave when fed an empty list of peers
         Assert.assertEquals(Collections.emptyList(), ClusterUtils.getAllPeerHostAddresses());

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessorTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessorTests.java
@@ -18,6 +18,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.MasterPendingValue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.MetricName;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
@@ -52,7 +53,7 @@ public class ReaderMetricsProcessorTests extends AbstractReaderTests {
   @Test
   public void testReaderMetricsProcessorFrequently() throws Exception {
     deleteAll();
-    ReaderMetricsProcessor mp = new ReaderMetricsProcessor(rootLocation, true);
+    ReaderMetricsProcessor mp = new ReaderMetricsProcessor(rootLocation, true, new AppContext());
 
     mp.processMetrics(rootLocation, 1566413975000L);
     mp.processMetrics(rootLocation, 1566413980000L);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/HotNodeClusterRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/HotNodeClusterRcaTest.java
@@ -18,7 +18,9 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.store.rca;
 
 import static java.time.Instant.ofEpochMilli;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.Resource;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Rca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.RcaTestHelper;
@@ -30,11 +32,14 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HotNodeClusterRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
 import java.sql.SQLException;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,21 +47,34 @@ import org.junit.experimental.categories.Category;
 
 @Category(GradleTaskForRca.class)
 public class HotNodeClusterRcaTest {
-
+  private AppContext appContext;
 
   @Before
   public void setupCluster() throws SQLException, ClassNotFoundException {
-    ClusterDetailsEventProcessorTestHelper clusterDetailsEventProcessorTestHelper = new ClusterDetailsEventProcessorTestHelper();
-    clusterDetailsEventProcessorTestHelper.addNodeDetails("node1", "127.0.0.0", false);
-    clusterDetailsEventProcessorTestHelper.addNodeDetails("node2", "127.0.0.1", false);
-    clusterDetailsEventProcessorTestHelper.addNodeDetails("node3", "127.0.0.2", false);
-    clusterDetailsEventProcessorTestHelper.generateClusterDetailsEvent();
+    ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
+    ClusterDetailsEventProcessor.NodeDetails node1 =
+        new ClusterDetailsEventProcessor.NodeDetails(AllMetrics.NodeRole.DATA, "node1", "127.0.0.0", false);
+    ClusterDetailsEventProcessor.NodeDetails node2 =
+        new ClusterDetailsEventProcessor.NodeDetails(AllMetrics.NodeRole.DATA, "node2", "127.0.0.1", false);
+    ClusterDetailsEventProcessor.NodeDetails node3 =
+        new ClusterDetailsEventProcessor.NodeDetails(AllMetrics.NodeRole.DATA, "node3", "127.0.0.2", false);
+
+    List<ClusterDetailsEventProcessor.NodeDetails> nodes = new ArrayList<>();
+    nodes.add(node1);
+    nodes.add(node2);
+    nodes.add(node3);
+    clusterDetailsEventProcessor.setNodesDetails(nodes);
+
+    appContext = new AppContext();
+    appContext.setClusterDetailsEventProcessor(clusterDetailsEventProcessor);
   }
 
   @Test
   public void testNodeCntThresholdAndTimestampExpiration() {
     RcaTestHelper nodeRca = new RcaTestHelper();
+    nodeRca.setAppContext(appContext);
     HotNodeClusterRcaX clusterRca = new HotNodeClusterRcaX(1, nodeRca);
+    clusterRca.setAppContext(appContext);
 
     Clock constantClock = Clock.fixed(ofEpochMilli(0), ZoneId.systemDefault());
     clusterRca.setClock(constantClock);
@@ -78,7 +96,9 @@ public class HotNodeClusterRcaTest {
   public void testCaptureHotNode() {
     ResourceFlowUnit fu;
     RcaTestHelper nodeRca = new RcaTestHelper();
+    nodeRca.setAppContext(appContext);
     HotNodeClusterRcaX clusterRca = new HotNodeClusterRcaX(1, nodeRca);
+    clusterRca.setAppContext(appContext);
 
     //medium = 5, below the 30% threshold
     nodeRca.mockFlowUnit(generateFlowUnit(ResourceUtil.OLD_GEN_HEAP_USAGE, 4, "node1"));
@@ -110,7 +130,9 @@ public class HotNodeClusterRcaTest {
   //check whether can filter out noise data if the resource usage is very small
   public void testFilterNoiseData() {
     RcaTestHelper nodeRca = new RcaTestHelper();
+    nodeRca.setAppContext(appContext);
     HotNodeClusterRcaX clusterRca = new HotNodeClusterRcaX(1, nodeRca);
+    clusterRca.setAppContext(appContext);
 
     //medium = 0.2, 0.8 is above the 30% threshold. but since the data is too small, we will drop it
     nodeRca.mockFlowUnit(generateFlowUnit(ResourceUtil.OLD_GEN_HEAP_USAGE, 0.1, "node1"));

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/HotNodeClusterRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/HotNodeClusterRcaTest.java
@@ -50,7 +50,7 @@ public class HotNodeClusterRcaTest {
   private AppContext appContext;
 
   @Before
-  public void setupCluster() throws SQLException, ClassNotFoundException {
+  public void setupCluster() {
     ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
     ClusterDetailsEventProcessor.NodeDetails node1 =
         new ClusterDetailsEventProcessor.NodeDetails(AllMetrics.NodeRole.DATA, "node1", "127.0.0.0", false);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/cluster/BaseClusterRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/cluster/BaseClusterRcaTest.java
@@ -17,6 +17,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.store.rca.cluste
 
 import static java.time.Instant.ofEpochMilli;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.Resource;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.NodeRole;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
@@ -28,11 +29,14 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.BaseClusterRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
 import java.sql.SQLException;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Before;
@@ -47,23 +51,41 @@ public class BaseClusterRcaTest {
   private Resource type1;
   private Resource type2;
   private Resource invalidType;
-
-  @Before
-  public void setupCluster() throws SQLException, ClassNotFoundException {
-    ClusterDetailsEventProcessorTestHelper clusterDetailsEventProcessorTestHelper = new ClusterDetailsEventProcessorTestHelper();
-    clusterDetailsEventProcessorTestHelper.addNodeDetails("node1", "127.0.0.0", false);
-    clusterDetailsEventProcessorTestHelper.addNodeDetails("node2", "127.0.0.1", false);
-    clusterDetailsEventProcessorTestHelper.addNodeDetails("node3", "127.0.0.2", false);
-    clusterDetailsEventProcessorTestHelper.addNodeDetails("master", "127.0.0.9", NodeRole.ELECTED_MASTER, true);
-    clusterDetailsEventProcessorTestHelper.generateClusterDetailsEvent();
-  }
+  private AppContext appContext;
 
   @Before
   public void init() {
+    ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
+    ClusterDetailsEventProcessor.NodeDetails node1 =
+        new ClusterDetailsEventProcessor.NodeDetails(NodeRole.DATA, "node1", "127.0.0.0", false);
+    ClusterDetailsEventProcessor.NodeDetails node2 =
+        new ClusterDetailsEventProcessor.NodeDetails(NodeRole.DATA, "node2", "127.0.0.1", false);
+    ClusterDetailsEventProcessor.NodeDetails node3 =
+        new ClusterDetailsEventProcessor.NodeDetails(NodeRole.DATA, "node3", "127.0.0.2", false);
+    ClusterDetailsEventProcessor.NodeDetails master =
+        new ClusterDetailsEventProcessor.NodeDetails(NodeRole.ELECTED_MASTER, "master", "127.0.0.9", true);
+
+    List<ClusterDetailsEventProcessor.NodeDetails> nodes = new ArrayList<>();
+    nodes.add(node1);
+    nodes.add(node2);
+    nodes.add(node3);
+    nodes.add(master);
+    clusterDetailsEventProcessor.setNodesDetails(nodes);
+
+    appContext = new AppContext();
+    appContext.setClusterDetailsEventProcessor(clusterDetailsEventProcessor);
+
     nodeRca = new RcaTestHelper<>("RCA1");
+    nodeRca.setAppContext(appContext);
+
     nodeRca2 = new RcaTestHelper<>("RCA2");
+    nodeRca2.setAppContext(appContext);
+
     invalidType = ResourceUtil.OLD_GEN_HEAP_USAGE;
+
     clusterRca = new BaseClusterRca(1, nodeRca, nodeRca2);
+    clusterRca.setAppContext(appContext);
+
     type1 = ResourceUtil.OLD_GEN_HEAP_USAGE;
     type2 = ResourceUtil.CPU_USAGE;
   }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotshard/HotShardClusterRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotshard/HotShardClusterRcaTest.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.store.rca.hotshard;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.RcaTestHelper;
@@ -25,6 +26,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotshard.HotShardClusterRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -65,8 +67,20 @@ public class HotShardClusterRcaTest {
 
             InstanceDetails instanceDetails =
                 new InstanceDetails(AllMetrics.NodeRole.DATA, "node1", "127.0.0.1", false);
-            hotShardRca.setInstanceDetails(instanceDetails);
-            hotShardClusterRca.setInstanceDetails(instanceDetails);
+            ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
+            clusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(
+                new ClusterDetailsEventProcessor.NodeDetails(
+                    AllMetrics.NodeRole.DATA,
+                    "node1",
+                    "127.0.0.1",
+                    false
+                )
+            ));
+            AppContext appContext = new AppContext();
+            appContext.setClusterDetailsEventProcessor(clusterDetailsEventProcessor);
+
+            hotShardRca.setAppContext(appContext);
+            hotShardClusterRca.setAppContext(appContext);
         } catch (Exception e) {
             Assert.assertTrue("Exception when generating cluster details event", false);
             return;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotshard/HotShardClusterRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotshard/HotShardClusterRcaTest.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.store.rca.hotshard;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.RcaTestHelper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Resources;
@@ -22,13 +23,11 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotshard.HotShardClusterRca;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,8 +39,6 @@ public class HotShardClusterRcaTest {
     private RcaTestHelper hotShardRca;
 
     private HotShardClusterRca hotShardClusterRca;
-
-    private ClusterDetailsEventProcessorTestHelper clusterDetailsEventProcessorTestHelper;
 
     private enum index {
         index_1,
@@ -65,10 +62,11 @@ public class HotShardClusterRcaTest {
         try {
             hotShardRca = new RcaTestHelper<HotNodeSummary>();
             hotShardClusterRca = new HotShardClusterRca(1, hotShardRca);
-            clusterDetailsEventProcessorTestHelper = new ClusterDetailsEventProcessorTestHelper();
-            clusterDetailsEventProcessorTestHelper.addNodeDetails("node1", "127.0.0.0", false);
-            clusterDetailsEventProcessorTestHelper.addNodeDetails("node2", "127.0.0.1", false);
-            clusterDetailsEventProcessorTestHelper.generateClusterDetailsEvent();
+
+            InstanceDetails instanceDetails =
+                new InstanceDetails(AllMetrics.NodeRole.DATA, "node1", "127.0.0.1", false);
+            hotShardRca.setInstanceDetails(instanceDetails);
+            hotShardClusterRca.setInstanceDetails(instanceDetails);
         } catch (Exception e) {
             Assert.assertTrue("Exception when generating cluster details event", false);
             return;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotshard/HotShardRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotshard/HotShardRcaTest.java
@@ -4,6 +4,7 @@ import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.Al
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CommonDimension.SHARD_ID;
 import static java.time.Instant.ofEpochMilli;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
@@ -12,6 +13,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotShardSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotshard.HotShardRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
 
@@ -36,8 +38,6 @@ public class HotShardRcaTest {
     private MetricTestHelper ioTotSyscallRate;
     private List<String> columnName;
 
-    private ClusterDetailsEventProcessorTestHelper clusterDetailsEventProcessorTestHelper;
-
     private enum index {
         index_1,
         index_2
@@ -52,14 +52,9 @@ public class HotShardRcaTest {
                 cpuUtilization, ioTotThroughput, ioTotSyscallRate);
         columnName = Arrays.asList(INDEX_NAME.toString(), SHARD_ID.toString(), MetricsDB.SUM);
 
-        try {
-            clusterDetailsEventProcessorTestHelper = new ClusterDetailsEventProcessorTestHelper();
-            clusterDetailsEventProcessorTestHelper.addNodeDetails("node1", "127.0.0.0", false);
-            clusterDetailsEventProcessorTestHelper.generateClusterDetailsEvent();
-        } catch (Exception e) {
-            Assert.assertTrue("Exception when generating cluster details event", false);
-            return;
-        }
+        InstanceDetails instanceDetails =
+            new InstanceDetails(AllMetrics.NodeRole.DATA, "node1", "127.0.0.1", false);
+        hotShardRcaX.setInstanceDetails(instanceDetails);
     }
 
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotshard/HotShardRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotshard/HotShardRcaTest.java
@@ -4,6 +4,7 @@ import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.Al
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CommonDimension.SHARD_ID;
 import static java.time.Instant.ofEpochMilli;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
@@ -13,17 +14,14 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotShardSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotshard.HotShardRca;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
-
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,9 +50,17 @@ public class HotShardRcaTest {
                 cpuUtilization, ioTotThroughput, ioTotSyscallRate);
         columnName = Arrays.asList(INDEX_NAME.toString(), SHARD_ID.toString(), MetricsDB.SUM);
 
-        InstanceDetails instanceDetails =
-            new InstanceDetails(AllMetrics.NodeRole.DATA, "node1", "127.0.0.1", false);
-        hotShardRcaX.setInstanceDetails(instanceDetails);
+        ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
+        clusterDetailsEventProcessor.setNodesDetails(
+            Collections.singletonList(new ClusterDetailsEventProcessor.NodeDetails(
+                AllMetrics.NodeRole.DATA,
+                "node1",
+                "127.0.0.1",
+                false))
+        );
+        AppContext appContext = new AppContext();
+        appContext.setClusterDetailsEventProcessor(clusterDetailsEventProcessor);
+        hotShardRcaX.setAppContext(appContext);
     }
 
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/threadpool/QueueRejectionRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/threadpool/QueueRejectionRcaTest.java
@@ -28,7 +28,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.threadpool.QueueRejectionRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import java.time.Clock;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/threadpool/QueueRejectionRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/threadpool/QueueRejectionRcaTest.java
@@ -18,6 +18,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.store.rca.thread
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolDimension.THREAD_POOL_TYPE;
 import static java.time.Instant.ofEpochMilli;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolType;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
@@ -26,8 +27,10 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.threadpool.QueueRejectionRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
+import com.sun.org.apache.bcel.internal.generic.INSTANCEOF;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.ZoneId;
@@ -62,9 +65,10 @@ public class QueueRejectionRcaTest {
     threadPool_RejectedReqs = new MetricTestHelper(5);
     queueRejectionRca = new QueueRejectionRca(1, threadPool_RejectedReqs);
     columnName = Arrays.asList(THREAD_POOL_TYPE.toString(), MetricsDB.MAX);
-    ClusterDetailsEventProcessorTestHelper clusterDetailsEventProcessorTestHelper = new ClusterDetailsEventProcessorTestHelper();
-    clusterDetailsEventProcessorTestHelper.addNodeDetails("node1", "127.0.0.0", false);
-    clusterDetailsEventProcessorTestHelper.generateClusterDetailsEvent();
+
+    InstanceDetails instanceDetails =
+        new InstanceDetails(AllMetrics.NodeRole.DATA, "node1", "127.0.0.1", false);
+    queueRejectionRca.setInstanceDetails(instanceDetails);
   }
 
   @Test

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/threadpool/QueueRejectionRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/threadpool/QueueRejectionRcaTest.java
@@ -18,6 +18,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.store.rca.thread
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolDimension.THREAD_POOL_TYPE;
 import static java.time.Instant.ofEpochMilli;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolType;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
@@ -29,12 +30,12 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.threadpool.QueueRejectionRca;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
-import com.sun.org.apache.bcel.internal.generic.INSTANCEOF;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
@@ -66,9 +67,19 @@ public class QueueRejectionRcaTest {
     queueRejectionRca = new QueueRejectionRca(1, threadPool_RejectedReqs);
     columnName = Arrays.asList(THREAD_POOL_TYPE.toString(), MetricsDB.MAX);
 
-    InstanceDetails instanceDetails =
-        new InstanceDetails(AllMetrics.NodeRole.DATA, "node1", "127.0.0.1", false);
-    queueRejectionRca.setInstanceDetails(instanceDetails);
+    ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
+    clusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(
+        new ClusterDetailsEventProcessor.NodeDetails(
+            AllMetrics.NodeRole.DATA,
+            "node1",
+            "127.0.0.1",
+            false
+        )
+    ));
+    AppContext appContext = new AppContext();
+    appContext.setClusterDetailsEventProcessor(clusterDetailsEventProcessor);
+
+    queueRejectionRca.setAppContext(appContext);
   }
 
   @Test


### PR DESCRIPTION
Using the static classes have problems as one instance of JVM can have only one instance of the class running. ClusterDetailsEventProcessor is an important class as it contains the instance details. If we want to simutate multiple RCAControllers running as part of a single JVM for the purpose of IntegrationTest framework, we should make ClusterDetailsEventProcessor a non-static class, such that each RcaController can work with its own. This is not the complete removal of the static methods in the ClusterDetailsEventProcessor, but just making the RCA framework not use them. There will be follow up PRs that will eventually make ClusterDetailsEventProcessor non-static

*Issue #, if available:*

*Description of changes:*

*Tests:*

*Code coverage percentage for this patch:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
