### PR TITLE
Fix PersistFlowUnitAndSummaryTest

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,6 +5,7 @@ on:
     branches: 
       - master
       - dev
+      - rguo*
 
   pull_request:
     branches: 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,7 +5,6 @@ on:
     branches: 
       - master
       - dev
-      - rguo*
 
   pull_request:
     branches: 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistorBase.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistorBase.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jooq.Field;
+import org.jooq.exception.DataAccessException;
 
 // TODO: Scheme to rotate the current file and garbage collect older files.
 public abstract class PersistorBase implements Persistable {
@@ -211,7 +212,7 @@ public abstract class PersistorBase implements Persistable {
       T flowUnit, String tableName) throws SQLException, IOException {
     try {
         tryWriteFlowUnit(flowUnit, tableName);
-    } catch (SQLException e) {
+    } catch (SQLException | DataAccessException e) {
       LOG.info(
           "RCA: Fail to write to table '{}', try creating a new DB", tableName);
       rotateRegisterGarbageThenCreateNewDB(RotationType.FORCE_ROTATE);
@@ -220,7 +221,7 @@ public abstract class PersistorBase implements Persistable {
   }
 
   private <T extends ResourceFlowUnit> void tryWriteFlowUnit(
-          T flowUnit, String nodeName) throws SQLException {
+          T flowUnit, String nodeName) throws SQLException, DataAccessException {
     String tableName = ResourceFlowUnit.RCA_TABLE_NAME;
     if (!tableNames.contains(tableName)) {
       LOG.info(

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistorBase.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistorBase.java
@@ -214,7 +214,7 @@ public abstract class PersistorBase implements Persistable {
         tryWriteFlowUnit(flowUnit, tableName);
     } catch (SQLException | DataAccessException e) {
       LOG.info(
-          "RCA: Fail to write to table '{}', try creating a new DB", tableName);
+          "RCA: Fail to write to table '{}', creating a new DB file and retrying write/create operation", tableName);
       rotateRegisterGarbageThenCreateNewDB(RotationType.FORCE_ROTATE);
       tryWriteFlowUnit(flowUnit, tableName);
     }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistFlowUnitAndSummaryTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistFlowUnitAndSummaryTest.java
@@ -202,6 +202,8 @@ public class PersistFlowUnitAndSummaryTest {
       String readTableStr = persistable.read();
       System.out.println(readTableStr);
       if (readTableStr != null) {
+        // HighHeapUsageClusterRcaX is a cluster level RCA so it should not be scheduled and persisted on
+        // data node.
         return readTableStr.contains("HotResourceSummary") && readTableStr.contains("DummyYoungGenRca")
                 && readTableStr.contains("HotNodeSummary") && readTableStr.contains("HotNodeRcaX");
       }


### PR DESCRIPTION
*Issue #, if available:*
#284 

*Description of changes:*
Fix PersistFlowUnitAndSummaryTest in UTs

We found three issue when debugging this UT:
1. db contention. need to run those two UT tests in sequential order
2. DataAcessExecption is not handled  when persistor trys to create a new table 
3. the graph defined in UT was wrong. the node tag need to be changed with MASTER_DATA

*Tests:*

*Code coverage percentage for this patch:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
