### PR TITLE
make ClusterDetailsEventProcessor and all its access methods `non-static`

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaEnabledSampler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaEnabledSampler.java
@@ -31,7 +31,7 @@ public class RcaEnabledSampler implements ISampler {
   private final AppContext appContext;
 
   RcaEnabledSampler(final AppContext appContext) {
-    Objects.nonNull(appContext);
+    Objects.requireNonNull(appContext);
     this.appContext = appContext;
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaEnabledSampler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaEnabledSampler.java
@@ -15,15 +15,25 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.samplers;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaController;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaRuntimeMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.collectors.SampleAggregator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.emitters.ISampler;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor.NodeDetails;
 import com.google.common.annotations.VisibleForTesting;
+import java.util.Objects;
+import javax.annotation.Nonnull;
 
 public class RcaEnabledSampler implements ISampler {
+  private final AppContext appContext;
+
+  RcaEnabledSampler(final AppContext appContext) {
+    Objects.nonNull(appContext);
+    this.appContext = appContext;
+  }
 
   @Override
   public void sample(SampleAggregator sampleCollector) {
@@ -32,8 +42,8 @@ public class RcaEnabledSampler implements ISampler {
 
   @VisibleForTesting
   boolean isRcaEnabled() {
-    NodeDetails currentNode = ClusterDetailsEventProcessor.getCurrentNodeDetails();
-    if (currentNode != null && currentNode.getIsMasterNode()) {
+    InstanceDetails currentNode = appContext.getMyInstanceDetails();
+    if (currentNode != null && currentNode.getIsMaster()) {
       return RcaController.isRcaEnabled();
     }
     return false;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaStateSamplers.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaStateSamplers.java
@@ -15,11 +15,12 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.samplers;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.emitters.ISampler;
 
 public class RcaStateSamplers {
 
-  public static ISampler getRcaEnabledSampler() {
-    return new RcaEnabledSampler();
+  public static ISampler getRcaEnabledSampler(final AppContext appContext) {
+    return new RcaEnabledSampler(appContext);
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessor.java
@@ -38,7 +38,7 @@ public class ClusterDetailsEventProcessor implements EventProcessor {
   /**
    * keep a volatile immutable list to make the read/write to this list thread safe.
    */
-  private static volatile ImmutableList<NodeDetails> nodesDetails = null;
+  private volatile ImmutableList<NodeDetails> nodesDetails = null;
 
   @Override
   public void initializeProcessing(long startTime, long endTime) {}
@@ -92,11 +92,11 @@ public class ClusterDetailsEventProcessor implements EventProcessor {
 
   }
 
-  public static void setNodesDetails(List<NodeDetails> nodesDetails) {
-    ClusterDetailsEventProcessor.nodesDetails = ImmutableList.copyOf(nodesDetails);
+  public void setNodesDetails(final List<NodeDetails> nodesDetails) {
+    this.nodesDetails = ImmutableList.copyOf(nodesDetails);
   }
 
-  public static List<NodeDetails> getNodesDetails() {
+  public List<NodeDetails> getNodesDetails() {
     if (nodesDetails != null) {
       return nodesDetails.asList();
     } else {
@@ -104,7 +104,7 @@ public class ClusterDetailsEventProcessor implements EventProcessor {
     }
   }
 
-  public static List<NodeDetails> getDataNodesDetails() {
+  public List<NodeDetails> getDataNodesDetails() {
     List<NodeDetails> allNodes = getNodesDetails();
     if (allNodes.size() > 0) {
       return allNodes.stream()
@@ -115,8 +115,7 @@ public class ClusterDetailsEventProcessor implements EventProcessor {
     }
   }
 
-  @Deprecated
-  public static NodeDetails getCurrentNodeDetails() {
+  public NodeDetails getCurrentNodeDetails() {
     List<NodeDetails> allNodes = getNodesDetails();
     if (allNodes.size() > 0) {
       return allNodes.get(0);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/RcaStatsCollectorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/RcaStatsCollectorTest.java
@@ -15,9 +15,12 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
 
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp.PERIODIC_SAMPLE_AGGREGATOR;
+
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaTestHelper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.AnalysisGraph;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
@@ -35,6 +38,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.uti
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.RCASchedulerTask;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.spec.MetricsDBProviderTestHelper;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.emitters.PeriodicSamplers;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import java.nio.file.Paths;
@@ -43,6 +47,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -131,6 +136,11 @@ public class RcaStatsCollectorTest {
     }
     for (JvmMetrics jvmMetrics1: jvmMetrics) {
       if (!verify(jvmMetrics1)) {
+        PerformanceAnalyzerApp.PERIODIC_SAMPLERS = new PeriodicSamplers(PERIODIC_SAMPLE_AGGREGATOR,
+            PerformanceAnalyzerApp.getAllSamplers(appContext),
+                (MetricsConfiguration.CONFIG_MAP.get(StatsCollector.class).samplingInterval) / 2,
+                TimeUnit.MILLISECONDS);
+
         PerformanceAnalyzerApp.PERIODIC_SAMPLERS.run();
       }
       Assert.assertTrue(verify(jvmMetrics1));

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaEnabledSamplerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaEnabledSamplerTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaController;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaRuntimeMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.collectors.SampleAggregator;
@@ -18,6 +19,7 @@ import org.mockito.MockitoAnnotations;
 
 public class RcaEnabledSamplerTest {
     private RcaEnabledSampler uut;
+    private AppContext appContext;
 
     @Mock
     private SampleAggregator sampleAggregator;
@@ -25,7 +27,8 @@ public class RcaEnabledSamplerTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        uut = new RcaEnabledSampler();
+        appContext = new AppContext();
+        uut = new RcaEnabledSampler(appContext);
     }
 
     @Test
@@ -33,10 +36,14 @@ public class RcaEnabledSamplerTest {
         assertFalse(uut.isRcaEnabled());
         ClusterDetailsEventProcessor.NodeDetails details =
                 ClusterDetailsEventProcessorTestHelper.newNodeDetails("", "", false);
-        ClusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(details));
+
+        ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
+        clusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(details));
+        appContext.setClusterDetailsEventProcessor(clusterDetailsEventProcessor);
+
         assertFalse(uut.isRcaEnabled());
         details = ClusterDetailsEventProcessorTestHelper.newNodeDetails("", "", true);
-        ClusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(details));
+        clusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(details));
         assertEquals(RcaController.isRcaEnabled(), uut.isRcaEnabled());
     }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaStateSamplersTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaStateSamplersTest.java
@@ -3,6 +3,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.samplers;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaController;
 import org.junit.Before;
 import org.junit.Test;
@@ -16,6 +17,6 @@ public class RcaStateSamplersTest {
     public void testGetRcaEnabledSampler() {  // done for constructor coverage
         uut = new RcaStateSamplers();
         assertSame(uut.getClass(), RcaStateSamplers.class);
-        assertTrue(RcaStateSamplers.getRcaEnabledSampler() instanceof RcaEnabledSampler);
+        assertTrue(RcaStateSamplers.getRcaEnabledSampler(new AppContext()) instanceof RcaEnabledSampler);
     }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtilsTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtilsTest.java
@@ -17,6 +17,7 @@ public class ClusterUtilsTest {
     private static final String HOST2 = "127.0.0.2";
     private static final ClusterDetailsEventProcessor.NodeDetails EMPTY_DETAILS =
             ClusterDetailsEventProcessorTestHelper.newNodeDetails("", "", false);
+    private ClusterDetailsEventProcessor clusterDetailsEventProcessor;
 
     private List<InstanceDetails> getInstancesFromHost(List<String> hostIps) {
         List<InstanceDetails> instances = new ArrayList<>();
@@ -29,7 +30,8 @@ public class ClusterUtilsTest {
 
     @Before
     public void setup() {
-        ClusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(EMPTY_DETAILS));
+        clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
+        clusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(EMPTY_DETAILS));
     }
 
     @Test
@@ -37,7 +39,7 @@ public class ClusterUtilsTest {
         // method should return false when there are no peers
         Assert.assertFalse(ClusterUtils.isHostAddressInCluster(HOST, getInstancesFromHost(Collections.EMPTY_LIST)));
         // method should properly recognize which hosts are peers and which aren't
-        ClusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
+        clusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
                 ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, HOST, false)
         ));
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessorTestHelper.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessorTestHelper.java
@@ -44,9 +44,9 @@ public class ClusterDetailsEventProcessorTestHelper extends AbstractReaderTests 
     return createNodeDetails(nodeId, address, isMasterNode);
   }
 
-  public void generateClusterDetailsEvent() {
+  public ClusterDetailsEventProcessor generateClusterDetailsEvent() {
     if (nodeDetails.isEmpty()) {
-      return;
+      return new ClusterDetailsEventProcessor();
     }
     StringBuilder stringBuilder = new StringBuilder().append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds());
     nodeDetails.stream().forEach(
@@ -58,5 +58,6 @@ public class ClusterDetailsEventProcessorTestHelper extends AbstractReaderTests 
     Event testEvent = new Event("", stringBuilder.toString(), 0);
     ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
     clusterDetailsEventProcessor.processEvent(testEvent);
+    return clusterDetailsEventProcessor;
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessorTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessorTests.java
@@ -38,17 +38,18 @@ public class ClusterDetailsEventProcessorTests {
     String address2 = "10.212.52.241";
     boolean isMasterNode2 = false;
 
+    ClusterDetailsEventProcessor clusterDetailsEventProcessor;
     try {
       ClusterDetailsEventProcessorTestHelper clusterDetailsEventProcessorTestHelper = new ClusterDetailsEventProcessorTestHelper();
       clusterDetailsEventProcessorTestHelper.addNodeDetails(nodeId1, address1, isMasterNode1);
       clusterDetailsEventProcessorTestHelper.addNodeDetails(nodeId2, address2, isMasterNode2);
-      clusterDetailsEventProcessorTestHelper.generateClusterDetailsEvent();
+      clusterDetailsEventProcessor = clusterDetailsEventProcessorTestHelper.generateClusterDetailsEvent();
     } catch (Exception e) {
       Assert.assertTrue("got exception when generating cluster details event", false);
       return;
     }
 
-    List<NodeDetails> nodes = ClusterDetailsEventProcessor.getNodesDetails();
+    List<NodeDetails> nodes = clusterDetailsEventProcessor.getNodesDetails();
 
     assertEquals(nodeId1, nodes.get(0).getId());
     assertEquals(address1, nodes.get(0).getHostAddress());

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/cluster/BaseClusterRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/cluster/BaseClusterRcaTest.java
@@ -246,7 +246,8 @@ public class BaseClusterRcaTest {
     Assert.assertTrue(flowUnit.getResourceContext().isUnhealthy());
     Assert.assertEquals(2, flowUnit.getSummary().getNumOfUnhealthyNodes());
 
-    removeNodeFromCluster();
+    ClusterDetailsEventProcessor clusterDetailsEventProcessor = removeNodeFromCluster();
+    appContext.setClusterDetailsEventProcessor(clusterDetailsEventProcessor);
 
     nodeRca.mockFlowUnit();
     flowUnit = clusterRca.operate();
@@ -268,9 +269,10 @@ public class BaseClusterRcaTest {
     Assert.assertEquals(1, flowUnit.getSummary().getNumOfUnhealthyNodes());
     Assert.assertTrue(compareNodeSummary("node1", type1, flowUnit.getSummary().getHotNodeSummaryList().get(0)));
 
-    addNewNodeIntoCluster();
+    ClusterDetailsEventProcessor clusterDetailsEventProcessor = addNewNodeIntoCluster();
 
     nodeRca.mockFlowUnit();
+    appContext.setClusterDetailsEventProcessor(clusterDetailsEventProcessor);
     flowUnit = clusterRca.operate();
     Assert.assertTrue(flowUnit.getResourceContext().isUnhealthy());
     Assert.assertEquals(1, flowUnit.getSummary().getNumOfUnhealthyNodes());
@@ -285,22 +287,22 @@ public class BaseClusterRcaTest {
     Assert.assertTrue(compareNodeSummary("node4", type2, clusterSummary.getHotNodeSummaryList().get(1)));
   }
 
-   private void removeNodeFromCluster() throws SQLException, ClassNotFoundException {
+   private ClusterDetailsEventProcessor removeNodeFromCluster() throws SQLException, ClassNotFoundException {
     ClusterDetailsEventProcessorTestHelper clusterDetailsEventProcessorTestHelper = new ClusterDetailsEventProcessorTestHelper();
     clusterDetailsEventProcessorTestHelper.addNodeDetails("node2", "127.0.0.1", false);
     clusterDetailsEventProcessorTestHelper.addNodeDetails("node3", "127.0.0.2", false);
     clusterDetailsEventProcessorTestHelper.addNodeDetails("master", "127.0.0.9", NodeRole.ELECTED_MASTER, true);
-    clusterDetailsEventProcessorTestHelper.generateClusterDetailsEvent();
+    return clusterDetailsEventProcessorTestHelper.generateClusterDetailsEvent();
   }
 
-  private void addNewNodeIntoCluster() throws SQLException, ClassNotFoundException {
+  private ClusterDetailsEventProcessor addNewNodeIntoCluster() throws SQLException, ClassNotFoundException {
     ClusterDetailsEventProcessorTestHelper clusterDetailsEventProcessorTestHelper = new ClusterDetailsEventProcessorTestHelper();
     clusterDetailsEventProcessorTestHelper.addNodeDetails("node1", "127.0.0.0", false);
     clusterDetailsEventProcessorTestHelper.addNodeDetails("node2", "127.0.0.1", false);
     clusterDetailsEventProcessorTestHelper.addNodeDetails("node3", "127.0.0.2", false);
     clusterDetailsEventProcessorTestHelper.addNodeDetails("node4", "127.0.0.3", false);
     clusterDetailsEventProcessorTestHelper.addNodeDetails("master", "127.0.0.9", NodeRole.ELECTED_MASTER, true);
-    clusterDetailsEventProcessorTestHelper.generateClusterDetailsEvent();
+    return clusterDetailsEventProcessorTestHelper.generateClusterDetailsEvent();
   }
 
   private boolean compareResourceSummary(Resource resource, HotResourceSummary resourceSummary) {


### PR DESCRIPTION
Issue #, if available: #280

Description of changes: Makes all the methods and class members non-static.

Tests: No new tests are required and all current tests work fine.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.