### PR TITLE
Implement Action Flip Flop Detection in the Publisher

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collections/TimeExpiringSet.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collections/TimeExpiringSet.java
@@ -1,0 +1,76 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.collections;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import javax.annotation.Nonnull;
+
+/**
+ * Stores a set of elements which are automatically removed from the Set after a given time period.
+ *
+ * <p>Subsequent calls to add with the same element refresh the expiry period for that element.
+ */
+public class TimeExpiringSet<E> implements Iterable<E> {
+  private Cache<E, E> cache;
+
+  /**
+   * Allocates a new TimeExpiringSet whose elements expire after the given time period
+   * @param duration The magnitude of the expiry duration
+   * @param unit The unit of the expiry duration
+   */
+  public TimeExpiringSet(long duration, TimeUnit unit) {
+    cache = CacheBuilder.newBuilder()
+        .expireAfterWrite(duration, unit)
+        .build();
+  }
+
+  /**
+   * Returns true if e is currently a member of the Set
+   * @param e The element to tests
+   * @return true if e is currently a member of the Set
+   */
+  public boolean contains(E e) {
+    return cache.getIfPresent(e) != null;
+  }
+
+  /**
+   * Returns the number of elements currently in the Set
+   * @return the number of elements currently in the Set
+   */
+  public long size() {
+    return cache.size();
+  }
+
+  /**
+   * Returns a weakly-consistent, thread-safe {@link Iterator} over the elements in the Set
+   *
+   * <p>This means that while the Iterator is thread-safe, if elements expire after the Iterator is
+   * created, the changes may not be reflected in the iteration. That is, you may iterate over an
+   * element which was invalidated during your iteration. This is okay for many use cases which can
+   * tolerate weak consistency.
+   *
+   * @return a weakly-consistent, thread-safe {@link Iterator} over the elements in the Set
+   */
+  @Nonnull
+  public Iterator<E> iterator() {
+    return cache.asMap().keySet().iterator();
+  }
+
+  /**
+   * Adds an element into the Set
+   * @param e the element to add into the Set
+   */
+  public void add(E e) {
+    cache.put(e, e);
+  }
+
+  /**
+   * Simple weakly-consistent forEach implementation applies the given action to each element
+   * @param action The action to apply to each element
+   */
+  public void forEach(Consumer<? super E> action) {
+    iterator().forEachRemaining(action);
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collections/TimeExpiringSet.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collections/TimeExpiringSet.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.collections;
 
 import com.google.common.cache.Cache;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collections/TimeExpiringSet.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collections/TimeExpiringSet.java
@@ -23,7 +23,7 @@ import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 
 /**
- * Stores a set of elements which are automatically removed from the Set after a given time period.
+ * Caches a set of elements which are automatically evicted based on the cache TTL.
  *
  * <p>Subsequent calls to add with the same element refresh the expiry period for that element.
  */
@@ -32,12 +32,16 @@ public class TimeExpiringSet<E> implements Iterable<E> {
 
   /**
    * Allocates a new TimeExpiringSet whose elements expire after the given time period
-   * @param duration The magnitude of the expiry duration
-   * @param unit The unit of the expiry duration
+   *
+   * <p>E.g. for a ttl of 5 and a unit of TimeUnit.SECONDS, a newly added element will remain
+   * in the Set for 5 seconds before it is evicted.
+   *
+   * @param ttl The magnitude of the time a unit will remain in the cache before it is evicted
+   * @param unit The unit of the ttl
    */
-  public TimeExpiringSet(long duration, TimeUnit unit) {
+  public TimeExpiringSet(long ttl, TimeUnit unit) {
     cache = CacheBuilder.newBuilder()
-        .expireAfterWrite(duration, unit)
+        .expireAfterWrite(ttl, unit)
         .build();
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/FlipFlopDetector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/FlipFlopDetector.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions;
 
 /**

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/FlipFlopDetector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/FlipFlopDetector.java
@@ -1,0 +1,26 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions;
+
+/**
+ * Records a series of actions and can determine whether a subsequent action would "flip flop" with
+ * the previously recorded actions.
+ *
+ * <p>A flip flop is defined as any action which would undo changes made by a previous action. For
+ * example, decreasing CPU allocation then immediately increasing it may be considered a flip flop,
+ * but this is up to the implementation.
+ */
+public interface FlipFlopDetector {
+
+    /**
+     * Determines whether action will "flip flop" with any of the previously recorded actions
+     * @param action The {@link Action} to test
+     * @return True if action will "flip flop" with any of the previously recorded actions
+     */
+    public boolean isFlipFlop(Action action);
+
+    /**
+     * Records that an action was applied. This action may then be used in any subsequent isFlipFlop
+     * tests
+     * @param action The action to record
+     */
+    public void recordAction(Action action);
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ImpactVector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ImpactVector.java
@@ -18,6 +18,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.ac
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class ImpactVector {
 
@@ -63,5 +64,28 @@ public class ImpactVector {
     for (Dimension dimension : dimensions) {
       impactMap.put(dimension, Impact.NO_IMPACT);
     }
+  }
+
+  /**
+   * Two ImpactVectors are equal if and only if they have the same impact for each of their
+   * dimensions
+   * @param o The other ImpactVector to compare with this
+   * @return true if and only if this and o have the same impact for each of their dimensions
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ImpactVector that = (ImpactVector) o;
+    return Objects.equals(impactMap, that.impactMap);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(impactMap);
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/TimedFlipFlopDetector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/TimedFlipFlopDetector.java
@@ -1,0 +1,114 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collections.TimeExpiringSet;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ImpactVector.Dimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ImpactVector.Impact;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A {@link FlipFlopDetector} whose recorded actions expire after a given period of time.
+ *
+ * <p>This class defines a flip flop as an {@link Impact#DECREASES_PRESSURE}s followed by an
+ * {@link Impact#INCREASES_PRESSURE}s to be a flip flops.
+ *
+ * <p>This class stores a {@link TimeExpiringSet} of {@link ImpactVector}s per {@link NodeKey}
+ * that are used to determine these flip flops.
+ */
+public class TimedFlipFlopDetector implements FlipFlopDetector {
+    private Map<NodeKey, TimeExpiringSet<ImpactVector>> flipFlopMap;
+    private long expiryDuration;
+    private TimeUnit expiryUnit;
+
+    public TimedFlipFlopDetector(long duration, TimeUnit unit) {
+        flipFlopMap = new HashMap<>();
+        this.expiryDuration = duration;
+        this.expiryUnit = unit;
+    }
+
+    /**
+     * Tests if (a,b) is a flip flopping sequence of impacts.
+     *
+     * <p>Only an increase following a decrease is considered a flip flop
+     *
+     * @param a The first impact that would be applied
+     * @param b The subsequent impact that would be applied
+     * @return Whether or not (a,b) is a flip flopping sequence of impacts
+     */
+    protected boolean isFlipFlopImpact(Impact a, Impact b) {
+        return a.equals(Impact.DECREASES_PRESSURE) && b.equals(Impact.INCREASES_PRESSURE);
+    }
+
+    /**
+     * Returns true if the impact for a given Dimension in v is a flip flop Impact when compared to
+     * the impact for a given dimension in u
+     *
+     * <p>e.g. for u = (HEAP: INCREASE, CPU: DECREASE), v = (HEAP: DECREASE, CPU: INCREASE)
+     * (u,v) is a flip flop vector because a CPU: DECREASE followed by a CPU: INCREASE is a flip
+     * flop impact
+     *
+     * @param u The first impact vector that would be applied
+     * @param v The subsequent impact vector that would be applied
+     * @return true if the impact for a given Dimension in v is a flip flop Impact when compared to
+     *      the impact for a given dimension in u
+     */
+    protected boolean isFlipFlopVector(ImpactVector u, ImpactVector v) {
+        Map<Dimension, Impact> currentImpact = v.getImpact();
+        for (Map.Entry<Dimension, Impact> impactEntry : u.getImpact().entrySet()) {
+            Dimension dim = impactEntry.getKey();
+            Impact vImpact = currentImpact.get(dim);
+            if (isFlipFlopImpact(impactEntry.getValue(), vImpact)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Records an action's various {@link ImpactVector}s so that they may be used for future flip
+     * flop tests
+     *
+     * @param action The action to record
+     */
+    @Override
+    public void recordAction(Action action) {
+        for (Map.Entry<NodeKey, ImpactVector> entry : action.impact().entrySet()) {
+            flipFlopMap.compute(entry.getKey(), (k, v) -> {
+                if (v == null) {
+                    v = new TimeExpiringSet<>(expiryDuration, expiryUnit);
+                }
+                v.add(entry.getValue());
+                return v;
+            });
+        }
+    }
+
+    /**
+     * Returns true if for any NodeKey, ImpactVector pair (k, v) in action, v clashes with any of
+     * the {@link ImpactVector}s currently associated with k.
+     *
+     * @param action The {@link Action} to test
+     * @return true if applying the action would cause a flip flop
+     */
+    @Override
+    public boolean isFlipFlop(Action action) {
+        for (Map.Entry<NodeKey, ImpactVector> entry : action.impact().entrySet()) {
+            TimeExpiringSet<ImpactVector> previousImpacts = flipFlopMap.get(entry.getKey());
+            if (previousImpacts == null) {
+                continue;
+            }
+            // Weakly-consistent iteration over the previousImpacts
+            // If one of these impacts expires during our iteration we may incorrectly determine
+            // action to be a flip flop until the subsequent call of this function. This is OK for
+            // our use case since we're always erring on the side of stability
+            for (ImpactVector impactVector : previousImpacts) {
+                if (isFlipFlopVector(impactVector, entry.getValue())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/TimedFlipFlopDetector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/TimedFlipFlopDetector.java
@@ -29,34 +29,38 @@ public class TimedFlipFlopDetector implements FlipFlopDetector {
     }
 
     /**
-     * Tests if (a,b) is a flip flopping sequence of impacts.
+     * Tests if (prev, curr) is a flip flopping sequence of impacts.
      *
-     * <p>Only an increase following a decrease is considered a flip flop
+     * <p>Only an increase following a decrease is considered a flip flop. Therefore, if
+     * prev decreases pressure and curr increases pressure, then (prev, curr) is a flip flop.
      *
-     * @param a The first impact that would be applied
-     * @param b The subsequent impact that would be applied
-     * @return Whether or not (a,b) is a flip flopping sequence of impacts
+     * @param prev The {@link Impact} that curr is compared against
+     * @param curr The {@link Impact} that you'd like to test and apply
+     * @return Whether or not (prev, curr) is a flip flopping sequence of impacts
      */
-    protected boolean isFlipFlopImpact(Impact a, Impact b) {
-        return a.equals(Impact.DECREASES_PRESSURE) && b.equals(Impact.INCREASES_PRESSURE);
+    protected boolean isFlipFlopImpact(Impact prev, Impact curr) {
+        return prev.equals(Impact.DECREASES_PRESSURE) && curr.equals(Impact.INCREASES_PRESSURE);
     }
 
     /**
-     * Returns true if the impact for a given Dimension in v is a flip flop Impact when compared to
-     * the impact for a given dimension in u
+     * Returns true if the impact for any given Dimension in prev is a flip flop Impact when compared to
+     * the impact for a given dimension in prev
      *
-     * <p>e.g. for u = (HEAP: INCREASE, CPU: DECREASE), v = (HEAP: DECREASE, CPU: INCREASE)
-     * (u,v) is a flip flop vector because a CPU: DECREASE followed by a CPU: INCREASE is a flip
-     * flop impact
+     * <p>e.g. for prev = (HEAP: INCREASE, CPU: DECREASE), curr = (HEAP: DECREASE, CPU: INCREASE)
+     * (prev, curr) is a flip flop vector because a CPU: DECREASE followed by a CPU: INCREASE is a flip
+     * flop impact. Note that (HEAP: DECREASE) followed by (CPU: INCREASE) is not a flip flop
+     * because HEAP =/= CPU.
      *
-     * @param u The first impact vector that would be applied
-     * @param v The subsequent impact vector that would be applied
-     * @return true if the impact for a given Dimension in v is a flip flop Impact when compared to
-     *      the impact for a given dimension in u
+     * @param prev The first {@link ImpactVector}. Its Impacts appear on the LHS of calls to
+     *             {@link this#isFlipFlopImpact(Impact, Impact)}
+     * @param curr The second {@link ImpactVector}. Its Impacts appear on the RHS of calls to
+     *            {@link this#isFlipFlopImpact(Impact, Impact)}.
+     * @return true if the impact for any given Dimension in curr is a flip flop Impact when compared to
+     *      the impact for a given dimension in prev
      */
-    protected boolean isFlipFlopVector(ImpactVector u, ImpactVector v) {
-        Map<Dimension, Impact> currentImpact = v.getImpact();
-        for (Map.Entry<Dimension, Impact> impactEntry : u.getImpact().entrySet()) {
+    protected boolean isFlipFlopVector(ImpactVector prev, ImpactVector curr) {
+        Map<Dimension, Impact> currentImpact = curr.getImpact();
+        for (Map.Entry<Dimension, Impact> impactEntry : prev.getImpact().entrySet()) {
             Dimension dim = impactEntry.getKey();
             Impact vImpact = currentImpact.get(dim);
             if (isFlipFlopImpact(impactEntry.getValue(), vImpact)) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/TimedFlipFlopDetector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/TimedFlipFlopDetector.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collections.TimeExpiringSet;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/Publisher.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/Publisher.java
@@ -77,7 +77,7 @@ public class Publisher extends NonLeafNode<EmptyFlowUnit> {
     // TODO: Need to add dampening, avoidance, state persistence etc.
     Decision decision = collator.getFlowUnits().get(0);
     for (Action action : decision.getActions()) {
-      if (isCooledOff(action) && !flipFlopDetector.isFlipFlop(action)) { // Only execute actions which have passed their cool off period
+      if (isCooledOff(action) && !flipFlopDetector.isFlipFlop(action)) {
         LOG.info("Publisher: Executing action: [{}]", action.name());
         action.execute();
         flipFlopDetector.recordAction(action);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/Publisher.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/Publisher.java
@@ -23,10 +23,10 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
+import com.google.common.annotations.VisibleForTesting;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
-import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/Publisher.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/Publisher.java
@@ -80,7 +80,7 @@ public class Publisher extends NonLeafNode<EmptyFlowUnit> {
       if (isCooledOff(action) && !flipFlopDetector.isFlipFlop(action)) { // Only execute actions which have passed their cool off period
         LOG.info("Publisher: Executing action: [{}]", action.name());
         action.execute();
-        //flipFlopDetector.up
+        flipFlopDetector.recordAction(action);
         actionToExecutionTime.put(action.name(), Instant.now().toEpochMilli());
       }
     }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/Publisher.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/Publisher.java
@@ -17,6 +17,8 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.de
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.Action;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.FlipFlopDetector;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.TimedFlipFlopDetector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.NonLeafNode;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
@@ -24,6 +26,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.Flo
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -33,6 +37,7 @@ public class Publisher extends NonLeafNode<EmptyFlowUnit> {
   private final long initTime;
 
   private Collator collator;
+  private FlipFlopDetector flipFlopDetector;
   private boolean isMuted = false;
   private Map<String, Long> actionToExecutionTime;
 
@@ -40,6 +45,8 @@ public class Publisher extends NonLeafNode<EmptyFlowUnit> {
     super(0, evalIntervalSeconds);
     this.collator = collator;
     this.actionToExecutionTime = new HashMap<>();
+    // TODO please bring in guice so we can configure this with DI
+    this.flipFlopDetector = new TimedFlipFlopDetector(1, TimeUnit.HOURS);
     initTime = Instant.now().toEpochMilli();
   }
 
@@ -67,13 +74,13 @@ public class Publisher extends NonLeafNode<EmptyFlowUnit> {
 
   @Override
   public EmptyFlowUnit operate() {
-    // TODO: Pass through implementation, need to add dampening, action flip-flop
-    // avoidance, state persistence etc.
+    // TODO: Need to add dampening, avoidance, state persistence etc.
     Decision decision = collator.getFlowUnits().get(0);
     for (Action action : decision.getActions()) {
-      if (isCooledOff(action)) { // Only execute actions which have passed their cool off period
+      if (isCooledOff(action) && !flipFlopDetector.isFlipFlop(action)) { // Only execute actions which have passed their cool off period
         LOG.info("Publisher: Executing action: [{}]", action.name());
         action.execute();
+        //flipFlopDetector.up
         actionToExecutionTime.put(action.name(), Instant.now().toEpochMilli());
       }
     }
@@ -118,5 +125,10 @@ public class Publisher extends NonLeafNode<EmptyFlowUnit> {
 
   public long getInitTime() {
     return this.initTime;
+  }
+
+  @VisibleForTesting
+  protected FlipFlopDetector getFlipFlopDetector() {
+    return this.flipFlopDetector;
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collections/TimeExpiringSetTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collections/TimeExpiringSetTest.java
@@ -1,0 +1,62 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.collections;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TimeExpiringSetTest {
+  private TimeExpiringSet<Integer> timeExpiringSet;
+
+  @Before
+  public void setup() {
+    timeExpiringSet = new TimeExpiringSet<>(1, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void testContains() throws Exception {
+    timeExpiringSet.add(5);
+    Thread.sleep(500L);
+    Assert.assertTrue(timeExpiringSet.contains(5));
+    Thread.sleep(600L);
+    Assert.assertFalse(timeExpiringSet.contains(5));
+  }
+
+  @Test
+  public void testElementRefresh() throws Exception {
+    timeExpiringSet.add(5);
+    Thread.sleep(500L);
+    Assert.assertTrue(timeExpiringSet.contains(5));
+    timeExpiringSet.add(5);
+    Assert.assertEquals(1, timeExpiringSet.size());
+    Thread.sleep(750L);
+    Assert.assertTrue(timeExpiringSet.contains(5));
+    Thread.sleep(300L);
+    Assert.assertFalse(timeExpiringSet.contains(5));
+  }
+
+  /**
+   * Verifies weakly-consistent iteration behavior
+   */
+  @Test
+  public void testExpiringIteration() throws Exception {
+    for (int i = 0; i < 100; i++) { // ~10s for perpetual sanity
+      TimeExpiringSet<Integer> tes = new TimeExpiringSet<>(100, TimeUnit.MILLISECONDS);
+      Set<Integer> seen = new HashSet<>();
+      tes.add(5);
+      Thread.sleep(50L);
+      tes.add(10);
+      Thread.sleep(30L);
+      tes.add(15);
+      Iterator<Integer> it = tes.iterator();
+      Thread.sleep(50L);
+      while (it.hasNext()) {
+        seen.add(it.next());
+      }
+      Assert.assertTrue(seen.size() >= 2);
+    }
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collections/TimeExpiringSetTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collections/TimeExpiringSetTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.collections;
 
 import java.util.HashSet;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/TimedFlipFlopDetectorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/TimedFlipFlopDetectorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions;
 
 import static org.mockito.Mockito.when;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/TimedFlipFlopDetectorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/TimedFlipFlopDetectorTest.java
@@ -1,0 +1,156 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions;
+
+import static org.mockito.Mockito.when;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ImpactVector.Dimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ImpactVector.Impact;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class TimedFlipFlopDetectorTest {
+  private TimedFlipFlopDetector flipFlopDetector;
+  private static ImpactVector increaseAll = new ImpactVector();
+  private static ImpactVector decreaseAll = new ImpactVector();
+  private static ImpactVector noImpact = new ImpactVector();
+
+  @BeforeClass
+  public static void setupClass() {
+    increaseAll.increasesPressure(Dimension.values());
+    decreaseAll.decreasesPressure(Dimension.values());
+    noImpact.noImpact(Dimension.values());
+  }
+
+  @Before
+  public void setup() {
+    flipFlopDetector = new TimedFlipFlopDetector(2, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Tests that a Impact.DECREASES_PRESSURE followed by a Impact.INCREASES_PRESSURE is the only
+   * order of impacts that should be considered a flip flop
+   */
+  @Test
+  public void testIsFlipFlopImpact() {
+    int flipFlopImpacts = 0;
+    for (Impact a : Impact.values()) {
+      for (Impact b : Impact.values()) {
+        if (flipFlopDetector.isFlipFlopImpact(a, b)) {
+          flipFlopImpacts++;
+        }
+      }
+    }
+    Assert.assertEquals(1, flipFlopImpacts);
+    Assert.assertTrue(flipFlopDetector.isFlipFlopImpact(Impact.DECREASES_PRESSURE,
+        Impact.INCREASES_PRESSURE));
+  }
+
+  /**
+   * Tests that we can identify flip flops for any two impact vectors (u,v)
+   */
+  @Test
+  public void testIsClash() {
+    // Stability changes are not flip flops
+    Assert.assertFalse(flipFlopDetector.isFlipFlopVector(increaseAll, decreaseAll));
+    // Multiple increases are not flip flops, cool off can handle throttling these
+    Assert.assertFalse(flipFlopDetector.isFlipFlopVector(increaseAll, increaseAll));
+    // Multiple decreases are not flip flops, cool off can handle throttling these
+    Assert.assertFalse(flipFlopDetector.isFlipFlopVector(decreaseAll, decreaseAll));
+    // noImpact dimensions shouldn't contribute to flip flop detection
+    Assert.assertFalse(flipFlopDetector.isFlipFlopVector(decreaseAll, noImpact));
+    Assert.assertFalse(flipFlopDetector.isFlipFlopVector(increaseAll, noImpact));
+    Assert.assertFalse(flipFlopDetector.isFlipFlopVector(noImpact, increaseAll));
+    Assert.assertFalse(flipFlopDetector.isFlipFlopVector(noImpact, decreaseAll));
+    // An increase after a decrease that hasn't expired is the definition of a flip flop
+    Assert.assertTrue(flipFlopDetector.isFlipFlopVector(decreaseAll, increaseAll));
+  }
+
+  private static Action mockAction(NodeKey key, ImpactVector impactVector) {
+    Action action = Mockito.mock(Action.class);
+    Map<NodeKey, ImpactVector> impactMap = new HashMap<>();
+    impactMap.put(key, impactVector);
+    when(action.impact()).thenReturn(impactMap);
+    return action;
+  }
+
+  @Test
+  public void testIsFlipFlop() throws Exception {
+    // Setup mock actions, action followed by flipFlopAction is a flip flop
+    NodeKey nodeKey = new NodeKey("A", "localhost");
+    Action action = mockAction(nodeKey, decreaseAll);
+    Action flipflopAction = mockAction(nodeKey, increaseAll);
+    // Update the flipFlopDetector so that the last "executed" action is action
+    flipFlopDetector.recordAction(action);
+    // Verify that the basic flip flop test succeeds
+    Assert.assertTrue(flipFlopDetector.isFlipFlop(flipflopAction));
+    // Verify that once the expiry period has passed, flipFlopAction is no longer considered a
+    // flip flop
+    Thread.sleep(2500L);
+    Assert.assertFalse(flipFlopDetector.isFlipFlop(flipflopAction));
+
+  }
+
+  /**
+   * This test verifies that multiple actions applied to a node are all considered when determining
+   * a flip flop.
+   *
+   * <p>e.g. c clashes with b; apply a; apply b; verify that c is considered a flip flop
+   */
+  @Test
+  public void testMultipleActionFlipFlop() throws Exception {
+    // Setup test objects, flip flops are (b, c) and (a, d)
+    NodeKey nodeKey = new NodeKey("A", "localhost");
+    ImpactVector aVector = new ImpactVector();
+    aVector.decreasesPressure(Dimension.HEAP);
+    Action a = mockAction(nodeKey, aVector);
+    ImpactVector bVector = new ImpactVector();
+    bVector.decreasesPressure(Dimension.CPU);
+    Action b = mockAction(nodeKey, bVector);
+    ImpactVector cVector = new ImpactVector();
+    cVector.increasesPressure(Dimension.CPU);
+    Action c = mockAction(nodeKey, cVector);
+    ImpactVector dVector = new ImpactVector();
+    dVector.increasesPressure(Dimension.HEAP);
+    Action d = mockAction(nodeKey, dVector);
+    // Apply a, verify b and c are not flip flops, verify d is a flip flop
+    flipFlopDetector.recordAction(a);
+    Assert.assertFalse(flipFlopDetector.isFlipFlop(b));
+    Assert.assertFalse(flipFlopDetector.isFlipFlop(c));
+    Assert.assertTrue(flipFlopDetector.isFlipFlop(d));
+    Thread.sleep(1000L);
+    // Apply b, verify that c is now a flip flop
+    flipFlopDetector.recordAction(b);
+    Assert.assertTrue(flipFlopDetector.isFlipFlop(c));
+    // Let a expire, verify d is no longer a flip flop
+    Thread.sleep(1500L);
+    Assert.assertFalse(flipFlopDetector.isFlipFlop(d));
+    // Let b expire, verify c is no longer a flip flop
+    Thread.sleep(1000L);
+    Assert.assertFalse(flipFlopDetector.isFlipFlop(c));
+  }
+
+  /**
+   * If the same action (based on its ImpactVector) is applied multiple times,
+   * its expiry should reset
+   */
+  @Test
+  public void testFlipFlopRefresh() throws Exception {
+    NodeKey nodeKey = new NodeKey("A", "localhost");
+    Action action = mockAction(nodeKey, decreaseAll);
+    Action flipflopAction = mockAction(nodeKey, increaseAll);
+    flipFlopDetector.recordAction(action);
+    Thread.sleep(1000L);
+    // refresh the action
+    flipFlopDetector.recordAction(action);
+    Thread.sleep(1500L);
+    // verify that even though the 2s expiry for the initial action has passed, the action is still
+    // around because it was refreshed
+    Assert.assertTrue(flipFlopDetector.isFlipFlop(flipflopAction));
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/PublisherTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/PublisherTest.java
@@ -2,13 +2,17 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.de
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.Action;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ImpactVector;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ImpactVector.Dimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
 import com.google.common.collect.Lists;
 
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
 
+import java.util.Map;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.mockito.Mock;
@@ -29,37 +33,17 @@ public class PublisherTest {
     @Mock
     private Action action;
 
-    private static class TestDecider extends Decider {
-        public TestDecider(long evalIntervalSeconds, int decisionFrequency) {
-            super(evalIntervalSeconds, decisionFrequency);
-        }
-
-        @Override
-        public String name() {
-            return getClass().getSimpleName();
-        }
-
-        @Override
-        public Decision operate() {
-            return null;
-        }
-    }
-
-    @BeforeClass
-    public static void setupClass() {
-    }
-
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
         publisher = new Publisher(EVAL_INTERVAL_S, collator);
+        List<Decision> decisionList = Lists.newArrayList(decision);
+        Mockito.when(collator.getFlowUnits()).thenReturn(decisionList);
+        Mockito.when(decision.getActions()).thenReturn(Lists.newArrayList(action));
     }
 
     @Test
     public void testIsCooledOff() throws Exception {
-        List<Decision> decisionList = Lists.newArrayList(decision);
-        Mockito.when(collator.getFlowUnits()).thenReturn(decisionList);
-        Mockito.when(decision.getActions()).thenReturn(Lists.newArrayList(action));
         Mockito.when(action.name()).thenReturn("testIsCooledOffAction");
         Mockito.when(action.coolOffPeriodInMillis()).thenReturn(100_000L);
         // Verify that a newly initialized publisher doesn't execute an action until the publisher object
@@ -80,5 +64,30 @@ public class PublisherTest {
         Thread.sleep(4000L);
         publisher.operate();
         Mockito.verify(action, Mockito.times(1)).execute();
+    }
+
+    @Test
+    public void testRejectsFlipFlops() throws Exception {
+        // Setup testing objects
+        NodeKey nodeKey = new NodeKey("A", "localhost");
+        ImpactVector allDecrease = new ImpactVector();
+        allDecrease.decreasesPressure(Dimension.values());
+        Map<NodeKey, ImpactVector> impactVectorMap = new HashMap<>();
+        impactVectorMap.put(nodeKey, allDecrease);
+        Mockito.when(action.name()).thenReturn("testIsCooledOffAction");
+        Mockito.when(action.coolOffPeriodInMillis()).thenReturn(500L);
+        Mockito.when(action.impact()).thenReturn(impactVectorMap);
+        // Record a flip flopping action
+        publisher.getFlipFlopDetector().recordAction(action);
+        ImpactVector allIncrease = new ImpactVector();
+        allIncrease.increasesPressure(Dimension.values());
+        Map<NodeKey, ImpactVector> increaseMap = new HashMap<>();
+        increaseMap.put(nodeKey, allIncrease);
+        Mockito.when(action.impact()).thenReturn(increaseMap);
+        Thread.sleep(1000L);
+        // Even though our action has cooled off, it will flip flop, so the publisher shouldn't
+        // execute it
+        publisher.operate();
+        Mockito.verify(action, Mockito.times(0)).execute();
     }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/PublisherTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/PublisherTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.Action;


### PR DESCRIPTION
*Issue #:* #286 

*Description of changes:* 
We don't want to rubber-band when applying Actions (e.g. applying a CPU
increase right after we apply a CPU decrease).

This commit implements logic which allows the Publisher to reject
Actions which flip flop.

*Tests:* 
- TimeExpiringSetTest - Verifies that the underlying TimedFlipFlopDetector collection works as expected
- PublisherTest - Verifies that the publisher rejects flip flopping actions
- TimedFlipFlopDetectorTest - Verifies that the FlipFlopDetector implementation works as expected


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
