### PR TITLE
Add listeners for publisher actions

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/Action.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/Action.java
@@ -33,13 +33,6 @@ public interface Action {
   /** Time to wait since last recommendation, before suggesting this action again */
   long coolOffPeriodInMillis();
 
-  /**
-   * Called when the action is invoked.
-   *
-   * <p>Specific implementation may include executing the action, or invoking downstream APIs
-   */
-  void execute();
-
   /** Returns a list of Elasticsearch nodes impacted by this action. */
   List<NodeKey> impactedNodes();
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ActionListener.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ActionListener.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions;
+
+/**
+ * This listener is notified whenever an action suggestion is
+ * published by the decision maker Publisher
+ */
+public interface ActionListener {
+
+  /**
+   * Called when Publisher emits an action
+   */
+  void actionPublished(Action action);
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyCacheCapacityAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyCacheCapacityAction.java
@@ -85,13 +85,6 @@ public class ModifyCacheCapacityAction implements Action {
     }
 
     @Override
-    public void execute() {
-        // Making this a no-op for now
-        // TODO: Modify based on downstream CoS agent API calls
-        assert true;
-    }
-
-    @Override
     public String summary() {
         if (!isActionable()) {
             return String.format("No action to take for: [%s]", NAME);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyQueueCapacityAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyQueueCapacityAction.java
@@ -82,13 +82,6 @@ public class ModifyQueueCapacityAction implements Action {
   }
 
   @Override
-  public void execute() {
-    // Making this a no-op for now
-    // TODO: Modify based on downstream agent API calls
-    assert true;
-  }
-
-  @Override
   public String summary() {
     if (!isActionable()) {
       return String.format("No action to take for: [%s]", NAME);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/Publisher.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/Publisher.java
@@ -28,10 +28,10 @@ import com.google.common.annotations.VisibleForTesting;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.concurrent.TimeUnit;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/Publisher.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/Publisher.java
@@ -25,12 +25,14 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.met
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import com.google.common.annotations.VisibleForTesting;
+
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.HashMap;
-import java.util.Map;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -113,8 +115,8 @@ public class Publisher extends NonLeafNode<EmptyFlowUnit> {
 
   /**
    * Register an action listener with Publisher
-   * <p>
-   * The listener is notified whenever an action is published
+   *
+   * <p>The listener is notified whenever an action is published
    */
   public void addActionListener(ActionListener listener) {
     actionListeners.add(listener);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/Plugin.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/Plugin.java
@@ -17,8 +17,8 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.plugins;
 
 /**
  * Allows adding custom extensions to the analysis graph.
- * <p>
- * RCA framework plugins can be installed to extend the analysis graph through custom
+ *
+ * <p>RCA framework plugins can be installed to extend the analysis graph through custom
  * metric nodes, rca nodes, deciders or action listeners. These can subscribe to flow
  * units from existing nodes to add new functionality, or override existing graph nodes to
  * customize for specific use cases.

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/Plugin.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/Plugin.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.plugins;
+
+/**
+ * Allows adding custom extensions to the analysis graph.
+ * <p>
+ * RCA framework plugins can be installed to extend the analysis graph through custom
+ * metric nodes, rca nodes, deciders or action listeners. These can subscribe to flow
+ * units from existing nodes to add new functionality, or override existing graph nodes to
+ * customize for specific use cases.
+ */
+public abstract class Plugin {
+
+  public abstract String name();
+
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/PluginController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/PluginController.java
@@ -58,7 +58,8 @@ public class PluginController {
         plugins.add((Plugin) constructors[0].newInstance());
         LOG.info("loaded plugin: [{}]", plugins.get(plugins.size() - 1).name());
       } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-        e.printStackTrace();
+        LOG.error("Failed to instantiate plugin", e);
+        throw new IllegalStateException("Failed to instantiate plugin: [" + pluginClass.getName() + "]", e);
       }
     }
   }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/PluginController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/PluginController.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.plugins;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ActionListener;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.Publisher;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class PluginController {
+
+  private static final Logger LOG = LogManager.getLogger(PluginController.class);
+  private final Publisher publisher;
+  private List<Plugin> plugins;
+
+  public PluginController(Publisher publisher) {
+    this.publisher = publisher;
+    this.plugins = new ArrayList<>();
+    loadFrameworkPlugins();
+    registerActionListeners();
+  }
+
+  private void loadFrameworkPlugins() {
+    for (Class<?> pluginClass : PluginControllerConfig.getFrameworkPlugins()) {
+      final Constructor<?>[] constructors = pluginClass.getConstructors();
+      if (constructors.length == 0) {
+        throw new IllegalStateException(
+            "no public constructor found for plugin class: [" + pluginClass.getName() + "]");
+      }
+      if (constructors.length > 1) {
+        throw new IllegalStateException(
+            "unique constructor expected for plugin class: [" + pluginClass.getName() + "]");
+      }
+      if (constructors[0].getParameterCount() != 0) {
+        throw new IllegalStateException(
+            "default constructor expected for plugin class: [" + pluginClass.getName() + "]");
+      }
+
+      try {
+        plugins.add((Plugin) constructors[0].newInstance());
+        LOG.info("loaded plugin: [{}]", plugins.get(plugins.size() - 1).name());
+      } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  private void registerActionListeners() {
+    for (Plugin plugin: plugins) {
+      if (ActionListener.class.isAssignableFrom(plugin.getClass())) {
+        publisher.addActionListener((ActionListener)plugin);
+      }
+    }
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/PluginController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/PluginController.java
@@ -30,8 +30,10 @@ public class PluginController {
   private static final Logger LOG = LogManager.getLogger(PluginController.class);
   private final Publisher publisher;
   private List<Plugin> plugins;
+  private PluginControllerConfig pluginControllerConfig;
 
-  public PluginController(Publisher publisher) {
+  public PluginController(PluginControllerConfig pluginConfig, Publisher publisher) {
+    this.pluginControllerConfig = pluginConfig;
     this.publisher = publisher;
     this.plugins = new ArrayList<>();
     loadFrameworkPlugins();
@@ -39,7 +41,7 @@ public class PluginController {
   }
 
   private void loadFrameworkPlugins() {
-    for (Class<?> pluginClass : PluginControllerConfig.getFrameworkPlugins()) {
+    for (Class<?> pluginClass : pluginControllerConfig.getFrameworkPlugins()) {
       final Constructor<?>[] constructors = pluginClass.getConstructors();
       if (constructors.length == 0) {
         throw new IllegalStateException(

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/PluginController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/PluginController.java
@@ -36,6 +36,9 @@ public class PluginController {
     this.pluginControllerConfig = pluginConfig;
     this.publisher = publisher;
     this.plugins = new ArrayList<>();
+  }
+
+  public void initPlugins() {
     loadFrameworkPlugins();
     registerActionListeners();
   }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/PluginController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/PluginController.java
@@ -17,6 +17,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.plugins;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ActionListener;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.Publisher;
+import com.google.common.annotations.VisibleForTesting;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -68,5 +69,10 @@ public class PluginController {
         publisher.addActionListener((ActionListener)plugin);
       }
     }
+  }
+
+  @VisibleForTesting
+  List<Plugin> getPlugins() {
+    return plugins;
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/PluginControllerConfig.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/PluginControllerConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.plugins;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PluginControllerConfig {
+
+  /**
+   * Returns a list of entry point classes for internal framework plugins
+   */
+  public static List<Class<? extends Plugin>> getFrameworkPlugins() {
+    List<Class<? extends Plugin>> frameworkPlugins = new ArrayList<>();
+    frameworkPlugins.add(PublisherEventsLogger.class);
+    return frameworkPlugins;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/PluginControllerConfig.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/PluginControllerConfig.java
@@ -20,12 +20,17 @@ import java.util.List;
 
 public class PluginControllerConfig {
 
+  private List<Class<? extends Plugin>> frameworkPlugins;
+
+  public PluginControllerConfig() {
+    frameworkPlugins = new ArrayList<>();
+    frameworkPlugins.add(PublisherEventsLogger.class);
+  }
+
   /**
    * Returns a list of entry point classes for internal framework plugins
    */
-  public static List<Class<? extends Plugin>> getFrameworkPlugins() {
-    List<Class<? extends Plugin>> frameworkPlugins = new ArrayList<>();
-    frameworkPlugins.add(PublisherEventsLogger.class);
+  public List<Class<? extends Plugin>> getFrameworkPlugins() {
     return frameworkPlugins;
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/PublisherEventsLogger.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/PublisherEventsLogger.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.plugins;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.Action;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ActionListener;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * A simple listener that logs all actions published by the publisher
+ */
+public class PublisherEventsLogger extends Plugin implements ActionListener {
+
+  private static final Logger LOG = LogManager.getLogger(PublisherEventsLogger.class);
+  public static final String NAME = "publisher_events_logger_plugin";
+
+  @Override
+  public void actionPublished(Action action) {
+    LOG.info("Action: [{}] published by decision maker publisher.", action.name());
+  }
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
@@ -27,6 +27,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.dec
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CommonDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.plugins.PluginController;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.plugins.PluginControllerConfig;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.AnalysisGraph;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Rca;
@@ -217,7 +218,8 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
     publisher.addAllUpstreams(Collections.singletonList(collator));
 
     // TODO: Refactor using DI to move out of construct method
-    PluginController pluginController = new PluginController(publisher);
+    PluginControllerConfig pluginControllerConfig = new PluginControllerConfig();
+    PluginController pluginController = new PluginController(pluginControllerConfig, publisher);
   }
 
   private void constructShardResourceUsageGraph() {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
@@ -220,6 +220,7 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
     // TODO: Refactor using DI to move out of construct method
     PluginControllerConfig pluginControllerConfig = new PluginControllerConfig();
     PluginController pluginController = new PluginController(pluginControllerConfig, publisher);
+    pluginController.initPlugins();
   }
 
   private void constructShardResourceUsageGraph() {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
@@ -26,6 +26,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.dec
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.QueueHealthDecider;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CommonDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.plugins.PluginController;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.AnalysisGraph;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Rca;
@@ -214,6 +215,9 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
     Publisher publisher = new Publisher(EVALUATION_INTERVAL_SECONDS, collator);
     publisher.addTag(TAG_LOCUS, LOCUS_MASTER_NODE);
     publisher.addAllUpstreams(Collections.singletonList(collator));
+
+    // TODO: Refactor using DI to move out of construct method
+    PluginController pluginController = new PluginController(publisher);
   }
 
   private void constructShardResourceUsageGraph() {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/PublisherTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/PublisherTest.java
@@ -16,18 +16,21 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.Action;
-
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ActionListener;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ImpactVector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ImpactVector.Dimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.plugins.Plugin;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
 import com.google.common.collect.Lists;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-
 import java.util.Map;
+
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -36,74 +39,110 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 public class PublisherTest {
-    private static final int EVAL_INTERVAL_S = 5;
-    private static Publisher publisher;
 
-    // Mock objects
-    @Mock
-    private Collator collator;
+  private static final int EVAL_INTERVAL_S = 5;
+  private static Publisher publisher;
 
-    @Mock
-    private Decision decision;
+  // Mock objects
+  @Mock
+  private Collator collator;
 
-    @Mock
-    private Action action;
+  @Mock
+  private Decision decision;
 
-    @Before
-    public void setup() {
-        MockitoAnnotations.initMocks(this);
-        publisher = new Publisher(EVAL_INTERVAL_S, collator);
-        List<Decision> decisionList = Lists.newArrayList(decision);
-        Mockito.when(collator.getFlowUnits()).thenReturn(decisionList);
-        Mockito.when(decision.getActions()).thenReturn(Lists.newArrayList(action));
+  @Mock
+  private Action action;
+
+  @Mock
+  private ActionListener actionListener;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    publisher = new Publisher(EVAL_INTERVAL_S, collator);
+    publisher.addActionListener(actionListener);
+    List<Decision> decisionList = Lists.newArrayList(decision);
+    Mockito.when(collator.getFlowUnits()).thenReturn(decisionList);
+    Mockito.when(decision.getActions()).thenReturn(Lists.newArrayList(action));
+  }
+
+  @Test
+  public void testIsCooledOff() throws Exception {
+    Mockito.when(action.name()).thenReturn("testIsCooledOffAction");
+    Mockito.when(action.coolOffPeriodInMillis()).thenReturn(100_000L);
+    // Verify that a newly initialized publisher doesn't execute an action until the publisher object
+    // has been alive for longer than the action's cool off period
+    publisher.operate();
+    Mockito.verify(actionListener, Mockito.times(0)).actionPublished(action);
+    Mockito.when(action.coolOffPeriodInMillis()).thenReturn(Instant.now().toEpochMilli()
+        - publisher.getInitTime() - 1000L);
+    publisher.operate();
+    Mockito.verify(actionListener, Mockito.times(1)).actionPublished(action);
+    Mockito.reset(action);
+    // Verify that a publisher doesn't execute a previously executed action until the action's cool off period
+    // has elapsed
+    Mockito.when(action.coolOffPeriodInMillis()).thenReturn(3000L);
+    publisher.operate();
+    Mockito.verify(actionListener, Mockito.times(0)).actionPublished(action);
+    // Verify that a published executes a previously executed action once the action's cool off period has elapsed
+    Thread.sleep(4000L);
+    publisher.operate();
+    Mockito.verify(actionListener, Mockito.times(1)).actionPublished(action);
+  }
+
+  @Test
+  public void testRejectsFlipFlops() throws Exception {
+    // Setup testing objects
+    NodeKey nodeKey = new NodeKey(new InstanceDetails.Id("A"), new InstanceDetails.Ip("127.0.0.1"));
+    ImpactVector allDecrease = new ImpactVector();
+    allDecrease.decreasesPressure(Dimension.values());
+    Map<NodeKey, ImpactVector> impactVectorMap = new HashMap<>();
+    impactVectorMap.put(nodeKey, allDecrease);
+    Mockito.when(action.name()).thenReturn("testIsCooledOffAction");
+    Mockito.when(action.coolOffPeriodInMillis()).thenReturn(500L);
+    Mockito.when(action.impact()).thenReturn(impactVectorMap);
+    // Record a flip flopping action
+    publisher.getFlipFlopDetector().recordAction(action);
+    ImpactVector allIncrease = new ImpactVector();
+    allIncrease.increasesPressure(Dimension.values());
+    Map<NodeKey, ImpactVector> increaseMap = new HashMap<>();
+    increaseMap.put(nodeKey, allIncrease);
+    Mockito.when(action.impact()).thenReturn(increaseMap);
+    Thread.sleep(1000L);
+    // Even though our action has cooled off, it will flip flop, so the publisher shouldn't
+    // execute it
+    publisher.operate();
+    Mockito.verify(actionListener, Mockito.times(0)).actionPublished(action);
+  }
+
+  @Test
+  public void testListenerInvocations() {
+    Mockito.when(collator.getFlowUnits()).thenReturn(Collections.singletonList(decision));
+    Mockito.when(decision.getActions()).thenReturn(Lists.newArrayList(action));
+    Mockito.when(action.name()).thenReturn("testAction");
+    Mockito.when(action.coolOffPeriodInMillis()).thenReturn(0L);
+
+    ActionListener actionListener2 = Mockito.mock(ActionListener.class);
+    ActionListener testActionListener = Mockito.mock(TestActionListener.class);
+    publisher.addActionListener(actionListener2);
+    publisher.addActionListener(testActionListener);
+
+    publisher.operate();
+    Mockito.verify(actionListener, Mockito.times(1)).actionPublished(action);
+    Mockito.verify(actionListener2, Mockito.times(1)).actionPublished(action);
+    Mockito.verify(testActionListener, Mockito.times(1)).actionPublished(action);
+  }
+
+  public static class TestActionListener extends Plugin implements ActionListener {
+
+    @Override
+    public void actionPublished(Action action) {
+      assert true;
     }
 
-    @Test
-    public void testIsCooledOff() throws Exception {
-        Mockito.when(action.name()).thenReturn("testIsCooledOffAction");
-        Mockito.when(action.coolOffPeriodInMillis()).thenReturn(100_000L);
-        // Verify that a newly initialized publisher doesn't execute an action until the publisher object
-        // has been alive for longer than the action's cool off period
-        publisher.operate();
-        Mockito.verify(action, Mockito.times(0)).execute();
-        Mockito.when(action.coolOffPeriodInMillis()).thenReturn(Instant.now().toEpochMilli()
-                - publisher.getInitTime() - 1000L);
-        publisher.operate();
-        Mockito.verify(action, Mockito.times(1)).execute();
-        Mockito.reset(action);
-        // Verify that a publisher doesn't execute a previously executed action until the action's cool off period
-        // has elapsed
-        Mockito.when(action.coolOffPeriodInMillis()).thenReturn(3000L);
-        publisher.operate();
-        Mockito.verify(action, Mockito.times(0)).execute();
-        // Verify that a published executes a previously executed action once the action's cool off period has elapsed
-        Thread.sleep(4000L);
-        publisher.operate();
-        Mockito.verify(action, Mockito.times(1)).execute();
+    @Override
+    public String name() {
+      return "Test_Plugin";
     }
-
-    @Test
-    public void testRejectsFlipFlops() throws Exception {
-        // Setup testing objects
-        NodeKey nodeKey = new NodeKey(new InstanceDetails.Id("A"), new InstanceDetails.Ip("127.0.0.1"));
-        ImpactVector allDecrease = new ImpactVector();
-        allDecrease.decreasesPressure(Dimension.values());
-        Map<NodeKey, ImpactVector> impactVectorMap = new HashMap<>();
-        impactVectorMap.put(nodeKey, allDecrease);
-        Mockito.when(action.name()).thenReturn("testIsCooledOffAction");
-        Mockito.when(action.coolOffPeriodInMillis()).thenReturn(500L);
-        Mockito.when(action.impact()).thenReturn(impactVectorMap);
-        // Record a flip flopping action
-        publisher.getFlipFlopDetector().recordAction(action);
-        ImpactVector allIncrease = new ImpactVector();
-        allIncrease.increasesPressure(Dimension.values());
-        Map<NodeKey, ImpactVector> increaseMap = new HashMap<>();
-        increaseMap.put(nodeKey, allIncrease);
-        Mockito.when(action.impact()).thenReturn(increaseMap);
-        Thread.sleep(1000L);
-        // Even though our action has cooled off, it will flip flop, so the publisher shouldn't
-        // execute it
-        publisher.operate();
-        Mockito.verify(action, Mockito.times(0)).execute();
-    }
+  }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/PublisherTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/PublisherTest.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/PublisherTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/PublisherTest.java
@@ -78,6 +78,7 @@ public class PublisherTest {
     publisher.operate();
     Mockito.verify(actionListener, Mockito.times(1)).actionPublished(action);
     Mockito.reset(action);
+    Mockito.reset(actionListener);
     // Verify that a publisher doesn't execute a previously executed action until the action's cool off period
     // has elapsed
     Mockito.when(action.coolOffPeriodInMillis()).thenReturn(3000L);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/PluginControllerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/PluginControllerTest.java
@@ -26,28 +26,20 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.dec
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@PowerMockIgnore({"com.sun.org.apache.xerces.*", "org.apache.logging.log4j.*"})
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(PluginControllerConfig.class)
 public class PluginControllerTest {
 
   @Test
   public void testInit() {
-    PowerMockito.mockStatic(PluginControllerConfig.class);
     List<Class<? extends Plugin>> frameworkPlugins = new ArrayList<Class<? extends Plugin>>() {{
       add(TestActionListener.class);
       add(TestPlugin.class);
     }};
-    PowerMockito.when(PluginControllerConfig.getFrameworkPlugins()).thenReturn(frameworkPlugins);
+    PluginControllerConfig pluginControllerConfig = Mockito.mock(PluginControllerConfig.class);
+    Mockito.when(pluginControllerConfig.getFrameworkPlugins()).thenReturn(frameworkPlugins);
     Publisher publisher = Mockito.mock(Publisher.class);
-    PluginController pluginController = new PluginController(publisher);
+    PluginController pluginController = new PluginController(pluginControllerConfig, publisher);
 
     List<Plugin> plugins = pluginController.getPlugins();
     assertEquals(2, plugins.size());
@@ -59,35 +51,35 @@ public class PluginControllerTest {
 
   @Test(expected = IllegalStateException.class)
   public void testPrivateConstructorPlugin() {
-    PowerMockito.mockStatic(PluginControllerConfig.class);
     List<Class<? extends Plugin>> frameworkPlugins = new ArrayList<Class<? extends Plugin>>() {{
       add(TestPrivateConstructorPlugin.class);
     }};
-    PowerMockito.when(PluginControllerConfig.getFrameworkPlugins()).thenReturn(frameworkPlugins);
+    PluginControllerConfig pluginControllerConfig = Mockito.mock(PluginControllerConfig.class);
+    Mockito.when(pluginControllerConfig.getFrameworkPlugins()).thenReturn(frameworkPlugins);
     Publisher publisher = Mockito.mock(Publisher.class);
-    PluginController pluginController = new PluginController(publisher);
+    PluginController pluginController = new PluginController(pluginControllerConfig, publisher);
   }
 
   @Test(expected = IllegalStateException.class)
   public void testMultiConstructorPlugin() {
-    PowerMockito.mockStatic(PluginControllerConfig.class);
     List<Class<? extends Plugin>> frameworkPlugins = new ArrayList<Class<? extends Plugin>>() {{
       add(TestMultiConstructorPlugin.class);
     }};
-    PowerMockito.when(PluginControllerConfig.getFrameworkPlugins()).thenReturn(frameworkPlugins);
+    PluginControllerConfig pluginControllerConfig = Mockito.mock(PluginControllerConfig.class);
+    Mockito.when(pluginControllerConfig.getFrameworkPlugins()).thenReturn(frameworkPlugins);
     Publisher publisher = Mockito.mock(Publisher.class);
-    PluginController pluginController = new PluginController(publisher);
+    PluginController pluginController = new PluginController(pluginControllerConfig, publisher);
   }
 
   @Test(expected = IllegalStateException.class)
   public void testNonDefaultConstructorPlugin() {
-    PowerMockito.mockStatic(PluginControllerConfig.class);
     List<Class<? extends Plugin>> frameworkPlugins = new ArrayList<Class<? extends Plugin>>() {{
       add(TestNonDefaultConstructorPlugin.class);
     }};
-    PowerMockito.when(PluginControllerConfig.getFrameworkPlugins()).thenReturn(frameworkPlugins);
+    PluginControllerConfig pluginControllerConfig = Mockito.mock(PluginControllerConfig.class);
+    Mockito.when(pluginControllerConfig.getFrameworkPlugins()).thenReturn(frameworkPlugins);
     Publisher publisher = Mockito.mock(Publisher.class);
-    PluginController pluginController = new PluginController(publisher);
+    PluginController pluginController = new PluginController(pluginControllerConfig, publisher);
   }
 
   public static class TestActionListener extends Plugin implements ActionListener {
@@ -154,5 +146,4 @@ public class PluginControllerTest {
       return name;
     }
   }
-
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/PluginControllerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/PluginControllerTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.plugins;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.times;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.Action;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ActionListener;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.Publisher;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "org.apache.logging.log4j.*"})
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(PluginControllerConfig.class)
+public class PluginControllerTest {
+
+  @Test
+  public void testInit() {
+    PowerMockito.mockStatic(PluginControllerConfig.class);
+    List<Class<? extends Plugin>> frameworkPlugins = new ArrayList<Class<? extends Plugin>>() {{
+      add(TestActionListener.class);
+      add(TestPlugin.class);
+    }};
+    PowerMockito.when(PluginControllerConfig.getFrameworkPlugins()).thenReturn(frameworkPlugins);
+    Publisher publisher = Mockito.mock(Publisher.class);
+    PluginController pluginController = new PluginController(publisher);
+
+    List<Plugin> plugins = pluginController.getPlugins();
+    assertEquals(2, plugins.size());
+
+    // Only action listeners registered with publisher
+    Mockito.verify(publisher, times(1)).addActionListener(any());
+    Mockito.verify(publisher, times(1)).addActionListener(isA(TestActionListener.class));
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testPrivateConstructorPlugin() {
+    PowerMockito.mockStatic(PluginControllerConfig.class);
+    List<Class<? extends Plugin>> frameworkPlugins = new ArrayList<Class<? extends Plugin>>() {{
+      add(TestPrivateConstructorPlugin.class);
+    }};
+    PowerMockito.when(PluginControllerConfig.getFrameworkPlugins()).thenReturn(frameworkPlugins);
+    Publisher publisher = Mockito.mock(Publisher.class);
+    PluginController pluginController = new PluginController(publisher);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testMultiConstructorPlugin() {
+    PowerMockito.mockStatic(PluginControllerConfig.class);
+    List<Class<? extends Plugin>> frameworkPlugins = new ArrayList<Class<? extends Plugin>>() {{
+      add(TestMultiConstructorPlugin.class);
+    }};
+    PowerMockito.when(PluginControllerConfig.getFrameworkPlugins()).thenReturn(frameworkPlugins);
+    Publisher publisher = Mockito.mock(Publisher.class);
+    PluginController pluginController = new PluginController(publisher);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testNonDefaultConstructorPlugin() {
+    PowerMockito.mockStatic(PluginControllerConfig.class);
+    List<Class<? extends Plugin>> frameworkPlugins = new ArrayList<Class<? extends Plugin>>() {{
+      add(TestNonDefaultConstructorPlugin.class);
+    }};
+    PowerMockito.when(PluginControllerConfig.getFrameworkPlugins()).thenReturn(frameworkPlugins);
+    Publisher publisher = Mockito.mock(Publisher.class);
+    PluginController pluginController = new PluginController(publisher);
+  }
+
+  public static class TestActionListener extends Plugin implements ActionListener {
+
+    @Override
+    public void actionPublished(Action action) {
+      assert true;
+    }
+
+    @Override
+    public String name() {
+      return "Test_Action_Listener";
+    }
+  }
+
+  public static class TestPlugin extends Plugin {
+
+    @Override
+    public String name() {
+      return "Test_Plugin";
+    }
+  }
+
+  public static class TestPrivateConstructorPlugin extends Plugin {
+
+    private TestPrivateConstructorPlugin() {
+      assert true;
+    }
+
+    @Override
+    public String name() {
+      return "Test_Private_Constructor_Plugin";
+    }
+  }
+
+  public static class TestMultiConstructorPlugin extends Plugin {
+
+    private String name;
+
+    public TestMultiConstructorPlugin() {
+      this.name = "Test_Multi_Constructor_Plugin";
+    }
+
+    public TestMultiConstructorPlugin(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public String name() {
+      return name;
+    }
+  }
+
+  public static class TestNonDefaultConstructorPlugin extends Plugin {
+
+    private String name;
+
+    public TestNonDefaultConstructorPlugin(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public String name() {
+      return name;
+    }
+  }
+
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/PluginControllerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/plugins/PluginControllerTest.java
@@ -40,6 +40,7 @@ public class PluginControllerTest {
     Mockito.when(pluginControllerConfig.getFrameworkPlugins()).thenReturn(frameworkPlugins);
     Publisher publisher = Mockito.mock(Publisher.class);
     PluginController pluginController = new PluginController(pluginControllerConfig, publisher);
+    pluginController.initPlugins();
 
     List<Plugin> plugins = pluginController.getPlugins();
     assertEquals(2, plugins.size());
@@ -58,6 +59,7 @@ public class PluginControllerTest {
     Mockito.when(pluginControllerConfig.getFrameworkPlugins()).thenReturn(frameworkPlugins);
     Publisher publisher = Mockito.mock(Publisher.class);
     PluginController pluginController = new PluginController(pluginControllerConfig, publisher);
+    pluginController.initPlugins();
   }
 
   @Test(expected = IllegalStateException.class)
@@ -69,6 +71,7 @@ public class PluginControllerTest {
     Mockito.when(pluginControllerConfig.getFrameworkPlugins()).thenReturn(frameworkPlugins);
     Publisher publisher = Mockito.mock(Publisher.class);
     PluginController pluginController = new PluginController(pluginControllerConfig, publisher);
+    pluginController.initPlugins();
   }
 
   @Test(expected = IllegalStateException.class)
@@ -80,6 +83,7 @@ public class PluginControllerTest {
     Mockito.when(pluginControllerConfig.getFrameworkPlugins()).thenReturn(frameworkPlugins);
     Publisher publisher = Mockito.mock(Publisher.class);
     PluginController pluginController = new PluginController(pluginControllerConfig, publisher);
+    pluginController.initPlugins();
   }
 
   public static class TestActionListener extends Plugin implements ActionListener {


### PR DESCRIPTION
*Issue #:* 316
https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/issues/316

*Description of changes:* Allows users to plugin different action listeners to publisher. Action suggestions are published to each listener.

*Tests:* WIP


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
