### PR TITLE
[bugfix] update the ClusterDetailsEventProcessor only when it is valid.

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/AppContext.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/AppContext.java
@@ -45,6 +45,9 @@ public class AppContext {
 
   public AppContext(AppContext other) {
     this.clusterDetailsEventProcessor = new ClusterDetailsEventProcessor(other.clusterDetailsEventProcessor);
+
+    // Initializing this as we don't want to copy the entire cache.
+    this.nodeConfigCache = new NodeConfigCache();
   }
 
   public void setClusterDetailsEventProcessor(final ClusterDetailsEventProcessor clusterDetailsEventProcessor) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/AppContext.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/AppContext.java
@@ -43,6 +43,10 @@ public class AppContext {
     this.nodeConfigCache = new NodeConfigCache();
   }
 
+  public AppContext(AppContext other) {
+    this.clusterDetailsEventProcessor = new ClusterDetailsEventProcessor(other.clusterDetailsEventProcessor);
+  }
+
   public void setClusterDetailsEventProcessor(final ClusterDetailsEventProcessor clusterDetailsEventProcessor) {
     this.clusterDetailsEventProcessor = clusterDetailsEventProcessor;
   }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Stats.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/Stats.java
@@ -113,7 +113,11 @@ public class Stats {
   }
 
   public int getMutedGraphNodesCount() {
-    return mutedGraphNodes.size();
+    int count = 0;
+    if (mutedGraphNodes != null) {
+      count = mutedGraphNodes.size();
+    }
+    return count;
   }
 
   public static void clear() {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/InstanceDetails.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/InstanceDetails.java
@@ -49,4 +49,14 @@ public class InstanceDetails {
   public boolean getIsMaster() {
     return isMaster;
   }
+
+  @Override
+  public String toString() {
+    return "InstanceDetails{"
+            + "role=" + role
+            + ", InstanceId='" + InstanceId + '\''
+            + ", instanceIp='" + instanceIp + '\''
+            + ", isMaster=" + isMaster
+            + '}';
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
@@ -362,7 +362,7 @@ class SQLitePersistor extends PersistorBase {
         response.addNestedSummaryList(nodeLevelDimSummary);
       }
     } catch (DataAccessException dex) {
-      LOG.error("Failed to read temperature profile RCA for {}", rca, dex);
+      LOG.warn("Failed to read temperature profile RCA for {}. Msg: {}", rca, dex.getMessage());
       if (dex.getMessage().contains("no such table")) {
         JsonObject json = new JsonObject();
         json.addProperty("error", "RCAs are not created yet.");

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
@@ -362,11 +362,12 @@ class SQLitePersistor extends PersistorBase {
         response.addNestedSummaryList(nodeLevelDimSummary);
       }
     } catch (DataAccessException dex) {
-      LOG.warn("Failed to read temperature profile RCA for {}. Msg: {}", rca, dex.getMessage());
       if (dex.getMessage().contains("no such table")) {
         JsonObject json = new JsonObject();
         json.addProperty("error", "RCAs are not created yet.");
         return json;
+      } else {
+        LOG.error("Failed to read temperature profile RCA for {}.", rca, dex);
       }
     }
     return response.toJson();

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
@@ -181,7 +181,9 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
     queueHealthDecider.addAllUpstreams(Collections.singletonList(queueRejectionClusterRca));
 
     constructShardResourceUsageGraph();
-    constructResourceHeatMapGraph();
+
+    // The temperature profile is not stable. It is turned OFF for now.
+    // constructResourceHeatMapGraph();
 
     // Collator - Collects actions from all deciders and aligns impact vectors
     Collator collator = new Collator(EVALUATION_INTERVAL_SECONDS, queueHealthDecider);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessor.java
@@ -44,12 +44,11 @@ public class ClusterDetailsEventProcessor implements EventProcessor {
 
   public ClusterDetailsEventProcessor(final ClusterDetailsEventProcessor other) {
     if (other.nodesDetails != null) {
-      List<NodeDetails> nodeDetails = new ArrayList<>();
+      ImmutableList.Builder builder = new ImmutableList.Builder<NodeDetails>();
       for (final NodeDetails oldDetails : other.nodesDetails) {
-        NodeDetails copiedNodeDetails = new NodeDetails(oldDetails);
-        nodeDetails.add(copiedNodeDetails);
+        builder.add(new NodeDetails(oldDetails));
       }
-      this.nodesDetails = ImmutableList.copyOf(nodeDetails);
+      this.nodesDetails = builder.build();
     }
   }
 
@@ -162,10 +161,12 @@ public class ClusterDetailsEventProcessor implements EventProcessor {
     }
 
     public NodeDetails(final NodeDetails other) {
-      this.id = other.id;
-      this.hostAddress = other.hostAddress;
-      this.isMasterNode = other.isMasterNode;
-      this.role = other.role;
+      if (other != null) {
+        this.id = other.id;
+        this.hostAddress = other.hostAddress;
+        this.isMasterNode = other.isMasterNode;
+        this.role = other.role;
+      }
     }
 
     @Override

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessor.java
@@ -161,7 +161,7 @@ public class ClusterDetailsEventProcessor implements EventProcessor {
       this.role = role.toString();
     }
 
-    public NodeDetails(NodeDetails other) {
+    public NodeDetails(final NodeDetails other) {
       this.id = other.id;
       this.hostAddress = other.hostAddress;
       this.isMasterNode = other.isMasterNode;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessor.java
@@ -40,6 +40,19 @@ public class ClusterDetailsEventProcessor implements EventProcessor {
    */
   private volatile ImmutableList<NodeDetails> nodesDetails = null;
 
+  public ClusterDetailsEventProcessor() {}
+
+  public ClusterDetailsEventProcessor(final ClusterDetailsEventProcessor other) {
+    if (other.nodesDetails != null) {
+      List<NodeDetails> nodeDetails = new ArrayList<>();
+      for (final NodeDetails oldDetails : other.nodesDetails) {
+        NodeDetails copiedNodeDetails = new NodeDetails(oldDetails);
+        nodeDetails.add(copiedNodeDetails);
+      }
+      this.nodesDetails = ImmutableList.copyOf(nodeDetails);
+    }
+  }
+
   @Override
   public void initializeProcessing(long startTime, long endTime) {}
 
@@ -146,6 +159,13 @@ public class ClusterDetailsEventProcessor implements EventProcessor {
       this.hostAddress = hostAddress;
       this.isMasterNode = isMaster;
       this.role = role.toString();
+    }
+
+    public NodeDetails(NodeDetails other) {
+      this.id = other.id;
+      this.hostAddress = other.hostAddress;
+      this.isMasterNode = other.isMasterNode;
+      this.role = other.role;
     }
 
     @Override

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessor.java
@@ -436,10 +436,7 @@ public class ReaderMetricsProcessor implements Runnable {
     EventProcessor nodeEventsProcessor =
         NodeMetricsEventProcessor.buildNodeMetricEventsProcessor(
             currWindowStartTime, conn, nodeMetricsMap);
-    EventProcessor clusterDetailsEventsProcessor = new ClusterDetailsEventProcessor();
-    if (appContext != null) {
-      appContext.setClusterDetailsEventProcessor((ClusterDetailsEventProcessor) clusterDetailsEventsProcessor);
-    }
+    ClusterDetailsEventProcessor clusterDetailsEventsProcessor = new ClusterDetailsEventProcessor();
 
     // The event dispatcher dispatches events to each of the registered event processors.
     // In addition to event processing each processor has an initialize/finalize function that is
@@ -465,6 +462,10 @@ public class ReaderMetricsProcessor implements Runnable {
     eventDispatcher.finalizeProcessing();
 
     emitMetrics(currWindowStartTime);
+
+    if (appContext != null && !clusterDetailsEventsProcessor.getNodesDetails().isEmpty()) {
+      appContext.setClusterDetailsEventProcessor(clusterDetailsEventsProcessor);
+    }
 
     StatsCollector.instance()
         .logStatsRecord(null, STATS_DATA, TIMING_STATS, start, System.currentTimeMillis());

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessor.java
@@ -463,6 +463,11 @@ public class ReaderMetricsProcessor implements Runnable {
 
     emitMetrics(currWindowStartTime);
 
+    // There are cases, such as tests where appContext may not be initialized.
+    // We always create a new ClusterDetailsEventsProcessor object above but we may not always
+    // process the writer file, in which case the recently initialized
+    // ClusterDetailsEventsProcessor does not contain valid values. Therefore, the empty check
+    // for nodeDetails is required.
     if (appContext != null && !clusterDetailsEventsProcessor.getNodesDetails().isEmpty()) {
       appContext.setClusterDetailsEventProcessor(clusterDetailsEventsProcessor);
     }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/threads/ThreadProvider.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/threads/ThreadProvider.java
@@ -46,6 +46,7 @@ public class ThreadProvider {
       try {
         innerRunnable.run();
       } catch (Throwable innerThrowable) {
+        LOG.error("A thread crashed: ", innerThrowable);
         try {
           PerformanceAnalyzerApp.exceptionQueue.put(new PAThreadException(paThread,
               innerThrowable));


### PR DESCRIPTION
There was a bug where we were updating the ClusterDetailsEventProcessor before it was filled with data. This fixes it and some other cases where we can run into NPE.

*Issue #:* #305

*Description of changes:* ReaderMetricsProcessor skips updating the ClusterDetails every other time this is when the AppContext will be set with a cluster details that says the current node role is unknown. This would be the reason the RCA rest API would complain about the current node not being the elected master. 

The change in the node role can also cause the RcaScheduler to not start up.

*Tests:* Tested it on docker where the error was reported.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
