### PR TITLE
Update jackson and bouncycastle artifacts

### DIFF
--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -1,11 +1,11 @@
 ** GoogleGuava; version 27.0.1-jre -- https://github.com/google/guava
-** Jackson-annotations; version 2.8.11 -- https://github.com/FasterXML/jackson-annotations/
-** Jackson-databind; version 2.8.11 -- https://github.com/FasterXML/jackson-databind
+** Jackson-annotations; version 2.11.1 -- https://github.com/FasterXML/jackson-annotations/
+** Jackson-databind; version 2.11.1 -- https://github.com/FasterXML/jackson-databind
 ** jooq; version 3.10.8 -- https://github.com/jOOQ/jOOQ
 ** org.xerial:sqlite-jdbc; version 3.8.11.2 -- https://bitbucket.org/xerial/sqlite-jdbc/src/8de652d3f54cdfd32d5a493130c995f36e16c652/LICENSE?at=default&fileviewer=file-view-default
 ** PowerMock; version 1.6.1 -- https://github.com/powermock/powermock
 ** Javax-annotation; version 1.3.2 -- https://github.com/javaee/javax.annotation
-** Bouncy castle; version 1.60 -- https://github.com/bcgit/bc-java
+** Bouncy castle; version 1.66 -- https://github.com/bcgit/bc-java
 ** xerial/sqlite-jdbc; version 3.8.11 -- https://github.com/xerial/sqlite-jdbc
 ** log4j; version 2.8 -- https://github.com/apache/log4j
 ** grpc-java; version 1.25 -- https://github.com/grpc/grpc-java

--- a/build.gradle
+++ b/build.gradle
@@ -229,12 +229,12 @@ dependencies {
     }
 
     compile 'org.jooq:jooq:3.10.8'
-    compile 'org.bouncycastle:bcprov-jdk15on:1.60'
-    compile 'org.bouncycastle:bcpkix-jdk15on:1.60'
+    compile 'org.bouncycastle:bcprov-jdk15on:1.66'
+    compile 'org.bouncycastle:bcpkix-jdk15on:1.66'
     compile 'org.xerial:sqlite-jdbc:3.8.11.2'
     compile 'com.google.guava:guava:28.1-jre'
-    compile 'com.fasterxml.jackson.core:jackson-annotations:2.8.11'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.8.11'
+    compile 'com.fasterxml.jackson.core:jackson-annotations:2.11.1'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.11.1'
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.13.0'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.13.0'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'


### PR DESCRIPTION
*Issue #:* #306 

*Description of changes:*
- Update com.fasterxml.jackson.core:jackson-annotations to 2.11.1
- Update com.fasterxml.jackson.corejackson-databind to 2.11.1
- Update org.bouncycastle:bcprov-jdk15on to 1.66
- Update org.bouncycastle:bcpix-jdk15on to 1.66

*Tests:* N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
