### PR TITLE
Grpc server can run on different ports on different nodes of the cluster

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/PluginSettings.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/PluginSettings.java
@@ -115,7 +115,8 @@ public class PluginSettings {
   }
 
   @VisibleForTesting
-  public @Nullable String getProperty(String key) {
+  @Nullable
+  public String getProperty(String key) {
     return settings.getProperty(key);
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/PluginSettings.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/PluginSettings.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.util.Properties;
 
+import javax.annotation.Nullable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -111,6 +112,11 @@ public class PluginSettings {
   @VisibleForTesting
   public void overrideProperty(String key, String value) {
     settings.setProperty(key, value);
+  }
+
+  @VisibleForTesting
+  public @Nullable String getProperty(String key) {
+    return settings.getProperty(key);
   }
 
   public boolean shouldCleanupMetricsDBFiles() {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/Decision.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/Decision.java
@@ -19,6 +19,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.act
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericFlowUnit;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -65,7 +66,7 @@ public class Decision extends GenericFlowUnit {
   }
 
   @Override
-  public FlowUnitMessage buildFlowUnitMessage(String graphNode, String esNode) {
+  public FlowUnitMessage buildFlowUnitMessage(String graphNode, InstanceDetails.Id esNode) {
     // All deciders run on the master node, (in initial versions), so we dont expect Decisions
     // to be passed over wire.
     throw new IllegalStateException(

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/EmptyFlowUnit.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/EmptyFlowUnit.java
@@ -17,6 +17,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.de
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 
 public class EmptyFlowUnit extends GenericFlowUnit {
 
@@ -25,7 +26,7 @@ public class EmptyFlowUnit extends GenericFlowUnit {
   }
 
   @Override
-  public FlowUnitMessage buildFlowUnitMessage(String graphNode, String esNode) {
+  public FlowUnitMessage buildFlowUnitMessage(String graphNode, InstanceDetails.Id esNode) {
     throw new IllegalStateException(this.getClass().getSimpleName() + " not expected to be passed over wire");
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/net/GRPCConnectionManager.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/net/GRPCConnectionManager.java
@@ -113,7 +113,7 @@ public class GRPCConnectionManager {
    */
   public InterNodeRpcServiceStub getClientStubForHost(
       final InstanceDetails remoteHost) {
-    final AtomicReference<InterNodeRpcServiceStub> stubAtomicReference = perHostClientStubMap.get(remoteHost);
+    final AtomicReference<InterNodeRpcServiceStub> stubAtomicReference = perHostClientStubMap.get(remoteHost.getInstanceId());
     if (stubAtomicReference != null) {
       return stubAtomicReference.get();
     }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/net/NetClient.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/net/NetClient.java
@@ -26,6 +26,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.PublishRespo
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeResponse;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import java.util.Map;
@@ -56,7 +57,7 @@ public class NetClient {
     return connectionManager;
   }
 
-  private ConcurrentMap<String, AtomicReference<StreamObserver<FlowUnitMessage>>> perHostOpenDataStreamMap =
+  private ConcurrentMap<InstanceDetails.Id, AtomicReference<StreamObserver<FlowUnitMessage>>> perHostOpenDataStreamMap =
       new ConcurrentHashMap<>();
 
   /**
@@ -69,16 +70,14 @@ public class NetClient {
    * @param serverResponseStream The response stream for the server to communicate back on.
    */
   public void subscribe(
-      final String remoteHost,
+      final InstanceDetails remoteHost,
       final SubscribeMessage subscribeMessage,
       StreamObserver<SubscribeResponse> serverResponseStream) {
     LOG.debug("Trying to send intent message to {}", remoteHost);
     try {
-      connectionManager
-          .getClientStubForHost(remoteHost)
-          .subscribe(subscribeMessage, serverResponseStream);
+      connectionManager.getClientStubForHost(remoteHost).subscribe(subscribeMessage, serverResponseStream);
       PerformanceAnalyzerApp.RCA_GRAPH_METRICS_AGGREGATOR
-          .updateStat(RcaGraphMetrics.NET_BYTES_OUT, subscribeMessage.getRequesterNode(),
+          .updateStat(RcaGraphMetrics.NET_BYTES_OUT, subscribeMessage.getRequesterGraphNode(),
               subscribeMessage.getSerializedSize());
     } catch (StatusRuntimeException sre) {
       LOG.error("Encountered an error trying to subscribe. Status: {}",
@@ -97,7 +96,7 @@ public class NetClient {
    * @param serverResponseStream The stream for the server to communicate back on.
    */
   public void publish(
-      final String remoteHost,
+      final InstanceDetails remoteHost,
       final FlowUnitMessage flowUnitMessage,
       final StreamObserver<PublishResponse> serverResponseStream) {
     LOG.debug("Publishing {} data to {}", flowUnitMessage.getGraphNode(), remoteHost);
@@ -116,7 +115,7 @@ public class NetClient {
   }
 
   public void getMetrics(
-      String remoteNodeIP,
+      InstanceDetails remoteNodeIP,
       MetricsRequest request,
       StreamObserver<MetricsResponse> responseObserver) {
     InterNodeRpcServiceGrpc.InterNodeRpcServiceStub stub =
@@ -129,13 +128,13 @@ public class NetClient {
     closeAllDataStreams();
   }
 
-  public void flushStream(final String remoteHost) {
+  public void flushStream(final InstanceDetails.Id remoteHost) {
     LOG.debug("removing data streams for {} as we are no publishing to it.", remoteHost);
     perHostOpenDataStreamMap.remove(remoteHost);
   }
 
   private void closeAllDataStreams() {
-    for (Map.Entry<String, AtomicReference<StreamObserver<FlowUnitMessage>>> entry :
+    for (Map.Entry<InstanceDetails.Id, AtomicReference<StreamObserver<FlowUnitMessage>>> entry :
         perHostOpenDataStreamMap.entrySet()) {
       LOG.debug("Closing stream for host: {}", entry.getKey());
       // Sending an onCompleted should trigger the subscriber's node state manager
@@ -146,7 +145,7 @@ public class NetClient {
   }
 
   private StreamObserver<FlowUnitMessage> getDataStreamForHost(
-      final String remoteHost, final StreamObserver<PublishResponse> serverResponseStream) {
+      final InstanceDetails remoteHost, final StreamObserver<PublishResponse> serverResponseStream) {
     final AtomicReference<StreamObserver<FlowUnitMessage>> streamObserverAtomicReference =
         perHostOpenDataStreamMap.get(remoteHost);
     if (streamObserverAtomicReference != null) {
@@ -163,12 +162,11 @@ public class NetClient {
    * @return A stream to the host.
    */
   private synchronized StreamObserver<FlowUnitMessage> addOrUpdateDataStreamForHost(
-      final String remoteHost, final StreamObserver<PublishResponse> serverResponseStream) {
-    InterNodeRpcServiceGrpc.InterNodeRpcServiceStub stub =
-        connectionManager.getClientStubForHost(remoteHost);
+      final InstanceDetails remoteHost, final StreamObserver<PublishResponse> serverResponseStream) {
+    InterNodeRpcServiceGrpc.InterNodeRpcServiceStub stub = connectionManager.getClientStubForHost(remoteHost);
     final StreamObserver<FlowUnitMessage> dataStream = stub.publish(serverResponseStream);
-    perHostOpenDataStreamMap.computeIfAbsent(remoteHost, s -> new AtomicReference<>());
-    perHostOpenDataStreamMap.get(remoteHost).set(dataStream);
+    perHostOpenDataStreamMap.computeIfAbsent(remoteHost.getInstanceId(), s -> new AtomicReference<>());
+    perHostOpenDataStreamMap.get(remoteHost.getInstanceId()).set(dataStream);
     return dataStream;
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/net/NetClient.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/net/NetClient.java
@@ -147,7 +147,7 @@ public class NetClient {
   private StreamObserver<FlowUnitMessage> getDataStreamForHost(
       final InstanceDetails remoteHost, final StreamObserver<PublishResponse> serverResponseStream) {
     final AtomicReference<StreamObserver<FlowUnitMessage>> streamObserverAtomicReference =
-        perHostOpenDataStreamMap.get(remoteHost);
+        perHostOpenDataStreamMap.get(remoteHost.getInstanceId());
     if (streamObserverAtomicReference != null) {
       return streamObserverAtomicReference.get();
     }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -466,4 +466,9 @@ public class RcaController {
   public void setDeliberateInterrupt() {
     deliberateInterrupt = true;
   }
+
+  public void setDbProvider(Queryable dbProvider) {
+    this.dbProvider = dbProvider;
+  }
+
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/MetricFlowUnit.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/MetricFlowUnit.java
@@ -17,6 +17,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.ap
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import java.util.List;
 import org.jooq.Field;
 import org.jooq.Record;
@@ -53,7 +54,7 @@ public class MetricFlowUnit extends GenericFlowUnit {
    * never be called. so return null in case we run into it.
    */
   @Override
-  public FlowUnitMessage buildFlowUnitMessage(final String graphNode, final String esNode) {
+  public FlowUnitMessage buildFlowUnitMessage(final String graphNode, final InstanceDetails.Id esNode) {
     return null;
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/NodeConfigFlowUnit.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/NodeConfigFlowUnit.java
@@ -23,6 +23,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.contexts.ResourceContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -107,8 +108,8 @@ public class NodeConfigFlowUnit extends ResourceFlowUnit<HotNodeSummary> {
     NodeConfigFlowUnit nodeConfigFlowUnit;
     if (message.getSummaryOneofCase() == SummaryOneofCase.HOTNODESUMMARY) {
       HotNodeSummaryMessage nodeSummaryMessage = message.getHotNodeSummary();
-      NodeKey nodeKey = new NodeKey(nodeSummaryMessage.getNodeID(),
-          nodeSummaryMessage.getHostAddress());
+      NodeKey nodeKey = new NodeKey(new InstanceDetails.Id(nodeSummaryMessage.getNodeID()),
+          new InstanceDetails.Ip(nodeSummaryMessage.getHostAddress()));
       nodeConfigFlowUnit = new NodeConfigFlowUnit(message.getTimeStamp(), nodeKey);
       if (nodeSummaryMessage.hasHotResourceSummaryList()) {
         for (int i = 0;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/ResourceFlowUnit.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/ResourceFlowUnit.java
@@ -24,6 +24,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
@@ -106,10 +107,10 @@ public class ResourceFlowUnit<T extends GenericSummary> extends GenericFlowUnit 
   }
 
   @Override
-  public FlowUnitMessage buildFlowUnitMessage(final String graphNode, final String esNode) {
+  public FlowUnitMessage buildFlowUnitMessage(final String graphNode, final InstanceDetails.Id esNode) {
     final FlowUnitMessage.Builder messageBuilder = FlowUnitMessage.newBuilder();
     messageBuilder.setGraphNode(graphNode);
-    messageBuilder.setEsNode(esNode);
+    messageBuilder.setEsNode(esNode.toString());
     messageBuilder.setTimeStamp(System.currentTimeMillis());
     if (resourceContext != null) {
           messageBuilder.setResourceContext(resourceContext.buildContextMessage());

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/SymptomFlowUnit.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/SymptomFlowUnit.java
@@ -19,6 +19,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMess
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.contexts.SymptomContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericFlowUnit;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import java.util.List;
 
 public class SymptomFlowUnit extends GenericFlowUnit {
@@ -54,10 +55,10 @@ public class SymptomFlowUnit extends GenericFlowUnit {
     return new SymptomFlowUnit(System.currentTimeMillis());
   }
 
-  public FlowUnitMessage buildFlowUnitMessage(final String graphNode, final String esNode) {
+  public FlowUnitMessage buildFlowUnitMessage(final String graphNode, final InstanceDetails.Id esNode) {
     final FlowUnitMessage.Builder messageBuilder = FlowUnitMessage.newBuilder();
     messageBuilder.setGraphNode(graphNode);
-    messageBuilder.setEsNode(esNode);
+    messageBuilder.setEsNode(esNode.toString());
 
     messageBuilder.setTimeStamp(System.currentTimeMillis());
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/temperature/ClusterTemperatureFlowUnit.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/temperature/ClusterTemperatureFlowUnit.java
@@ -19,6 +19,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMess
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.contexts.ResourceContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.ClusterTemperatureSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 
 public class ClusterTemperatureFlowUnit extends ResourceFlowUnit<ClusterTemperatureSummary> {
     private final ClusterTemperatureSummary clusterTemperatureSummary;
@@ -30,7 +31,7 @@ public class ClusterTemperatureFlowUnit extends ResourceFlowUnit<ClusterTemperat
     }
 
     @Override
-    public FlowUnitMessage buildFlowUnitMessage(String graphNode, String esNode) {
+    public FlowUnitMessage buildFlowUnitMessage(String graphNode, InstanceDetails.Id esNode) {
         throw new IllegalStateException(this.getClass().getSimpleName() + " should not be passed "
                 + "over the wire.");
     }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/temperature/CompactNodeTemperatureFlowUnit.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/temperature/CompactNodeTemperatureFlowUnit.java
@@ -20,6 +20,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.contexts.ResourceContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.CompactNodeSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 
 /**
  * This is a grpc wrapper on top of the CompactNodeTemperatureSummary. The flow unit is passed
@@ -43,10 +45,10 @@ public class CompactNodeTemperatureFlowUnit extends ResourceFlowUnit<CompactNode
     }
 
     @Override
-    public FlowUnitMessage buildFlowUnitMessage(String graphNode, String esNode) {
+    public FlowUnitMessage buildFlowUnitMessage(String graphNode, InstanceDetails.Id esNode) {
         FlowUnitMessage.Builder builder = FlowUnitMessage.newBuilder();
         builder.setGraphNode(graphNode);
-        builder.setEsNode(esNode);
+        builder.setEsNode(esNode.toString());
         builder.setTimeStamp(System.currentTimeMillis());
         if (compactNodeTemperatureSummary != null) {
             compactNodeTemperatureSummary.buildSummaryMessageAndAddToFlowUnit(builder);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/temperature/DimensionalTemperatureFlowUnit.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/temperature/DimensionalTemperatureFlowUnit.java
@@ -19,6 +19,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMess
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.contexts.ResourceContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.NodeLevelDimensionalSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 
 /**
  * This is the FlowUnit wrapper over the summary of the given node across all the tracked
@@ -42,7 +43,7 @@ public class DimensionalTemperatureFlowUnit extends ResourceFlowUnit<NodeLevelDi
 
     // A dimension flow unit never leaves a node. So, we don't need to generate protobuf messages.
     @Override
-    public FlowUnitMessage buildFlowUnitMessage(String graphNode, String esNode) {
+    public FlowUnitMessage buildFlowUnitMessage(String graphNode, InstanceDetails.Id esNode) {
         throw new IllegalStateException(this.getClass().getSimpleName() + " should not be passed "
                 + "over the wire.");
     }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/GenericFlowUnit.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/GenericFlowUnit.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 
 // TODO: Doc comments and a description of each member.
 public abstract class GenericFlowUnit {
@@ -37,5 +38,5 @@ public abstract class GenericFlowUnit {
     return this.empty;
   }
 
-  public abstract FlowUnitMessage buildFlowUnitMessage(final String graphNode, final String esNode);
+  public abstract FlowUnitMessage buildFlowUnitMessage(final String graphNode, final InstanceDetails.Id esNode);
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/InstanceDetails.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/InstanceDetails.java
@@ -15,34 +15,128 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.core.Util;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Objects;
+import com.google.common.net.InetAddresses;
 
 public class InstanceDetails {
-  private final AllMetrics.NodeRole role;
-  private final String InstanceId;
-  private final String instanceIp;
-  private final boolean isMaster;
+  public static class Ip {
 
-  public InstanceDetails(AllMetrics.NodeRole role, String instanceId, String instanceIp, boolean isMaster) {
+    // The only way to get the ip is to get the serialized string representation of it.
+    private String ip;
+
+    public Ip(String ip) {
+      if (!InetAddresses.isInetAddress(ip)) {
+        throw new IllegalArgumentException("The provided string is not an IPV4ip: '" + ip + "'");
+      }
+      this.ip = ip;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Ip)) {
+        return false;
+      }
+      Ip ip1 = (Ip) o;
+      return Objects.equal(ip, ip1.ip);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(ip);
+    }
+
+    @Override
+    public String toString() {
+      return ip;
+    }
+  }
+
+  public static class Id {
+    private String id;
+
+    public Id(String id) {
+      if (InetAddresses.isInetAddress(id)) {
+        throw new IllegalArgumentException("The provided string is in the form an IPV4 address: '" + id
+                + "'. Are you sure this is the host ID");
+      }
+      this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Id)) {
+        return false;
+      }
+      Id id1 = (Id) o;
+      return Objects.equal(id, id1.id);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(id);
+    }
+
+    @Override
+    public String toString() {
+      return id;
+    }
+  }
+
+
+  private final AllMetrics.NodeRole role;
+  private final Id instanceId;
+  private final Ip instanceIp;
+  private final boolean isMaster;
+  private final int grpcPort;
+
+  public InstanceDetails(AllMetrics.NodeRole role, Id instanceId, Ip instanceIp, boolean isMaster) {
+    this(role, instanceId, instanceIp, isMaster, Util.RPC_PORT);
+  }
+
+  public InstanceDetails(AllMetrics.NodeRole role, Id instanceId, Ip instanceIp, boolean isMaster, int grpcPort) {
     this.role = role;
-    InstanceId = instanceId;
+    this.instanceId = instanceId;
     this.instanceIp = instanceIp;
     this.isMaster = isMaster;
+    this.grpcPort = grpcPort;
+  }
+
+  public InstanceDetails(ClusterDetailsEventProcessor.NodeDetails nodeDetails) {
+    this(AllMetrics.NodeRole.valueOf(nodeDetails.getRole()),
+            new Id(nodeDetails.getId()),
+            new Ip(nodeDetails.getHostAddress()),
+            nodeDetails.getIsMasterNode(),
+            nodeDetails.getGrpcPort());
   }
 
   public InstanceDetails(AllMetrics.NodeRole role) {
-    this(role, "", "", false);
+    this(role, new Id("unknown"), new Ip("0.0.0.0"), false);
+  }
+
+  @VisibleForTesting
+  public InstanceDetails(Id instanceId, Ip instanceIp, int myGrpcServerPort) {
+    this(AllMetrics.NodeRole.UNKNOWN, instanceId, instanceIp, false, myGrpcServerPort);
   }
 
   public AllMetrics.NodeRole getRole() {
     return role;
   }
 
-  public String getInstanceId() {
-    return InstanceId;
+  public Id getInstanceId() {
+    return instanceId;
   }
 
-  public String getInstanceIp() {
+  public Ip getInstanceIp() {
     return instanceIp;
   }
 
@@ -50,13 +144,37 @@ public class InstanceDetails {
     return isMaster;
   }
 
+  public int getGrpcPort() {
+    return grpcPort;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof InstanceDetails)) {
+      return false;
+    }
+    InstanceDetails that = (InstanceDetails) o;
+    return isMaster == that.isMaster
+            && getGrpcPort() == that.getGrpcPort()
+            && getRole() == that.getRole()
+            && Objects.equal(getInstanceId(), that.getInstanceId())
+            && Objects.equal(getInstanceIp(), that.getInstanceIp());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(getRole(), getInstanceId(), getInstanceIp(), isMaster, getGrpcPort());
+  }
+
   @Override
   public String toString() {
-    return "InstanceDetails{"
-            + "role=" + role
-            + ", InstanceId='" + InstanceId + '\''
-            + ", instanceIp='" + instanceIp + '\''
-            + ", isMaster=" + isMaster
-            + '}';
+    return ""
+            + instanceId + "::"
+            + instanceIp + "::"
+            + role + "::"
+            + grpcPort;
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/messages/DataMsg.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/messages/DataMsg.java
@@ -19,23 +19,23 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import java.util.List;
 
 public class DataMsg {
-  String sourceNode;
-  List<String> destinationNodes;
+  String sourceGraphNode;
+  List<String> destinationGraphNodes;
   List<? extends GenericFlowUnit> flowUnits;
 
   public DataMsg(
-      String sourceNode, List<String> destinationNode, List<? extends GenericFlowUnit> flowUnits) {
-    this.sourceNode = sourceNode;
-    this.destinationNodes = destinationNode;
+          String sourceGraphNode, List<String> destinationNodes, List<? extends GenericFlowUnit> flowUnits) {
+    this.sourceGraphNode = sourceGraphNode;
+    this.destinationGraphNodes = destinationNodes;
     this.flowUnits = flowUnits;
   }
 
-  public String getSourceNode() {
-    return sourceNode;
+  public String getSourceGraphNode() {
+    return sourceGraphNode;
   }
 
-  public List<String> getDestinationNode() {
-    return destinationNodes;
+  public List<String> getDestinationGraphNodes() {
+    return destinationGraphNodes;
   }
 
   public List<? extends GenericFlowUnit> getFlowUnits() {
@@ -44,6 +44,6 @@ public class DataMsg {
 
   @Override
   public String toString() {
-    return String.format("Data::from: '%s', to: %s", sourceNode, destinationNodes);
+    return String.format("Data::from: '%s', to: %s", sourceGraphNode, destinationGraphNodes);
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/messages/IntentMsg.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/messages/IntentMsg.java
@@ -22,10 +22,10 @@ public class IntentMsg {
    * The node sending the intent. This is the node whose one or more dependency is not locally
    * available.
    */
-  String requesterNode;
+  String requesterGraphNode;
 
   /** The name of the destination node whose data is desired. */
-  String destinationNode;
+  String destinationGraphNode;
 
   /**
    * The requesting node's rca.conf tags. This tags will be used by the requested Node's network
@@ -33,26 +33,26 @@ public class IntentMsg {
    */
   Map<String, String> rcaConfTags;
 
-  public String getRequesterNode() {
-    return requesterNode;
+  public String getRequesterGraphNode() {
+    return requesterGraphNode;
   }
 
-  public String getDestinationNode() {
-    return destinationNode;
+  public String getDestinationGraphNode() {
+    return destinationGraphNode;
   }
 
   public Map<String, String> getRcaConfTags() {
     return rcaConfTags;
   }
 
-  public IntentMsg(String requesterNode, String destinationNode, Map<String, String> rcaConfTags) {
-    this.requesterNode = requesterNode;
-    this.destinationNode = destinationNode;
+  public IntentMsg(String requesterGraphNode, String destinationGraphNode, Map<String, String> rcaConfTags) {
+    this.requesterGraphNode = requesterGraphNode;
+    this.destinationGraphNode = destinationGraphNode;
     this.rcaConfTags = rcaConfTags;
   }
 
   @Override
   public String toString() {
-    return String.format("Intent::from: '%s', to: '%s'", requesterNode, destinationNode);
+    return String.format("Intent::from: '%s', to: '%s'", requesterGraphNode, destinationGraphNode);
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/messages/UnicastIntentMsg.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/messages/UnicastIntentMsg.java
@@ -1,18 +1,19 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import java.util.Map;
 
 public class UnicastIntentMsg extends IntentMsg {
 
-  private final String unicastDestinationHostAddress;
+  private final InstanceDetails unicastDestinationInstance;
 
   public UnicastIntentMsg(String requesterNode, String destinationNode,
-      Map<String, String> rcaConfTags, String unicastDestinationHostAddress) {
+      Map<String, String> rcaConfTags, InstanceDetails unicastDestinationInstance) {
     super(requesterNode, destinationNode, rcaConfTags);
-    this.unicastDestinationHostAddress = unicastDestinationHostAddress;
+    this.unicastDestinationInstance = unicastDestinationInstance;
   }
 
-  public String getUnicastDestinationHostAddress() {
-    return unicastDestinationHostAddress;
+  public InstanceDetails getUnicastDestinationInstance() {
+    return unicastDestinationInstance;
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/NodeStateManager.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/NodeStateManager.java
@@ -17,6 +17,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeResponse.SubscriptionStatus;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.util.ClusterUtils;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -35,12 +36,12 @@ public class NodeStateManager {
   private static final String SEPARATOR = ".";
 
   /**
-   * Map of host address of a remote node to the last time we received a flow unit from that node.
+   * Map of hostID of a remote node to the last time we received a flow unit from that node.
    */
   private final ConcurrentMap<String, Long> lastReceivedTimestampMap = new ConcurrentHashMap<>();
 
   /**
-   * Map of host address to the current subscription status of that host.
+   * Map of hostId to the current subscription status of that host.
    */
   private final ConcurrentMap<String, AtomicReference<SubscriptionStatus>> subscriptionStatusMap =
       new ConcurrentHashMap<>();
@@ -59,7 +60,7 @@ public class NodeStateManager {
    * @param graphNode The vertex for which the flow unit was sent for.
    * @param timestamp The timestamp at which we received.
    */
-  public void updateReceiveTime(final String host, final String graphNode, final long timestamp) {
+  public void updateReceiveTime(final InstanceDetails.Id host, final String graphNode, final long timestamp) {
     final String compositeKey = graphNode + SEPARATOR + host;
     lastReceivedTimestampMap.put(compositeKey, timestamp);
   }
@@ -73,14 +74,14 @@ public class NodeStateManager {
    * @return The timestamp at which we received a flow unit from the host for the vertex if present,
    *         a timestamp in the distant past(0) otherwise.
    */
-  public long getLastReceivedTimestamp(String graphNode, String host) {
+  public long getLastReceivedTimestamp(String graphNode, InstanceDetails.Id host) {
     final String compositeKey = graphNode + SEPARATOR + host;
     // Return the last received value or a value that is in the distant past.
     return lastReceivedTimestampMap.getOrDefault(compositeKey, 0L);
   }
 
   @VisibleForTesting
-  SubscriptionStatus getSubscriptionStatus(String graphNode, String host) {
+  SubscriptionStatus getSubscriptionStatus(String graphNode, InstanceDetails.Id host) {
     final String compositeKey = graphNode + SEPARATOR + host;
     // Return the last received value or a value that is in the distant past.
     AtomicReference<SubscriptionStatus> ref = subscriptionStatusMap.get(compositeKey);
@@ -97,7 +98,7 @@ public class NodeStateManager {
    * @param host      The host.
    * @param status    The subscription status.
    */
-  public synchronized void updateSubscriptionState(final String graphNode, final String host, final
+  public synchronized void updateSubscriptionState(final String graphNode, final InstanceDetails.Id host, final
   SubscriptionStatus status) {
     final String compositeKey = graphNode + SEPARATOR + host;
     subscriptionStatusMap.putIfAbsent(compositeKey, new AtomicReference<>());
@@ -114,22 +115,31 @@ public class NodeStateManager {
    * @param publishers      A set of known publishers for the current vertex.
    * @return a list of hosts that we need to subscribe to.
    */
-  public ImmutableList<String> getStaleOrNotSubscribedNodes(final String graphNode,
-      final long maxIdleDuration, Set<String> publishers) {
+  public ImmutableList<InstanceDetails> getStaleOrNotSubscribedNodes(final String graphNode,
+      final long maxIdleDuration, Set<InstanceDetails.Id> publishers) {
     final long currentTime = System.currentTimeMillis();
-    final Set<String> hostsToSubscribeTo = new HashSet<>();
-    for (final String publisher : publishers) {
+    final Set<InstanceDetails> hostsToSubscribeTo = new HashSet<>();
+
+    for (final InstanceDetails.Id publisher : publishers) {
       long lastRxTimestamp = getLastReceivedTimestamp(graphNode, publisher);
-      if (lastRxTimestamp > 0 && currentTime - lastRxTimestamp > maxIdleDuration && ClusterUtils
-          .isHostAddressInCluster(publisher, appContext.getAllClusterInstances())) {
-        hostsToSubscribeTo.add(publisher);
+
+      // If we haven't received FlowUnits from the Instance for a certain amount of time (enough to consider it stale)
+      // and the node is still part of the cluster, we better re-send subscription. The node might have restarted or
+      // something and forgot that we want to subscribe to its data.
+      if (lastRxTimestamp > 0
+              && currentTime - lastRxTimestamp > maxIdleDuration
+              && ClusterUtils.isHostIdInCluster(publisher, appContext.getAllClusterInstances())) {
+        hostsToSubscribeTo.add(appContext.getInstanceById(publisher));
       }
     }
 
-    final List<String> peers = appContext.getPeerInstanceIps();
+    // Then we go over all the nodes in the cluster once more. There might be new nodes that have joined the cluster
+    // that are evaluating the graph nodes whose data we are interested in. So, we want to send them a subscription
+    // message as well.
+    final Set<InstanceDetails> peers = appContext.getPeerInstances();
     if (peers != null) {
-      for (final String peerHost : peers) {
-        String compositeKey = graphNode + SEPARATOR + peerHost;
+      for (final InstanceDetails peerHost : peers) {
+        String compositeKey = graphNode + SEPARATOR + peerHost.getInstanceId();
         if (!subscriptionStatusMap.containsKey(compositeKey)) {
           hostsToSubscribeTo.add(peerHost);
         }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopper.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopper.java
@@ -48,6 +48,7 @@ public class WireHopper {
   private final SubscriptionManager subscriptionManager;
   private final NodeStateManager nodeStateManager;
   private final AtomicReference<ExecutorService> executorReference;
+
   private final ReceivedFlowUnitStore receivedFlowUnitStore;
   private final AppContext appContext;
 
@@ -150,4 +151,25 @@ public class WireHopper {
     netClient.stop();
     netClient.getConnectionManager().shutdown();
   }
+
+  @VisibleForTesting
+  public SubscriptionManager getSubscriptionManager() {
+    return subscriptionManager;
+  }
+
+  @VisibleForTesting
+  public NodeStateManager getNodeStateManager() {
+    return nodeStateManager;
+  }
+
+  @VisibleForTesting
+  public AtomicReference<ExecutorService> getExecutorReference() {
+    return executorReference;
+  }
+
+  @VisibleForTesting
+  public ReceivedFlowUnitStore getReceivedFlowUnitStore() {
+    return receivedFlowUnitStore;
+  }
+
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopper.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopper.java
@@ -143,4 +143,11 @@ public class WireHopper {
     }
     return remoteFlowUnits;
   }
+
+  @VisibleForTesting
+  public void shutdownAll() {
+    executorReference.get().shutdown();
+    netClient.stop();
+    netClient.getConnectionManager().shutdown();
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/handler/SubscribeServerHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/handler/SubscribeServerHandler.java
@@ -55,7 +55,7 @@ public class SubscribeServerHandler {
       try {
         executorService.execute(new SubscriptionRxTask(subscriptionManager, subscribeRequest));
         PerformanceAnalyzerApp.RCA_GRAPH_METRICS_AGGREGATOR.updateStat(RcaGraphMetrics.NET_BYTES_IN,
-            subscribeRequest.getSubscribeMessage().getRequesterNode(),
+            subscribeRequest.getSubscribeMessage().getRequesterGraphNode(),
             subscribeRequest.getSubscribeMessage().getSerializedSize());
       } catch (final RejectedExecutionException ree) {
         LOG.warn("Dropped processing subscription request because the network threadpool is full");

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/BroadcastSubscriptionTxTask.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/BroadcastSubscriptionTxTask.java
@@ -17,10 +17,10 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.tasks;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetClient;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.IntentMsg;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.NodeStateManager;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.SubscriptionManager;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.util.ClusterUtils;
 import java.util.Map;
 
 /**
@@ -43,11 +43,11 @@ public class BroadcastSubscriptionTxTask extends SubscriptionTxTask {
    */
   @Override
   public void run() {
-    final String requesterVertex = intentMsg.getRequesterNode();
-    final String destinationVertex = intentMsg.getDestinationNode();
+    final String requesterVertex = intentMsg.getRequesterGraphNode();
+    final String destinationVertex = intentMsg.getDestinationGraphNode();
     final Map<String, String> tags = intentMsg.getRcaConfTags();
 
-    for (final String remoteHost : getPeerIps()) {
+    for (final InstanceDetails remoteHost : getPeerInstances()) {
       sendSubscribeRequest(remoteHost, requesterVertex, destinationVertex, tags);
     }
   }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/FlowUnitRxTask.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/FlowUnitRxTask.java
@@ -19,6 +19,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyz
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.NodeStateManager;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.ReceivedFlowUnitStore;
@@ -62,7 +63,7 @@ public class FlowUnitRxTask implements Runnable {
    */
   @Override
   public void run() {
-    final String host = flowUnitMessage.getEsNode();
+    final InstanceDetails.Id host = new InstanceDetails.Id(flowUnitMessage.getEsNode());
     final String vertex = flowUnitMessage.getGraphNode();
 
     nodeStateManager.updateReceiveTime(host, vertex, System.currentTimeMillis());

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/SubscriptionTxTask.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/SubscriptionTxTask.java
@@ -20,6 +20,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyz
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetClient;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.IntentMsg;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.NodeStateManager;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.SubscribeResponseHandler;
@@ -27,6 +28,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.Subscript
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.util.ClusterUtils;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -72,16 +74,16 @@ public abstract class SubscriptionTxTask implements Runnable {
     this.appContext = appContext;
   }
 
-  protected void sendSubscribeRequest(final String remoteHost, final String requesterVertex,
+  protected void sendSubscribeRequest(final InstanceDetails remoteHost, final String requesterVertex,
       final String destinationVertex, final Map<String, String> tags) {
     LOG.debug("rca: [sub-tx]: {} -> {} to {}", requesterVertex, destinationVertex, remoteHost);
     final SubscribeMessage subscribeMessage = SubscribeMessage.newBuilder()
-                                                              .setDestinationNode(destinationVertex)
-                                                              .setRequesterNode(requesterVertex)
+                                                              .setDestinationGraphNode(destinationVertex)
+                                                              .setRequesterGraphNode(requesterVertex)
                                                               .putTags("locus", tags.get("locus"))
                                                               .putTags(
                                                                   "requester",
-                                                                  appContext.getMyInstanceDetails().getInstanceIp())
+                                                                  appContext.getMyInstanceDetails().getInstanceId().toString())
                                                               .build();
     netClient.subscribe(remoteHost, subscribeMessage,
         new SubscribeResponseHandler(subscriptionManager, nodeStateManager, remoteHost,
@@ -91,7 +93,7 @@ public abstract class SubscriptionTxTask implements Runnable {
             requesterVertex + ":" + destinationVertex, 1);
   }
 
-  public List<String> getPeerIps() {
-    return appContext.getPeerInstanceIps();
+  protected Set<InstanceDetails> getPeerInstances() {
+    return appContext.getPeerInstances();
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/UnicastSubscriptionTxTask.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/UnicastSubscriptionTxTask.java
@@ -17,6 +17,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.tasks;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.NetClient;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.UnicastIntentMsg;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.NodeStateManager;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.SubscriptionManager;
@@ -30,7 +31,7 @@ public class UnicastSubscriptionTxTask extends SubscriptionTxTask {
   /**
    * The host address of the destination node.
    */
-  private final String destinationHostAddress;
+  private final InstanceDetails destinationInstance;
 
   public UnicastSubscriptionTxTask(
       NetClient netClient,
@@ -39,7 +40,7 @@ public class UnicastSubscriptionTxTask extends SubscriptionTxTask {
       NodeStateManager nodeStateManager,
       final AppContext appContext) {
     super(netClient, intentMsg, subscriptionManager, nodeStateManager, appContext);
-    this.destinationHostAddress = intentMsg.getUnicastDestinationHostAddress();
+    this.destinationInstance = intentMsg.getUnicastDestinationInstance();
   }
 
   /**
@@ -48,10 +49,10 @@ public class UnicastSubscriptionTxTask extends SubscriptionTxTask {
    */
   @Override
   public void run() {
-    final String requesterVertex = intentMsg.getRequesterNode();
-    final String destinationVertex = intentMsg.getDestinationNode();
+    final String requesterVertex = intentMsg.getRequesterGraphNode();
+    final String destinationVertex = intentMsg.getDestinationGraphNode();
     final Map<String, String> tags = intentMsg.getRcaConfTags();
 
-    sendSubscribeRequest(destinationHostAddress, requesterVertex, destinationVertex, tags);
+    sendSubscribeRequest(destinationInstance, requesterVertex, destinationVertex, tags);
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
@@ -203,8 +203,7 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
 
     constructShardResourceUsageGraph();
 
-    // The temperature profile is not stable. It is turned OFF for now.
-    // constructResourceHeatMapGraph();
+    //constructResourceHeatMapGraph();
 
     // Collator - Collects actions from all deciders and aligns impact vectors
     Collator collator = new Collator(EVALUATION_INTERVAL_SECONDS, queueHealthDecider);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HighHeapUsageClusterRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HighHeapUsageClusterRca.java
@@ -81,7 +81,7 @@ public class HighHeapUsageClusterRca extends Rca<ResourceFlowUnit<HotClusterSumm
     ConcurrentMap<String, ImmutableList<ResourceFlowUnit<HotNodeSummary>>> currentMap =
         this.nodeStateCache.asMap();
     for (InstanceDetails nodeDetails : getDataNodeInstances()) {
-      ImmutableList<ResourceFlowUnit<HotNodeSummary>> nodeStateList = currentMap.get(nodeDetails.getInstanceId());
+      ImmutableList<ResourceFlowUnit<HotNodeSummary>> nodeStateList = currentMap.get(nodeDetails.getInstanceId().toString());
       if (nodeStateList != null) {
         List<HotResourceSummary> oldGenSummaries = new ArrayList<>();
         List<HotResourceSummary> youngGenSummaries = new ArrayList<>();
@@ -134,7 +134,7 @@ public class HighHeapUsageClusterRca extends Rca<ResourceFlowUnit<HotClusterSumm
       if (hotNodeRcaFlowUnit.isEmpty()) {
         continue;
       }
-      String nodeId = hotNodeRcaFlowUnit.getSummary().getNodeID();
+      String nodeId = hotNodeRcaFlowUnit.getSummary().getNodeID().toString();
       try {
         readComputeWrite(nodeId, hotNodeRcaFlowUnit);
       } catch (ExecutionException e) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/cluster/BaseClusterRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/cluster/BaseClusterRca.java
@@ -127,7 +127,7 @@ public class BaseClusterRca extends Rca<ResourceFlowUnit<HotClusterSummary>> {
   // to update the nodeMap whenever the ClusterDetailsEventProcessor is updated
   // so we don't have to keep polling the NodeDetails in every time window.
   private void removeInactiveNodeFromNodeMap() {
-    Set<String> nodeIdSet = new HashSet<>();
+    Set<InstanceDetails.Id> nodeIdSet = new HashSet<>();
     List<NodeKey> inactiveNodes = new ArrayList<>();
     for (InstanceDetails nodeDetail : getClusterNodesDetails()) {
       nodeIdSet.add(nodeDetail.getInstanceId());

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/cluster/NodeKey.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/cluster/NodeKey.java
@@ -19,10 +19,10 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.uti
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 public class NodeKey {
-  private final String nodeId;
-  private final String hostAddress;
+  private final InstanceDetails.Id nodeId;
+  private final InstanceDetails.Ip hostAddress;
 
-  public NodeKey(String nodeId, String hostAddress) {
+  public NodeKey(InstanceDetails.Id nodeId, InstanceDetails.Ip hostAddress) {
     this.nodeId = nodeId;
     this.hostAddress = hostAddress;
   }
@@ -31,11 +31,11 @@ public class NodeKey {
     this(instanceDetails.getInstanceId(), instanceDetails.getInstanceIp());
   }
 
-  public String getNodeId() {
+  public InstanceDetails.Id getNodeId() {
     return nodeId;
   }
 
-  public String getHostAddress() {
+  public InstanceDetails.Ip getHostAddress() {
     return hostAddress;
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotshard/HotShardClusterRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotshard/HotShardClusterRca.java
@@ -93,7 +93,7 @@ public class HotShardClusterRca extends Rca<ResourceFlowUnit<HotClusterSummary>>
 
     private void consumeFlowUnit(ResourceFlowUnit<HotNodeSummary> resourceFlowUnit) {
         HotNodeSummary hotNodeSummary = resourceFlowUnit.getSummary();
-        String nodeId = hotNodeSummary.getNodeID();
+        String nodeId = hotNodeSummary.getNodeID().toString();
         for (GenericSummary summary : hotNodeSummary.getNestedSummaryList()) {
             if (summary instanceof HotShardSummary) {
                 HotShardSummary hotShardSummary = (HotShardSummary) summary;
@@ -175,7 +175,7 @@ public class HotShardClusterRca extends Rca<ResourceFlowUnit<HotClusterSummary>>
             }
 
             if (resourceFlowUnit.getResourceContext().isUnhealthy()) {
-                unhealthyNodes.add(resourceFlowUnit.getSummary().getNodeID());
+                unhealthyNodes.add(resourceFlowUnit.getSummary().getNodeID().toString());
                 consumeFlowUnit(resourceFlowUnit);
             }
         }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotshard/HotShardRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotshard/HotShardRca.java
@@ -179,7 +179,7 @@ public class HotShardRca extends Rca<ResourceFlowUnit<HotNodeSummary>> {
                         || avgIoTotThroughput > ioTotThroughputThreshold
                         || avgIoTotSyscallRate > ioTotSysCallRateThreshold) {
                     HotShardSummary summary = new HotShardSummary(indexShardKey.getIndexName(),
-                            String.valueOf(indexShardKey.getShardId()), instanceDetails.getInstanceId(),
+                            String.valueOf(indexShardKey.getShardId()), instanceDetails.getInstanceId().toString(),
                         SLIDING_WINDOW_IN_SECONDS);
                     summary.setcpuUtilization(avgCpuUtilization);
                     summary.setCpuUtilizationThreshold(cpuUtilizationThreshold);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/NodeTemperatureRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/temperature/NodeTemperatureRca.java
@@ -131,8 +131,8 @@ public class NodeTemperatureRca extends Rca<CompactNodeTemperatureFlowUnit> {
 
     InstanceDetails instanceDetails = getInstanceDetails();
     FullNodeTemperatureSummary nodeProfile = new FullNodeTemperatureSummary(
-        instanceDetails.getInstanceId(),
-        instanceDetails.getInstanceIp());
+        instanceDetails.getInstanceId().toString(),
+        instanceDetails.getInstanceIp().toString());
     for (NodeLevelDimensionalSummary profile : dimensionProfiles) {
       nodeProfile.updateNodeDimensionProfile(profile);
     }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtils.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtils.java
@@ -1,5 +1,6 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.util;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import java.util.List;
 
@@ -7,14 +8,11 @@ import java.util.List;
  * Utility class to get details about the nodes in the cluster.
  */
 public class ClusterUtils {
-  public static boolean isHostAddressInCluster(final String hostAddress, final List<InstanceDetails> clusterInstances) {
-    if (clusterInstances.size() > 0) {
-      for (InstanceDetails node : clusterInstances) {
-        if (node.getInstanceIp().equals(hostAddress)) {
-          return true;
-        }
-      }
-    }
-    return false;
+  public static boolean isHostIdInCluster(final InstanceDetails.Id hostId, final List<InstanceDetails> clusterInstances) {
+    return clusterInstances
+            .stream()
+            .anyMatch(
+                    x -> hostId.equals(x.getInstanceId())
+            );
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ClusterDetailsEventProcessor.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.core.Util;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.RcaControllerHelper;
@@ -142,6 +143,7 @@ public class ClusterDetailsEventProcessor implements EventProcessor {
     private String hostAddress;
     private String role;
     private Boolean isMasterNode;
+    private int grpcPort = Util.RPC_PORT;
 
     NodeDetails(String stringifiedMetrics) {
       Map<String, Object> map = JsonConverter
@@ -154,10 +156,15 @@ public class ClusterDetailsEventProcessor implements EventProcessor {
     }
 
     public NodeDetails(AllMetrics.NodeRole role, String id, String hostAddress, boolean isMaster) {
+      this(role, id, hostAddress, isMaster, Util.RPC_PORT);
+    }
+
+    public NodeDetails(AllMetrics.NodeRole role, String id, String hostAddress, boolean isMaster, int grpcPort) {
       this.id = id;
       this.hostAddress = hostAddress;
       this.isMasterNode = isMaster;
       this.role = role.toString();
+      this.grpcPort = grpcPort;
     }
 
     public NodeDetails(final NodeDetails other) {
@@ -209,6 +216,10 @@ public class ClusterDetailsEventProcessor implements EventProcessor {
         isMasterNode = this.hostAddress.equalsIgnoreCase(electedMasterHostAddress);
       }
       return isMasterNode;
+    }
+
+    public int getGrpcPort() {
+      return grpcPort;
     }
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryMetricsRequestHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryMetricsRequestHandler.java
@@ -154,7 +154,7 @@ public class QueryMetricsRequestHandler extends MetricsHandler implements HttpHa
         final List<InstanceDetails> allNodes = appContext.getAllClusterInstances();
         String localNodeId = "local";
         if (allNodes.size() != 0) {
-          localNodeId = allNodes.get(0).getInstanceId();
+          localNodeId = allNodes.get(0).getInstanceId().toString();
         }
         nodeResponses.put(localNodeId, localResponseWithTimestamp);
         String response = metricsRestUtil.nodeJsonBuilder(nodeResponses);
@@ -233,7 +233,7 @@ public class QueryMetricsRequestHandler extends MetricsHandler implements HttpHa
     ThreadSafeStreamObserver responseObserver =
         new ThreadSafeStreamObserver(node, nodeResponses, doneSignal);
     try {
-      this.netClient.getMetrics(node.getInstanceIp(), request, responseObserver);
+      this.netClient.getMetrics(node, request, responseObserver);
     } catch (Exception e) {
       LOG.error("Metrics : Exception occurred while getting Metrics {}", e.getCause());
     }
@@ -331,7 +331,7 @@ public class QueryMetricsRequestHandler extends MetricsHandler implements HttpHa
     }
 
     public void onNext(MetricsResponse value) {
-      nodeResponses.putIfAbsent(node.getInstanceId(), value.getMetricsResult());
+      nodeResponses.putIfAbsent(node.getInstanceId().toString(), value.getMetricsResult());
     }
 
     @Override

--- a/src/main/proto/inter_node_rpc_service.proto
+++ b/src/main/proto/inter_node_rpc_service.proto
@@ -25,8 +25,8 @@ service InterNodeRpcService {
  Structure that describes the subscription message.
 */
 message SubscribeMessage {
-    string requester_node = 1;
-    string destination_node = 2;
+    string requester_graph_node = 1;
+    string destination_graph_node = 2;
     map<string, string> tags = 3;
 }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyCacheCapacityActionTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyCacheCapacityActionTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertTrue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ImpactVector.Dimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ImpactVector.Impact;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
 import java.util.Map;
 import org.junit.Test;
@@ -35,7 +36,8 @@ public class ModifyCacheCapacityActionTest {
 
     @Test
     public void testIncreaseCapacity() {
-        NodeKey node1 = new NodeKey("node-1", "1.2.3.4");
+        NodeKey node1 = new NodeKey(new InstanceDetails.Id("node-1"),
+                new InstanceDetails.Ip("1.2.3.4"));
         ModifyCacheCapacityAction modifyCacheCapacityAction =
                 new ModifyCacheCapacityAction(node1, ResourceEnum.FIELD_DATA_CACHE, 5000, true);
         assertTrue(
@@ -56,7 +58,7 @@ public class ModifyCacheCapacityActionTest {
 
     @Test
     public void testNoIncreaseCapacity() {
-        NodeKey node1 = new NodeKey("node-1", "1.2.3.4");
+        NodeKey node1 = new NodeKey(new InstanceDetails.Id("node-1"), new InstanceDetails.Ip("1.2.3.4"));
         ModifyCacheCapacityAction modifyCacheCapacityAction =
                 new ModifyCacheCapacityAction(node1, ResourceEnum.FIELD_DATA_CACHE, 5000, false);
         assertEquals(
@@ -78,7 +80,7 @@ public class ModifyCacheCapacityActionTest {
     @Test
     public void testBounds() {
         // TODO: Move to work with test rcaConf when bounds moved to nodeConfiguration rca
-        NodeKey node1 = new NodeKey("node-1", "1.2.3.4");
+        NodeKey node1 = new NodeKey(new InstanceDetails.Id("node-1"), new InstanceDetails.Ip("1.2.3.4"));
         ModifyCacheCapacityAction fieldCacheIncrease =
             new ModifyCacheCapacityAction(
                 node1, ResourceEnum.FIELD_DATA_CACHE, 12000 * 1_000_000L, true);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyQueueCapacityActionTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyQueueCapacityActionTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertTrue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ImpactVector.Dimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ImpactVector.Impact;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
 import java.util.Map;
 import org.junit.Test;
@@ -35,7 +36,7 @@ public class ModifyQueueCapacityActionTest {
 
   @Test
   public void testIncreaseCapacity() {
-    NodeKey node1 = new NodeKey("node-1", "1.2.3.4");
+    NodeKey node1 = new NodeKey(new InstanceDetails.Id("node-1"), new InstanceDetails.Ip("1.2.3.4"));
     ModifyQueueCapacityAction modifyQueueCapacityAction = new ModifyQueueCapacityAction(node1, ResourceEnum.WRITE_THREADPOOL, 300, true);
     assertTrue(modifyQueueCapacityAction.getDesiredCapacity() > modifyQueueCapacityAction.getCurrentCapacity());
     assertTrue(modifyQueueCapacityAction.isActionable());
@@ -54,7 +55,7 @@ public class ModifyQueueCapacityActionTest {
 
   @Test
   public void testDecreaseCapacity() {
-    NodeKey node1 = new NodeKey("node-1", "1.2.3.4");
+    NodeKey node1 = new NodeKey(new InstanceDetails.Id("node-1"), new InstanceDetails.Ip("1.2.3.4"));
     ModifyQueueCapacityAction modifyQueueCapacityAction = new ModifyQueueCapacityAction(node1, ResourceEnum.SEARCH_THREADPOOL, 1500, false);
     assertTrue(modifyQueueCapacityAction.getDesiredCapacity() < modifyQueueCapacityAction.getCurrentCapacity());
     assertTrue(modifyQueueCapacityAction.isActionable());
@@ -74,7 +75,7 @@ public class ModifyQueueCapacityActionTest {
   @Test
   public void testBounds() {
     // TODO: Move to work with test rcaConf when bounds moved to config
-    NodeKey node1 = new NodeKey("node-1", "1.2.3.4");
+    NodeKey node1 = new NodeKey(new InstanceDetails.Id("node-1"), new InstanceDetails.Ip("1.2.3.4"));
     ModifyQueueCapacityAction searchQueueIncrease = new ModifyQueueCapacityAction(node1, ResourceEnum.SEARCH_THREADPOOL, 3000, true);
     assertEquals(searchQueueIncrease.getDesiredCapacity(), searchQueueIncrease.getCurrentCapacity());
     assertFalse(searchQueueIncrease.isActionable());

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/TimedFlipFlopDetectorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/TimedFlipFlopDetectorTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ImpactVector.Dimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ImpactVector.Impact;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
 import java.util.HashMap;
 import java.util.Map;
@@ -97,7 +98,7 @@ public class TimedFlipFlopDetectorTest {
   @Test
   public void testIsFlipFlop() throws Exception {
     // Setup mock actions, action followed by flipFlopAction is a flip flop
-    NodeKey nodeKey = new NodeKey("A", "localhost");
+    NodeKey nodeKey = new NodeKey(new InstanceDetails.Id("A"), new InstanceDetails.Ip("127.0.0.1"));
     Action action = mockAction(nodeKey, decreaseAll);
     Action flipflopAction = mockAction(nodeKey, increaseAll);
     // Update the flipFlopDetector so that the last "executed" action is action
@@ -120,7 +121,7 @@ public class TimedFlipFlopDetectorTest {
   @Test
   public void testMultipleActionFlipFlop() throws Exception {
     // Setup test objects, flip flops are (b, c) and (a, d)
-    NodeKey nodeKey = new NodeKey("A", "localhost");
+    NodeKey nodeKey = new NodeKey(new InstanceDetails.Id("A"), new InstanceDetails.Ip("127.0.0.1"));
     ImpactVector aVector = new ImpactVector();
     aVector.decreasesPressure(Dimension.HEAP);
     Action a = mockAction(nodeKey, aVector);
@@ -156,7 +157,7 @@ public class TimedFlipFlopDetectorTest {
    */
   @Test
   public void testFlipFlopRefresh() throws Exception {
-    NodeKey nodeKey = new NodeKey("A", "localhost");
+    NodeKey nodeKey = new NodeKey(new InstanceDetails.Id("A"), new InstanceDetails.Ip("127.0.0.1"));
     Action action = mockAction(nodeKey, decreaseAll);
     Action flipflopAction = mockAction(nodeKey, increaseAll);
     flipFlopDetector.recordAction(action);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/CacheHealthDeciderTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/CacheHealthDeciderTest.java
@@ -136,7 +136,7 @@ public class CacheHealthDeciderTest {
     Map<String, Map<ResourceEnum, Integer>> nodeActionCounter = new HashMap<>();
     for (Action action : decision.getActions()) {
       assertEquals(1, action.impactedNodes().size());
-      String nodeId = action.impactedNodes().get(0).getNodeId();
+      String nodeId = action.impactedNodes().get(0).getNodeId().toString();
       String summary = action.summary();
       if (summary.contains(ResourceEnum.FIELD_DATA_CACHE.toString())) {
         nodeActionCounter

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/PublisherTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/PublisherTest.java
@@ -19,6 +19,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.act
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ImpactVector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ImpactVector.Dimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
 import com.google.common.collect.Lists;
 
@@ -84,7 +85,7 @@ public class PublisherTest {
     @Test
     public void testRejectsFlipFlops() throws Exception {
         // Setup testing objects
-        NodeKey nodeKey = new NodeKey("A", "localhost");
+        NodeKey nodeKey = new NodeKey(new InstanceDetails.Id("A"), new InstanceDetails.Ip("127.0.0.1"));
         ImpactVector allDecrease = new ImpactVector();
         allDecrease.decreasesPressure(Dimension.values());
         Map<NodeKey, ImpactVector> impactVectorMap = new HashMap<>();

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/QueueHealthDeciderTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/QueueHealthDeciderTest.java
@@ -98,7 +98,7 @@ public class QueueHealthDeciderTest {
     Map<String, Map<ResourceEnum, Integer>> nodeActionCounter = new HashMap<>();
     for (Action action: decision.getActions()) {
       assertEquals(1, action.impactedNodes().size());
-      String nodeId = action.impactedNodes().get(0).getNodeId();
+      String nodeId = action.impactedNodes().get(0).getNodeId().toString();
       String summary = action.summary();
       if (summary.contains(ResourceEnum.WRITE_THREADPOOL.toString())) {
         nodeActionCounter.computeIfAbsent(nodeId, k -> new HashMap<>()).merge(ResourceEnum.WRITE_THREADPOOL, 1, Integer::sum);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/net/GRPCTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/net/GRPCTest.java
@@ -5,6 +5,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSett
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.MetricsRequest;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.MetricsResponse;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.util.WaitFor;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
@@ -80,7 +81,10 @@ public class GRPCTest {
         NetClient validClient = new NetClient(new GRPCConnectionManager(true, TEST_PORT));
         // Make getMetrics request to server
         ResponseObserver observer = new ResponseObserver();
-        validClient.getMetrics("127.0.0.1", METRICS_REQUEST, observer);
+
+        InstanceDetails remoteInstance = new InstanceDetails(new InstanceDetails.Id("host1"),
+                new InstanceDetails.Ip("127.0.0.1"), TEST_PORT);
+        validClient.getMetrics(remoteInstance, METRICS_REQUEST, observer);
         // Wait for the expected response from the server
         WaitFor.waitFor(() -> {
             return observer.responses[0] != null && observer.responses[0].getMetricsResult().equals("metrics");
@@ -103,7 +107,9 @@ public class GRPCTest {
         NetClient invalidClient = new NetClient(new GRPCConnectionManager(true, TEST_PORT));
         // Make invalid getMetrics request to server
         ErrorObserver<MetricsResponse> observer = new ErrorObserver<>();
-        invalidClient.getMetrics("127.0.0.1", METRICS_REQUEST, observer);
+        InstanceDetails remoteInstance = new InstanceDetails(new InstanceDetails.Id("host1"),
+                new InstanceDetails.Ip("127.0.0.1"), TEST_PORT);
+        invalidClient.getMetrics(remoteInstance, METRICS_REQUEST, observer);
         // Wait for the client to fail
         WaitFor.waitFor(() -> observer.errors[0] != null && observer.errors[0] instanceof StatusRuntimeException,
                 15, TimeUnit.SECONDS);
@@ -120,7 +126,9 @@ public class GRPCTest {
         NetClient insecureClient = new NetClient(new GRPCConnectionManager(false, TEST_PORT));
         // Make invalid getMetrics request to server
         ErrorObserver<MetricsResponse> observer = new ErrorObserver<>();
-        insecureClient.getMetrics("127.0.0.1", METRICS_REQUEST, observer);
+        InstanceDetails remoteInstance = new InstanceDetails(new InstanceDetails.Id("host1"), new InstanceDetails.Ip("127.0.0.1"),
+                TEST_PORT);
+        insecureClient.getMetrics(remoteInstance, METRICS_REQUEST, observer);
         // Wait for the client to fail
         WaitFor.waitFor(() -> observer.errors[0] != null && observer.errors[0] instanceof StatusRuntimeException,
                 1, TimeUnit.MINUTES);
@@ -144,7 +152,10 @@ public class GRPCTest {
         NetClient client = new NetClient(new GRPCConnectionManager(true, TEST_PORT));
         // Make valid getMetrics request to server
         ErrorObserver<MetricsResponse> observer = new ErrorObserver<>();
-        client.getMetrics("127.0.0.1", METRICS_REQUEST, observer);
+
+        InstanceDetails remoteInstance = new InstanceDetails(new InstanceDetails.Id("host1"), new InstanceDetails.Ip("127.0.0.1"),
+                TEST_PORT);
+        client.getMetrics(remoteInstance, METRICS_REQUEST, observer);
         // Client should fail because the server cert isn't signed by the client CA
         WaitFor.waitFor(() -> observer.errors[0] != null && observer.errors[0] instanceof StatusRuntimeException,
                 15, TimeUnit.SECONDS);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/net/TestMultipleNetServers.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/net/TestMultipleNetServers.java
@@ -1,0 +1,125 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.net;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.IntentMsg;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.NodeStateManager;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.ReceivedFlowUnitStore;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.SubscriptionManager;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.WireHopper;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.handler.PublishRequestHandler;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.handler.SubscribeServerHandler;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.util.WaitFor;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestMultipleNetServers {
+
+    private static int port1 = 9800;
+    private static int port2 = 9801;
+
+    private static TestNetServer netServer1;
+    private static TestNetServer netServer2;
+
+    private static WireHopper wireHopper1;
+    private static WireHopper wireHopper2;
+
+    private static TestNetServer startServer(int port) throws Exception {
+        TestNetServer netServer = new TestNetServer(port, 1, false);
+        ExecutorService netServerExecutor = Executors.newSingleThreadExecutor();
+
+        netServerExecutor.execute(netServer);
+        // Wait for the TestNetServer to start
+        WaitFor.waitFor(() -> netServer.isRunning.get(), 10, TimeUnit.SECONDS);
+        if (!netServer.isRunning.get()) {
+            throw new RuntimeException("Unable to start TestNetServer");
+        }
+        return netServer;
+    }
+
+    @BeforeClass
+    public static void classSetUp() throws Exception {
+        netServer1 = startServer(port1);
+        netServer2 = startServer(port2);
+    }
+
+    @AfterClass
+    public static void shutdown() {
+        wireHopper1.shutdownAll();
+        wireHopper2.shutdownAll();
+
+        netServer1.shutdown();
+        netServer2.shutdown();
+    }
+
+    private ClusterDetailsEventProcessor.NodeDetails createNodeDetails(int port, String instance) {
+        return new ClusterDetailsEventProcessor.NodeDetails(
+                AllMetrics.NodeRole.DATA, instance, "127.0.0.1", false, port);
+    }
+
+    private ClusterDetailsEventProcessor createClusterDetails(ClusterDetailsEventProcessor.NodeDetails node1,
+                                                              ClusterDetailsEventProcessor.NodeDetails node2) {
+        ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
+        clusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(node1, node2));
+        return clusterDetailsEventProcessor;
+    }
+
+    public WireHopper setUpWireHopper(String instance1, int port1, String instance2, int port2) {
+        ClusterDetailsEventProcessor clusterDetailsEventProcessor = createClusterDetails(
+                createNodeDetails(port1, instance1),
+                createNodeDetails(port2, instance2)
+        );
+
+        AppContext appContext = new AppContext();
+        appContext.setClusterDetailsEventProcessor(clusterDetailsEventProcessor);
+
+        GRPCConnectionManager connectionManager = new GRPCConnectionManager(false);
+        NodeStateManager nodeStateManager = new NodeStateManager(appContext);
+        AtomicReference<ExecutorService> clientExecutor = new AtomicReference<>(Executors.newSingleThreadExecutor());
+        NetClient netClient = new NetClient(connectionManager);
+        SubscriptionManager subscriptionManager = new SubscriptionManager(connectionManager);
+        ReceivedFlowUnitStore receivedFlowUnitStore = new ReceivedFlowUnitStore();
+
+        // netServer1.setSendDataHandler(new PublishRequestHandler(
+        //         nodeStateManager, receivedFlowUnitStore, networkThreadPoolReference));
+        // netServer.setSubscribeHandler(
+        //         new SubscribeServerHandler(subscriptionManager, networkThreadPoolReference));
+
+
+        return new WireHopper(nodeStateManager, netClient, subscriptionManager, clientExecutor, receivedFlowUnitStore,
+                appContext);
+    }
+
+    @Before
+    public void setUp() {
+        wireHopper1 = setUpWireHopper("instance1", port1, "instance2", port2);
+        wireHopper2 = setUpWireHopper("instance2", port2, "instance1", port1);
+    }
+
+    /**
+     * This test tries to create multiple NetServers on the same host, each listening on a different port.
+     */
+    @Test
+    public void multipleNetServers() {
+        wireHopper1.sendIntent(
+                new IntentMsg(
+                        "node1", "node2", ImmutableMap.of("locus", "instance1")));
+
+        System.out.println("Tests are done !!");
+
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/RcaTestHelper.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/RcaTestHelper.java
@@ -22,6 +22,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotShardSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.collector.NodeConfigCache;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
@@ -87,7 +88,7 @@ public class RcaTestHelper<T extends GenericSummary> extends Rca<ResourceFlowUni
   public static ResourceFlowUnit<HotNodeSummary> generateFlowUnit(Resource type, String nodeID, Resources.State healthy) {
     HotResourceSummary resourceSummary = new HotResourceSummary(type,
         10, 5, 60);
-    HotNodeSummary nodeSummary = new HotNodeSummary(nodeID, "127.0.0.0");
+    HotNodeSummary nodeSummary = new HotNodeSummary(new InstanceDetails.Id(nodeID), new InstanceDetails.Ip("127.0.0.0"));
     nodeSummary.appendNestedSummary(resourceSummary);
     return new ResourceFlowUnit<>(System.currentTimeMillis(), new ResourceContext(healthy), nodeSummary);
   }
@@ -96,7 +97,7 @@ public class RcaTestHelper<T extends GenericSummary> extends Rca<ResourceFlowUni
       String hostAddress, Resources.State healthy) {
     HotResourceSummary resourceSummary = new HotResourceSummary(type,
         10, 5, 60);
-    HotNodeSummary nodeSummary = new HotNodeSummary(nodeID, hostAddress);
+    HotNodeSummary nodeSummary = new HotNodeSummary(new InstanceDetails.Id(nodeID), new InstanceDetails.Ip(hostAddress));
     nodeSummary.appendNestedSummary(resourceSummary);
     return new ResourceFlowUnit<>(System.currentTimeMillis(), new ResourceContext(healthy), nodeSummary);
   }
@@ -105,7 +106,7 @@ public class RcaTestHelper<T extends GenericSummary> extends Rca<ResourceFlowUni
       String hostAddress, Resources.State healthy, long timestamp) {
     HotResourceSummary resourceSummary = new HotResourceSummary(type,
         10, 5, 60);
-    HotNodeSummary nodeSummary = new HotNodeSummary(nodeID, hostAddress);
+    HotNodeSummary nodeSummary = new HotNodeSummary(new InstanceDetails.Id(nodeID), new InstanceDetails.Ip(hostAddress));
     nodeSummary.appendNestedSummary(resourceSummary);
     return new ResourceFlowUnit<>(timestamp, new ResourceContext(healthy), nodeSummary);
   }
@@ -113,7 +114,7 @@ public class RcaTestHelper<T extends GenericSummary> extends Rca<ResourceFlowUni
   /** Create HotNodeSummary flow unit with multiple unhealthy resources */
   public static ResourceFlowUnit<HotNodeSummary> generateFlowUnit(String nodeID, String hostAddress,
       Resources.State healthy, Resource... resources) {
-    HotNodeSummary nodeSummary = new HotNodeSummary(nodeID, hostAddress);
+    HotNodeSummary nodeSummary = new HotNodeSummary(new InstanceDetails.Id(nodeID), new InstanceDetails.Ip(hostAddress));
     for (Resource resource: resources) {
       HotResourceSummary resourceSummary = new HotResourceSummary(resource, 10, 5, 60);
       nodeSummary.appendNestedSummary(resourceSummary);
@@ -130,7 +131,7 @@ public class RcaTestHelper<T extends GenericSummary> extends Rca<ResourceFlowUni
     hotShardSummary.setIoThroughputThreshold(500000);
     hotShardSummary.setIoSysCallrate(io_sys_callrate);
     hotShardSummary.setIoSysCallrateThreshold(0.50);
-    HotNodeSummary nodeSummary = new HotNodeSummary(nodeID, "127.0.0.0");
+    HotNodeSummary nodeSummary = new HotNodeSummary(new InstanceDetails.Id(nodeID), new InstanceDetails.Ip("127.0.0.0"));
     nodeSummary.appendNestedSummary(hotShardSummary);
     return new ResourceFlowUnit<>(System.currentTimeMillis(), new ResourceContext(health), nodeSummary);
   }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/HotClusterSummaryTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/HotClusterSummaryTest.java
@@ -18,6 +18,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.ap
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary.SQL_SCHEMA_CONSTANTS;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.protobuf.GeneratedMessageV3;
@@ -87,7 +88,7 @@ public class HotClusterSummaryTest {
 
     @Test
     public void testToJson() {
-        HotNodeSummary nodeSummary = new HotNodeSummary(NODE_ID, NODE_ADDRESS);
+        HotNodeSummary nodeSummary = new HotNodeSummary(new InstanceDetails.Id(NODE_ID), new InstanceDetails.Ip(NODE_ADDRESS));
         uut.appendNestedSummary(nodeSummary);
         JsonElement elem = uut.toJson();
         Assert.assertTrue(elem.isJsonObject());

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/HotNodeSummaryTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/HotNodeSummaryTest.java
@@ -18,6 +18,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.ap
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.HotNodeSummaryMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary.SQL_SCHEMA_CONSTANTS;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
@@ -38,7 +39,7 @@ public class HotNodeSummaryTest {
 
     @BeforeClass
     public static void setup() {
-        uut = new HotNodeSummary(NODE_ID, HOST_ADDRESS);
+        uut = new HotNodeSummary(new InstanceDetails.Id(NODE_ID), new InstanceDetails.Ip(HOST_ADDRESS));
         uut.appendNestedSummary(new HotResourceSummary(ResourceUtil.YOUNG_GEN_PROMOTION_RATE, THRESHOLD, VALUE, 0));
     }
 
@@ -82,8 +83,8 @@ public class HotNodeSummaryTest {
     public void testGetSqlValue() {
         List<Object> rows = uut.getSqlValue();
         Assert.assertEquals(2, rows.size());
-        Assert.assertEquals(NODE_ID, rows.get(0));
-        Assert.assertEquals(HOST_ADDRESS, rows.get(1));
+        Assert.assertEquals(NODE_ID, rows.get(0).toString());
+        Assert.assertEquals(HOST_ADDRESS, rows.get(1).toString());
     }
 
     @Test
@@ -109,7 +110,7 @@ public class HotNodeSummaryTest {
                 .thenReturn(HOST_ADDRESS);
         HotNodeSummary summary = HotNodeSummary.buildSummary(testRecord);
         Assert.assertNotNull(summary);
-        Assert.assertEquals(NODE_ID, summary.getNodeID());
-        Assert.assertEquals(HOST_ADDRESS, summary.getHostAddress());
+        Assert.assertEquals(NODE_ID, summary.getNodeID().toString());
+        Assert.assertEquals(HOST_ADDRESS, summary.getHostAddress().toString());
     }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/InstanceDetailsTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/InstanceDetailsTest.java
@@ -1,0 +1,39 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class InstanceDetailsTest {
+    @Test
+    public void equality() {
+        AllMetrics.NodeRole nodeRole = AllMetrics.NodeRole.MASTER;
+        InstanceDetails.Id id = new InstanceDetails.Id("test-id");
+        InstanceDetails.Id id2 = new InstanceDetails.Id("test-id");
+
+        InstanceDetails.Ip ip = new InstanceDetails.Ip("127.0.0.1");
+        InstanceDetails.Ip ip2 = new InstanceDetails.Ip("127.0.0.1");
+        boolean isMaster = true;
+        int grpcPort = 123;
+
+        InstanceDetails instanceDetails1 = new InstanceDetails(nodeRole, id, ip, isMaster, grpcPort);
+        ClusterDetailsEventProcessor.NodeDetails nodeDetails =
+                new ClusterDetailsEventProcessor.NodeDetails(nodeRole, id2.toString(), ip2.toString(), isMaster, grpcPort);
+        InstanceDetails instanceDetails2 = new InstanceDetails(nodeDetails);
+
+        Assert.assertEquals(instanceDetails1, instanceDetails2);
+        Assert.assertEquals(id.toString() + "::" + ip.toString() + "::" + nodeRole + "::" + grpcPort,
+                instanceDetails1.toString());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidIp() {
+        InstanceDetails.Ip ip = new InstanceDetails.Ip("500.500.1.1");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidId() {
+        InstanceDetails.Id ip = new InstanceDetails.Id("127.0.0.1");
+    }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/NodeStateManagerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/NodeStateManagerTest.java
@@ -2,12 +2,15 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeResponse.SubscriptionStatus;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,14 +18,21 @@ import org.junit.Test;
 public class NodeStateManagerTest {
 
   private static final String TEST_HOST_1 = "host1";
+  private static final String IP_1 = "127.0.0.1";
   private static final String TEST_NODE_1 = "node1";
+
   private static final String TEST_HOST_2 = "host2";
+  private static final String IP_2 = "127.0.0.2";
+
   private static final String TEST_HOST_3 = "host3";
+  private static final String IP_3 = "127.0.0.3";
+
   private static final String TEST_HOST_4 = "host4";
+
   private static final int MS_IN_S = 1000;
   private static final int TEN_S_IN_MILLIS = 10 * MS_IN_S;
   private static final ClusterDetailsEventProcessor.NodeDetails EMPTY_DETAILS =
-          ClusterDetailsEventProcessorTestHelper.newNodeDetails("", "", false);
+          ClusterDetailsEventProcessorTestHelper.newNodeDetails("idid", "0.0.0.0", false);
 
   private NodeStateManager testNodeStateManager;
 
@@ -34,73 +44,83 @@ public class NodeStateManagerTest {
   @Test
   public void updateReceiveTime() {
     final long currentTime = System.currentTimeMillis();
-    testNodeStateManager.updateReceiveTime(TEST_HOST_1, TEST_NODE_1, currentTime);
+    testNodeStateManager.updateReceiveTime(new InstanceDetails.Id(TEST_HOST_1), TEST_NODE_1, currentTime);
     Assert.assertEquals(currentTime, testNodeStateManager.getLastReceivedTimestamp(TEST_NODE_1,
-        TEST_HOST_1));
+        new InstanceDetails.Id(TEST_HOST_1)));
   }
 
   @Test
   public void getLastReceivedTimestamp() {
     final long currentTime = System.currentTimeMillis();
-    Assert.assertEquals(0, testNodeStateManager.getLastReceivedTimestamp(TEST_NODE_1, TEST_HOST_2));
+    Assert.assertEquals(0, testNodeStateManager.getLastReceivedTimestamp(TEST_NODE_1, new InstanceDetails.Id(TEST_HOST_2)));
 
-    testNodeStateManager.updateReceiveTime(TEST_HOST_2, TEST_NODE_1, currentTime);
+    testNodeStateManager.updateReceiveTime(new InstanceDetails.Id(TEST_HOST_2), TEST_NODE_1, currentTime);
     Assert.assertEquals(currentTime, testNodeStateManager.getLastReceivedTimestamp(TEST_NODE_1,
-        TEST_HOST_2));
+        new InstanceDetails.Id(TEST_HOST_2)));
   }
 
   @Test
   public void testNewNodesAddedToCluster() {
     final long currentTime = System.currentTimeMillis();
-    testNodeStateManager.updateReceiveTime(TEST_HOST_1, TEST_NODE_1, currentTime);
+    testNodeStateManager.updateReceiveTime(new InstanceDetails.Id(TEST_HOST_1), TEST_NODE_1, currentTime);
 
     testNodeStateManager
-        .updateSubscriptionState(TEST_NODE_1, TEST_HOST_1, SubscriptionStatus.SUCCESS);
+        .updateSubscriptionState(TEST_NODE_1, new InstanceDetails.Id(TEST_HOST_1), SubscriptionStatus.SUCCESS);
 
     ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
     clusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
             EMPTY_DETAILS,
-            ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, TEST_HOST_1, false),
-            ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, TEST_HOST_2, false)
+            ClusterDetailsEventProcessorTestHelper.newNodeDetails(TEST_HOST_1, IP_1, false),
+            ClusterDetailsEventProcessorTestHelper.newNodeDetails(TEST_HOST_2, IP_2, false)
     ));
 
     testNodeStateManager.getAppContext().setClusterDetailsEventProcessor(clusterDetailsEventProcessor);
 
-    ImmutableList<String> hostsToSubscribeTo =
-        testNodeStateManager.getStaleOrNotSubscribedNodes(TEST_NODE_1, TEN_S_IN_MILLIS,
-            ImmutableSet.of(TEST_HOST_1));
+    ImmutableList<InstanceDetails> hostsToSubscribeTo = testNodeStateManager.getStaleOrNotSubscribedNodes(
+            TEST_NODE_1,
+            TEN_S_IN_MILLIS,
+            ImmutableSet.of(new InstanceDetails.Id(TEST_HOST_1)));
 
     Assert.assertEquals(1, hostsToSubscribeTo.size());
-    Assert.assertEquals(TEST_HOST_2, hostsToSubscribeTo.get(0));
+    Assert.assertEquals(TEST_HOST_2, hostsToSubscribeTo.get(0).getInstanceId().toString());
   }
 
   @Test
   public void testStaleNodesAndNewNodesAddedToCluster() {
     final long currentTime = System.currentTimeMillis();
 
-    testNodeStateManager.updateReceiveTime(TEST_HOST_1, TEST_NODE_1,
+    testNodeStateManager.updateReceiveTime(new InstanceDetails.Id(TEST_HOST_1), TEST_NODE_1,
         currentTime - 2 * TEN_S_IN_MILLIS);
     testNodeStateManager
-        .updateSubscriptionState(TEST_NODE_1, TEST_HOST_1, SubscriptionStatus.SUCCESS);
+        .updateSubscriptionState(TEST_NODE_1, new InstanceDetails.Id(TEST_HOST_1), SubscriptionStatus.SUCCESS);
 
-    testNodeStateManager.updateReceiveTime(TEST_HOST_2, TEST_NODE_1, currentTime);
-    testNodeStateManager.updateSubscriptionState(TEST_NODE_1, TEST_HOST_2, SubscriptionStatus.SUCCESS);
+    testNodeStateManager.updateReceiveTime(new InstanceDetails.Id(TEST_HOST_2), TEST_NODE_1, currentTime);
+    testNodeStateManager.updateSubscriptionState(TEST_NODE_1, new InstanceDetails.Id(TEST_HOST_2), SubscriptionStatus.SUCCESS);
 
     ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
     clusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
             EMPTY_DETAILS,
-            ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, TEST_HOST_1, false),
-            ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, TEST_HOST_2, false),
-            ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, TEST_HOST_3, false)
+            ClusterDetailsEventProcessorTestHelper.newNodeDetails(TEST_HOST_1, IP_1, false),
+            ClusterDetailsEventProcessorTestHelper.newNodeDetails(TEST_HOST_2, IP_2,  false),
+            ClusterDetailsEventProcessorTestHelper.newNodeDetails(TEST_HOST_3, IP_3, false)
     ));
     testNodeStateManager.getAppContext().setClusterDetailsEventProcessor(clusterDetailsEventProcessor);
 
-    ImmutableList<String> hostsToSubscribeTo =
-        testNodeStateManager.getStaleOrNotSubscribedNodes(TEST_NODE_1, TEN_S_IN_MILLIS,
-            ImmutableSet.of(TEST_HOST_1, TEST_HOST_2, TEST_HOST_4));
+    ImmutableSet<InstanceDetails.Id> hostSet = ImmutableSet.of(
+            new InstanceDetails.Id(TEST_HOST_1), // We will send subscription as it has become stale.
+            new InstanceDetails.Id(TEST_HOST_2),  // We don't expect to send subscription to host2 as we received one recently.
+            new InstanceDetails.Id(TEST_HOST_4));  // Although this is in the publisher list but not in ClusterDetails, so we will
+    // exclude it
+    ImmutableList<InstanceDetails> hostsToSubscribeTo = testNodeStateManager.getStaleOrNotSubscribedNodes(
+            TEST_NODE_1,
+            TEN_S_IN_MILLIS,
+            hostSet);
 
     Assert.assertEquals(2, hostsToSubscribeTo.size());
-    Assert.assertTrue(hostsToSubscribeTo.contains(TEST_HOST_1));
-    Assert.assertTrue(hostsToSubscribeTo.contains(TEST_HOST_3));
+
+    Set<String> expectedIs =
+            hostsToSubscribeTo.stream().map(InstanceDetails::getInstanceId).map(InstanceDetails.Id::toString).collect(Collectors.toSet());
+    Assert.assertTrue(expectedIs.contains(TEST_HOST_1));
+    Assert.assertTrue(expectedIs.contains(TEST_HOST_3));
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/SubscribeResponseHandlerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/SubscribeResponseHandlerTest.java
@@ -1,27 +1,60 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.CertificateUtils;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeResponse;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.GRPCConnectionManager;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.google.common.collect.Sets;
+import java.util.Objects;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class SubscribeResponseHandlerTest {
-    private static final String HOST = "127.0.0.1";
-    private static final String NODE = "TEST";
+    private static final InstanceDetails.Ip HOST = new InstanceDetails.Ip("127.0.0.1");
+    private static final InstanceDetails.Id HOST_ID = new InstanceDetails.Id("host1");
+    private static final String GRAPH_NODE = "TEST";
 
     private SubscriptionManager subscriptionManager;
     private NodeStateManager nodeStateManager;
     private SubscribeResponseHandler uut;
 
+    private String oldCertificateFile;
+    private String oldPrivateKeyFile;
+
     @Before
     public void setup() {
+        ClassLoader classLoader = getClass().getClassLoader();
+
+        oldCertificateFile = PluginSettings.instance().getProperty(CertificateUtils.CERTIFICATE_FILE_PATH);
+        oldPrivateKeyFile = PluginSettings.instance().getProperty(CertificateUtils.PRIVATE_KEY_FILE_PATH);
+
+        PluginSettings.instance().overrideProperty(CertificateUtils.CERTIFICATE_FILE_PATH,
+                Objects.requireNonNull(classLoader.getResource("tls/server/localhost.crt")).getFile());
+        PluginSettings.instance().overrideProperty(CertificateUtils.PRIVATE_KEY_FILE_PATH,
+                Objects.requireNonNull(classLoader.getResource("tls/server/localhost.key")).getFile());
+
         GRPCConnectionManager grpcConnectionManager = new GRPCConnectionManager(true);
         subscriptionManager = new SubscriptionManager(grpcConnectionManager);
         nodeStateManager = new NodeStateManager(new AppContext());
-        uut = new SubscribeResponseHandler(subscriptionManager, nodeStateManager, HOST, NODE);
+
+        InstanceDetails remoteInstance = new InstanceDetails(HOST_ID, HOST, -1);
+        uut = new SubscribeResponseHandler(subscriptionManager, nodeStateManager, remoteInstance, GRAPH_NODE);
+    }
+
+    @After
+    public void tearDown() {
+        if (oldCertificateFile != null) {
+            PluginSettings.instance().overrideProperty(CertificateUtils.CERTIFICATE_FILE_PATH, oldCertificateFile);
+        }
+
+        if (oldPrivateKeyFile != null) {
+            PluginSettings.instance().overrideProperty(CertificateUtils.PRIVATE_KEY_FILE_PATH, oldPrivateKeyFile);
+        }
     }
 
     @Test
@@ -30,16 +63,16 @@ public class SubscribeResponseHandlerTest {
         SubscribeResponse success = SubscribeResponse.newBuilder()
                 .setSubscriptionStatus(SubscribeResponse.SubscriptionStatus.SUCCESS).build();
         uut.onNext(success);
-        Assert.assertEquals(subscriptionManager.getPublishersForNode(NODE), Sets.newHashSet(HOST));
+        Assert.assertEquals(subscriptionManager.getPublishersForNode(GRAPH_NODE), Sets.newHashSet(HOST_ID));
         Assert.assertEquals(SubscribeResponse.SubscriptionStatus.SUCCESS,
-                nodeStateManager.getSubscriptionStatus(NODE, HOST));
+                nodeStateManager.getSubscriptionStatus(GRAPH_NODE, HOST_ID));
 
         // Test that onNext() properly processes a tag mismatch subscription message
         SubscribeResponse mismatch = SubscribeResponse.newBuilder()
                 .setSubscriptionStatus(SubscribeResponse.SubscriptionStatus.TAG_MISMATCH).build();
         uut.onNext(mismatch);
         Assert.assertEquals(SubscribeResponse.SubscriptionStatus.TAG_MISMATCH,
-                nodeStateManager.getSubscriptionStatus(NODE, HOST));
+                nodeStateManager.getSubscriptionStatus(GRAPH_NODE, HOST_ID));
         SubscribeResponse unknown = SubscribeResponse.newBuilder().build();
         uut.onNext(unknown); // This line is included for branch coverage
     }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/SubscriptionManagerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/SubscriptionManagerTest.java
@@ -1,94 +1,121 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.CertificateUtils;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeResponse;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.net.GRPCConnectionManager;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.google.common.collect.Sets;
 import java.util.Collections;
+import java.util.Objects;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-
 
 public class SubscriptionManagerTest {
     private GRPCConnectionManager grpcConnectionManager;
     private SubscriptionManager uut;
 
+    private String oldCertificateFile;
+    private String oldPrivateKeyFile;
+
     @Before
     public void setup() {
+        oldCertificateFile = PluginSettings.instance().getProperty(CertificateUtils.CERTIFICATE_FILE_PATH);
+        oldPrivateKeyFile = PluginSettings.instance().getProperty(CertificateUtils.PRIVATE_KEY_FILE_PATH);
+
+        ClassLoader classLoader = getClass().getClassLoader();
+        PluginSettings.instance().overrideProperty(CertificateUtils.CERTIFICATE_FILE_PATH,
+                Objects.requireNonNull(classLoader.getResource("tls/server/localhost.crt")).getFile());
+        PluginSettings.instance().overrideProperty(CertificateUtils.PRIVATE_KEY_FILE_PATH,
+                Objects.requireNonNull(classLoader.getResource("tls/server/localhost.key")).getFile());
+
         grpcConnectionManager = new GRPCConnectionManager(true);
         uut = new SubscriptionManager(grpcConnectionManager);
+    }
+
+    @After
+    public void tearDown() {
+        if (oldCertificateFile != null) {
+            PluginSettings.instance().overrideProperty(CertificateUtils.CERTIFICATE_FILE_PATH, oldCertificateFile);
+        }
+
+        if (oldPrivateKeyFile != null) {
+            PluginSettings.instance().overrideProperty(CertificateUtils.PRIVATE_KEY_FILE_PATH, oldPrivateKeyFile);
+        }
     }
 
     @Test
     public void testAddAndGetPublishers() {
         String testNode = "testNode";
         String ip1 = "127.0.0.1";
+        InstanceDetails.Id id1 = new InstanceDetails.Id("id-1");
+        InstanceDetails.Id id2 = new InstanceDetails.Id("id-2");
         String ip2 = "127.0.0.2";
         Assert.assertEquals(Collections.emptySet(), uut.getPublishersForNode(testNode));
-        uut.addPublisher(testNode, ip1);
-        Assert.assertEquals(Sets.newHashSet(ip1), uut.getPublishersForNode(testNode));
-        uut.addPublisher(testNode, ip2);
-        Assert.assertEquals(Sets.newHashSet(ip1, ip2), uut.getPublishersForNode(testNode));
+        uut.addPublisher(testNode, id1);
+        Assert.assertEquals(Sets.newHashSet(id1), uut.getPublishersForNode(testNode));
+        uut.addPublisher(testNode, id2);
+        Assert.assertEquals(Sets.newHashSet(id1, id2), uut.getPublishersForNode(testNode));
     }
 
     @Test
     public void testSubscriptionFlow() {
         String testNode = "testNode";
-        String ip1 = "127.0.0.1";
-        String ip2 = "127.0.0.2";
+        InstanceDetails.Id id1 = new InstanceDetails.Id("id-1");
+        InstanceDetails.Id id2 = new InstanceDetails.Id("id-2");
         String locus = "data-node";
 
         // Test that addSubscriber doesn't work on non-matching loci
-        SubscribeResponse.SubscriptionStatus status = uut.addSubscriber(testNode, ip1, locus);
+        SubscribeResponse.SubscriptionStatus status = uut.addSubscriber(testNode, id1, locus);
         Assert.assertEquals(SubscribeResponse.SubscriptionStatus.TAG_MISMATCH, status);
         Assert.assertFalse(uut.isNodeSubscribed(testNode));
 
         // Test that addSubscriber works for matching loci
         uut.setCurrentLocus(locus);
-        status = uut.addSubscriber(testNode, ip1, locus);
+        status = uut.addSubscriber(testNode, id1, locus);
         Assert.assertEquals(SubscribeResponse.SubscriptionStatus.SUCCESS, status);
-        Assert.assertEquals(Sets.newHashSet(ip1), uut.getSubscribersFor(testNode));
+        Assert.assertEquals(Sets.newHashSet(id1), uut.getSubscribersFor(testNode));
         Assert.assertTrue(uut.isNodeSubscribed(testNode));
 
         // Test that addSubscriber works on repeated calls
-        status = uut.addSubscriber(testNode, ip2, locus);
+        status = uut.addSubscriber(testNode, id2, locus);
         Assert.assertEquals(SubscribeResponse.SubscriptionStatus.SUCCESS, status);
-        Assert.assertEquals(Sets.newHashSet(ip1, ip2), uut.getSubscribersFor(testNode));
+        Assert.assertEquals(Sets.newHashSet(id1, id2), uut.getSubscribersFor(testNode));
         Assert.assertTrue(uut.isNodeSubscribed(testNode));
 
         // Add host connections to the grpcConnectionManager
-        grpcConnectionManager.getClientStubForHost(ip1);
-        Assert.assertTrue(grpcConnectionManager.getPerHostChannelMap().containsKey(ip1));
-        Assert.assertTrue(grpcConnectionManager.getPerHostClientStubMap().containsKey(ip1));
-        grpcConnectionManager.getClientStubForHost(ip2);
-        Assert.assertTrue(grpcConnectionManager.getPerHostChannelMap().containsKey(ip2));
-        Assert.assertTrue(grpcConnectionManager.getPerHostClientStubMap().containsKey(ip2));
+        grpcConnectionManager.getClientStubForHost(new InstanceDetails(id1,
+                new InstanceDetails.Ip("0.0.0.0"), 9000));
+        Assert.assertTrue(grpcConnectionManager.getPerHostChannelMap().containsKey(id1));
+        Assert.assertTrue(grpcConnectionManager.getPerHostClientStubMap().containsKey(id1));
+        grpcConnectionManager.getClientStubForHost(new InstanceDetails(id2, new InstanceDetails.Ip("0.0.0.0"), 9000));
+        Assert.assertTrue(grpcConnectionManager.getPerHostChannelMap().containsKey(id2));
+        Assert.assertTrue(grpcConnectionManager.getPerHostClientStubMap().containsKey(id2));
 
         // Test that unsubscribeAndTerminateConnection always terminates a connection
         // TODO is this actually the behavior we intended?
-        uut.unsubscribeAndTerminateConnection("nonExistentNode", ip1);
-        Assert.assertFalse(grpcConnectionManager.getPerHostChannelMap().containsKey(ip1));
-        Assert.assertFalse(grpcConnectionManager.getPerHostClientStubMap().containsKey(ip1));
+        uut.unsubscribeAndTerminateConnection("nonExistentNode", id1);
+        Assert.assertFalse(grpcConnectionManager.getPerHostChannelMap().containsKey(id1));
+        Assert.assertFalse(grpcConnectionManager.getPerHostClientStubMap().containsKey(id1));
 
         // Test that unsubscribeAndTerminateConnection properly updates the underlying map
-        grpcConnectionManager.getClientStubForHost(ip2);
-        uut.unsubscribeAndTerminateConnection(testNode, ip2);
-        Assert.assertEquals(Sets.newHashSet(ip1), uut.getSubscribersFor(testNode));
+        grpcConnectionManager.getClientStubForHost(new InstanceDetails(id2, new InstanceDetails.Ip("0.0.0.0"), 9000));
+        uut.unsubscribeAndTerminateConnection(testNode, id2);
+        Assert.assertEquals(Sets.newHashSet(id1), uut.getSubscribersFor(testNode));
         Assert.assertTrue(uut.isNodeSubscribed(testNode));
-        Assert.assertFalse(grpcConnectionManager.getPerHostChannelMap().containsKey(ip2));
-        Assert.assertFalse(grpcConnectionManager.getPerHostClientStubMap().containsKey(ip2));
+        Assert.assertFalse(grpcConnectionManager.getPerHostChannelMap().containsKey(id2));
+        Assert.assertFalse(grpcConnectionManager.getPerHostClientStubMap().containsKey(id2));
 
         // Test that unsubscribeAndTerminateConnection doesn't update the underlying map for non existent addresses
-        uut.unsubscribeAndTerminateConnection(testNode, "nonExistentAddress");
-        Assert.assertEquals(Sets.newHashSet(ip1), uut.getSubscribersFor(testNode));
+        uut.unsubscribeAndTerminateConnection(testNode, new InstanceDetails.Id("nonExistentAddress"));
+        Assert.assertEquals(Sets.newHashSet(id1), uut.getSubscribersFor(testNode));
         Assert.assertTrue(uut.isNodeSubscribed(testNode));
 
         // Test that unsubscribeAndTerminateConnection removes the node from the map once all of its subscriptions are
         // terminated
-        uut.unsubscribeAndTerminateConnection(testNode, ip1);
+        uut.unsubscribeAndTerminateConnection(testNode, id1);
         Assert.assertEquals(Collections.emptySet(), uut.getSubscribersFor(testNode));
         Assert.assertFalse(uut.isNodeSubscribed(testNode));
     }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/FlowUnitRxTaskTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/FlowUnitRxTaskTest.java
@@ -8,6 +8,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.NodeStateManager;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.ReceivedFlowUnitStore;
 import org.junit.Before;
@@ -46,7 +47,7 @@ public class FlowUnitRxTaskTest {
 
     testFlowUnitRxTask.run();
 
-    verify(mockNodeStateManager).updateReceiveTime(eq(TEST_ES_NODE), eq(TEST_GRAPH_NODE),
+    verify(mockNodeStateManager).updateReceiveTime(eq(new InstanceDetails.Id(TEST_ES_NODE)), eq(TEST_GRAPH_NODE),
         anyLong());
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/SubscriptionRxTaskTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/tasks/SubscriptionRxTaskTest.java
@@ -9,6 +9,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeMes
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeResponse;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.SubscribeResponse.SubscriptionStatus;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.SubscriptionManager;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.requests.CompositeSubscribeRequest;
 import io.grpc.stub.StreamObserver;
@@ -49,7 +50,7 @@ public class SubscriptionRxTaskTest {
   @Test
   public void testSubscribeSuccess() {
     when(mockRequest.getSubscribeMessage()).thenReturn(buildTestSubscribeMessage());
-    when(mockSubscriptionManager.addSubscriber(TEST_GRAPH_NODE, TEST_HOST_ADDRESS, TEST_LOCUS))
+    when(mockSubscriptionManager.addSubscriber(TEST_GRAPH_NODE, new InstanceDetails.Id(TEST_HOST_ADDRESS), TEST_LOCUS))
         .thenReturn(SubscriptionStatus.SUCCESS);
     when(mockRequest.getSubscribeResponseStream()).thenReturn(mockResponseStream);
 
@@ -62,7 +63,7 @@ public class SubscriptionRxTaskTest {
 
   private SubscribeMessage buildTestSubscribeMessage() {
     return SubscribeMessage.newBuilder()
-                           .setDestinationNode(TEST_GRAPH_NODE)
+                           .setDestinationGraphNode(TEST_GRAPH_NODE)
                            .putTags("locus", TEST_LOCUS)
                            .putTags("requester", TEST_HOST_ADDRESS)
                            .build();

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/response/RcaResponseTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/response/RcaResponseTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.isA;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import org.jooq.Field;
@@ -39,6 +40,7 @@ public class RcaResponseTest {
     private static final Long TIMESTAMP = 0L;
     private static final String NODE = "NODE";
     private static final String HOST = "HOST";
+    private static final String IP = "127.0.0.1";
 
 
     private RcaResponse uut;
@@ -108,7 +110,7 @@ public class RcaResponseTest {
                 .get(ResourceFlowUnit.SQL_SCHEMA_CONSTANTS.STATE_COL_NAME).getAsString());
         Assert.assertEquals(TIMESTAMP, (Long) obj
                 .get(ResourceFlowUnit.SQL_SCHEMA_CONSTANTS.TIMESTAMP_COL_NAME).getAsLong());
-        HotNodeSummary summary = new HotNodeSummary(NODE, HOST);
+        HotNodeSummary summary = new HotNodeSummary(new InstanceDetails.Id(NODE), new InstanceDetails.Ip(IP));
         uut.addNestedSummaryList(summary);
         jsonElement = uut.toJson();
         obj = jsonElement.getAsJsonObject();

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaEnabledSamplerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/RcaEnabledSamplerTest.java
@@ -39,14 +39,14 @@ public class RcaEnabledSamplerTest {
 
         assertFalse(uut.isRcaEnabled());
         ClusterDetailsEventProcessor.NodeDetails details =
-                ClusterDetailsEventProcessorTestHelper.newNodeDetails("", "", false);
+                ClusterDetailsEventProcessorTestHelper.newNodeDetails("nodex", "127.0.0.1", false);
 
         ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
         clusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(details));
         appContext.setClusterDetailsEventProcessor(clusterDetailsEventProcessor);
 
         assertFalse(uut.isRcaEnabled());
-        details = ClusterDetailsEventProcessorTestHelper.newNodeDetails("", "", true);
+        details = ClusterDetailsEventProcessorTestHelper.newNodeDetails("nodey", "127.0.0.2", true);
         clusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(details));
         assertEquals(rcaController.isRcaEnabled(), uut.isRcaEnabled());
     }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCASchedulerTaskTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCASchedulerTaskTests.java
@@ -18,7 +18,6 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler;
 import static org.junit.Assert.assertEquals;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.AnalysisGraph;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
@@ -30,7 +29,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Queryable;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.DataMsg;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.IntentMsg;
@@ -42,7 +40,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -228,16 +225,16 @@ public class RCASchedulerTaskTests {
 
       @Override
       public void sendData(DataMsg msg) {
-        assertEquals(msg.getSourceNode(), this.dataMsg.getSourceNode());
-        AssertHelper.compareLists(msg.getDestinationNode(), this.dataMsg.getDestinationNode());
+        assertEquals(msg.getSourceGraphNode(), this.dataMsg.getSourceGraphNode());
+        AssertHelper.compareLists(msg.getDestinationGraphNodes(), this.dataMsg.getDestinationGraphNodes());
       }
 
       @Override
       public void sendIntent(IntentMsg intentMsg) {
         assertEquals(
-            intentMsg.getRequesterNode(), this.intentMsgs.get(intextIdx).getRequesterNode());
+            intentMsg.getRequesterGraphNode(), this.intentMsgs.get(intextIdx).getRequesterGraphNode());
         assertEquals(
-            intentMsg.getDestinationNode(), this.intentMsgs.get(intextIdx).getDestinationNode());
+            intentMsg.getDestinationGraphNode(), this.intentMsgs.get(intextIdx).getDestinationGraphNode());
         intextIdx++;
       }
     }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ResourceHeatMapGraphTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ResourceHeatMapGraphTest.java
@@ -88,8 +88,8 @@ import java.util.stream.Collectors;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
-
 
 public class ResourceHeatMapGraphTest {
   private final int THREADS = 3;
@@ -190,7 +190,7 @@ public class ResourceHeatMapGraphTest {
             wireHopper,
             appContext);
 
-    RcaTestHelper.setMyIp(instanceDetails.getInstanceIp(), instanceDetails.getRole());
+    RcaTestHelper.setMyIp(instanceDetails.getInstanceIp().toString(), instanceDetails.getRole());
     rcaSchedulerTaskData.run();
     return connectedComponents;
   }
@@ -295,7 +295,7 @@ public class ResourceHeatMapGraphTest {
             wireHopper2,
             appContext);
     AllMetrics.NodeRole nodeRole2 = instanceDetails.getRole();
-    RcaTestHelper.setMyIp(instanceDetails.getInstanceIp(), nodeRole2);
+    RcaTestHelper.setMyIp(instanceDetails.getInstanceIp().toString(), nodeRole2);
     rcaSchedulerTaskMaster.run();
 
     testJsonResponse(makeRestRequest(
@@ -603,13 +603,13 @@ public class ResourceHeatMapGraphTest {
     JsonArray json = parser
         .parse(resp)
         .getAsJsonObject()
-        .getAsJsonArray(ALL_TEMPERATURE_DIMENSIONS)
-        .get(0)
-        .getAsJsonObject()
-        .getAsJsonArray(NodeLevelDimensionalSummary.SUMMARY_TABLE_NAME);
+        .getAsJsonArray(ALL_TEMPERATURE_DIMENSIONS);
+    System.out.println("ALL_TEMPERATURE_DIMENSIONS" + json);
 
-    for (JsonElement elem : json) {
+    for (JsonElement elem : json.get(0).getAsJsonObject().getAsJsonArray(NodeLevelDimensionalSummary.SUMMARY_TABLE_NAME)) {
       JsonObject object = elem.getAsJsonObject();
+      System.out.println(object);
+      System.out.println("dim obj: " + object.get("dimension"));
       switch (TemperatureDimension.valueOf(object.get("dimension").getAsString())) {
         case CPU_Utilization:
           verifyCpuDimension(object);
@@ -1087,7 +1087,7 @@ public class ResourceHeatMapGraphTest {
             wireHopper,
             appContext);
     AllMetrics.NodeRole nodeRole = dataInstance.getRole();
-    RcaTestHelper.setMyIp(dataInstance.getInstanceIp(), nodeRole);
+    RcaTestHelper.setMyIp(dataInstance.getInstanceIp().toString(), nodeRole);
     rcaSchedulerTaskData.run();
 
     String masterNodeRcaConf =
@@ -1116,7 +1116,7 @@ public class ResourceHeatMapGraphTest {
             wireHopper2,
             appContextMaster);
     AllMetrics.NodeRole nodeRole2 = masterInstance.getRole();
-    RcaTestHelper.setMyIp(masterInstance.getInstanceIp(), nodeRole2);
+    RcaTestHelper.setMyIp(masterInstance.getInstanceIp().toString(), nodeRole2);
     rcaSchedulerTaskMaster.run();
 
     URL url = null;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtilsTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/ClusterUtilsTest.java
@@ -13,16 +13,17 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class ClusterUtilsTest {
-    private static final String HOST = "127.0.0.1";
-    private static final String HOST2 = "127.0.0.2";
+    private static final String HOST1 = "host1";
+    private static final String HOST2 = "host2";
     private static final ClusterDetailsEventProcessor.NodeDetails EMPTY_DETAILS =
             ClusterDetailsEventProcessorTestHelper.newNodeDetails("", "", false);
     private ClusterDetailsEventProcessor clusterDetailsEventProcessor;
 
     private List<InstanceDetails> getInstancesFromHost(List<String> hostIps) {
         List<InstanceDetails> instances = new ArrayList<>();
-        for (String ip: hostIps) {
-            InstanceDetails instance = new InstanceDetails(AllMetrics.NodeRole.UNKNOWN, "", ip, false);
+        for (String id: hostIps) {
+            InstanceDetails instance = new InstanceDetails(AllMetrics.NodeRole.UNKNOWN, new InstanceDetails.Id(id),
+                    new InstanceDetails.Ip("0.0.0.0"), false);
             instances.add(instance);
         }
         return instances;
@@ -37,17 +38,17 @@ public class ClusterUtilsTest {
     @Test
     public void testIsHostAddressInCluster() {
         // method should return false when there are no peers
-        Assert.assertFalse(ClusterUtils.isHostAddressInCluster(HOST, getInstancesFromHost(Collections.EMPTY_LIST)));
+        Assert.assertFalse(ClusterUtils.isHostIdInCluster(new InstanceDetails.Id(HOST1), getInstancesFromHost(Collections.EMPTY_LIST)));
         // method should properly recognize which hosts are peers and which aren't
         clusterDetailsEventProcessor.setNodesDetails(Lists.newArrayList(
-                ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, HOST, false)
+                ClusterDetailsEventProcessorTestHelper.newNodeDetails(null, HOST1, false)
         ));
 
 
 
-        List<InstanceDetails> instances = getInstancesFromHost(Collections.singletonList(HOST));
+        List<InstanceDetails> instances = getInstancesFromHost(Collections.singletonList(HOST1));
 
-        Assert.assertTrue(ClusterUtils.isHostAddressInCluster(HOST, instances));
-        Assert.assertFalse(ClusterUtils.isHostAddressInCluster(HOST2, instances));
+        Assert.assertTrue(ClusterUtils.isHostIdInCluster(new InstanceDetails.Id(HOST1), instances));
+        Assert.assertFalse(ClusterUtils.isHostIdInCluster(new InstanceDetails.Id(HOST2), instances));
     }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/collector/NodeConfigCacheTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/collector/NodeConfigCacheTest.java
@@ -17,6 +17,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.store.collector;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.collector.NodeConfigCache;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
 import org.junit.Assert;
@@ -34,8 +35,8 @@ public class NodeConfigCacheTest {
   @Before
   public void init() {
     this.nodeConfigCache = new NodeConfigCache();
-    this.nodeKey1 = new NodeKey("node1", "127.0.0.1");
-    this.nodeKey2 = new NodeKey("node2", "127.0.0.2");
+    this.nodeKey1 = new NodeKey(new InstanceDetails.Id("node1"), new InstanceDetails.Ip("127.0.0.1"));
+    this.nodeKey2 = new NodeKey(new InstanceDetails.Id("node2"), new InstanceDetails.Ip("127.0.0.2"));
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/collector/NodeConfigClusterCollectorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/collector/NodeConfigClusterCollectorTest.java
@@ -21,6 +21,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.NodeConfigFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.collector.NodeConfigClusterCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.collector.NodeConfigCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
@@ -48,8 +49,8 @@ public class NodeConfigClusterCollectorTest {
 
   @Test
   public void testQueueCapacityCollection() {
-    NodeKey nodeKey1 = new NodeKey("node1", "127.0.0.1");
-    NodeKey nodeKey2 = new NodeKey("node2", "127.0.0.2");
+    NodeKey nodeKey1 = new NodeKey(new InstanceDetails.Id("node1"), new InstanceDetails.Ip("127.0.0.1"));
+    NodeKey nodeKey2 = new NodeKey(new InstanceDetails.Id("node2"), new InstanceDetails.Ip("127.0.0.2"));
     NodeConfigFlowUnit flowUnit = new NodeConfigFlowUnit(0, nodeKey1);
     flowUnit.addConfig(ResourceUtil.WRITE_QUEUE_CAPACITY, 100);
     collector.setLocalFlowUnit(flowUnit);
@@ -110,8 +111,8 @@ public class NodeConfigClusterCollectorTest {
 
   @Test
   public void testCacheMaxSizeCollection() {
-    NodeKey nodeKey1 = new NodeKey("node1", "127.0.0.1");
-    NodeKey nodeKey2 = new NodeKey("node2", "127.0.0.2");
+    NodeKey nodeKey1 = new NodeKey(new InstanceDetails.Id("node1"), new InstanceDetails.Ip("127.0.0.1"));
+    NodeKey nodeKey2 = new NodeKey(new InstanceDetails.Id("node2"), new InstanceDetails.Ip("127.0.0.2"));
     NodeConfigFlowUnit flowUnit = new NodeConfigFlowUnit(0, nodeKey1);
     flowUnit.addConfig(ResourceUtil.FIELD_DATA_CACHE_MAX_SIZE, 100000);
     collector.setLocalFlowUnit(flowUnit);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/HotNodeClusterRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/HotNodeClusterRcaTest.java
@@ -31,6 +31,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HotNodeClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessorTestHelper;
@@ -118,7 +119,7 @@ public class HotNodeClusterRcaTest {
     Assert.assertTrue(clusterSummary.getNestedSummaryList().size() > 0);
 
     HotNodeSummary nodeSummary = (HotNodeSummary) clusterSummary.getNestedSummaryList().get(0);
-    Assert.assertTrue(nodeSummary.getNodeID().equals("node1"));
+    Assert.assertTrue(nodeSummary.getNodeID().toString().equals("node1"));
     Assert.assertTrue(nodeSummary.getNestedSummaryList().size() > 0);
 
     HotResourceSummary resourceSummary = (HotResourceSummary) nodeSummary.getNestedSummaryList().get(0);
@@ -157,7 +158,7 @@ public class HotNodeClusterRcaTest {
   private ResourceFlowUnit generateFlowUnit(Resource type, double val, String nodeId) {
     HotResourceSummary resourceSummary = new HotResourceSummary(type,
         10, val, 60);
-    HotNodeSummary nodeSummary = new HotNodeSummary(nodeId, "127.0.0.0");
+    HotNodeSummary nodeSummary = new HotNodeSummary(new InstanceDetails.Id(nodeId), new InstanceDetails.Ip("127.0.0.0"));
     nodeSummary.appendNestedSummary(resourceSummary);
     return new ResourceFlowUnit(System.currentTimeMillis(), new ResourceContext(Resources.State.HEALTHY), nodeSummary);
   }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/cluster/BaseClusterRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/cluster/BaseClusterRcaTest.java
@@ -310,7 +310,10 @@ public class BaseClusterRcaTest {
   }
 
   private boolean compareNodeSummary(String nodeId, Resource resource, HotNodeSummary nodeSummary) {
-    if (!nodeId.equals(nodeSummary.getNodeID()) || nodeSummary.getHotResourceSummaryList().isEmpty()) {
+    if (!nodeId.equals(nodeSummary.getNodeID().toString())) {
+      return false;
+    }
+    if (nodeSummary.getHotResourceSummaryList().isEmpty()) {
       return false;
     }
     return compareResourceSummary(resource, nodeSummary.getHotResourceSummaryList().get(0));

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotshard/HotShardClusterRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotshard/HotShardClusterRcaTest.java
@@ -66,7 +66,7 @@ public class HotShardClusterRcaTest {
             hotShardClusterRca = new HotShardClusterRca(1, hotShardRca);
 
             InstanceDetails instanceDetails =
-                new InstanceDetails(AllMetrics.NodeRole.DATA, "node1", "127.0.0.1", false);
+                new InstanceDetails(AllMetrics.NodeRole.DATA, new InstanceDetails.Id("node1"), new InstanceDetails.Ip("127.0.0.1"), false);
             ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
             clusterDetailsEventProcessor.setNodesDetails(Collections.singletonList(
                 new ClusterDetailsEventProcessor.NodeDetails(


### PR DESCRIPTION
*Issue #:* #309 

*Description of changes:*
- The gRPC port is determined by the new field in the `InstanceDetails` class.
- Now gRPC server can run on different ports on different nodes of the cluster. 
- Use `node ID` as the primary way of distinguishing nodes in the networking layer rather than the IP addresses, for cases when all nodes run on the same machine, they will have the same IP but node IDs will still be unique.
- Because `ID` and `IP` are both represented as strings, it wasn't possible to distinguish them in the method arguments and one can slip in one for the other until the gRPC server creation complains. This PR makes them type safe by wrapping them in class of their own as java does not provide type aliasing.

*Tests:*
New tests are not added. All existing tests should continue to run correctly.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
