### PR TITLE
Adding Cache Max Size to Node Config Collector and adding Node Config Collector to ElasticSearchAnalysisGraph

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/AllMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/AllMetrics.java
@@ -138,7 +138,7 @@ public class AllMetrics {
    * Field Data Cache|26214400.0|26214400.0|26214400.0|26214400.0
    * Shard Request Cache|80181985.0|80181985.0|80181985.0|80181985.0
    */
-  public enum CacheConfigDimension implements MetricDimension {
+  public enum CacheConfigDimension implements MetricDimension, JooqFieldValue {
     CACHE_TYPE(Constants.TYPE_VALUE);
 
     private final String value;
@@ -149,6 +149,16 @@ public class AllMetrics {
 
     @Override
     public String toString() {
+      return value;
+    }
+
+    @Override
+    public Field<String> getField() {
+      return DSL.field(DSL.name(this.value), String.class);
+    }
+
+    @Override
+    public String getName() {
       return value;
     }
 
@@ -194,9 +204,9 @@ public class AllMetrics {
     }
 
     public static class Constants {
-      public static final String FIELD_DATA_CACHE_NAME = "Field_Data_Cache";
-      public static final String SHARD_REQUEST_CACHE_NAME = "Shard_Request_Cache";
-      public static final String NODE_QUERY_CACHE_NAME = "Node_Query_Cache";
+      public static final String FIELD_DATA_CACHE_NAME = "field_data_cache";
+      public static final String SHARD_REQUEST_CACHE_NAME = "shard_request_cache";
+      public static final String NODE_QUERY_CACHE_NAME = "node_query_cache";
     }
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/ResourceUtil.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/ResourceUtil.java
@@ -69,12 +69,18 @@ public class ResourceUtil {
   public static final Resource FIELD_DATA_CACHE_EVICTION = Resource.newBuilder()
           .setResourceEnum(ResourceEnum.FIELD_DATA_CACHE)
           .setMetricEnum(MetricEnum.CACHE_EVICTION).build();
+  public static final Resource FIELD_DATA_CACHE_MAX_SIZE = Resource.newBuilder()
+          .setResourceEnum(ResourceEnum.FIELD_DATA_CACHE)
+          .setMetricEnum(MetricEnum.CACHE_MAX_SIZE).build();
   public static final Resource SHARD_REQUEST_CACHE_EVICTION = Resource.newBuilder()
           .setResourceEnum(ResourceEnum.SHARD_REQUEST_CACHE)
           .setMetricEnum(MetricEnum.CACHE_EVICTION).build();
   public static final Resource SHARD_REQUEST_CACHE_HIT = Resource.newBuilder()
           .setResourceEnum(ResourceEnum.SHARD_REQUEST_CACHE)
           .setMetricEnum(MetricEnum.CACHE_HIT).build();
+  public static final Resource SHARD_REQUEST_CACHE_MAX_SIZE = Resource.newBuilder()
+          .setResourceEnum(ResourceEnum.SHARD_REQUEST_CACHE)
+          .setMetricEnum(MetricEnum.CACHE_MAX_SIZE).build();
 
   /**
    * Read the resourceType name from the ResourceType object

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
@@ -58,6 +58,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.temperature.ShardStore;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.collector.NodeConfigClusterCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.collector.NodeConfigCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.AggregateMetric;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.metric.AggregateMetric.AggregateFunction;
@@ -195,6 +196,10 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
     NodeConfigCollector nodeConfigCollector = new NodeConfigCollector(RCA_PERIOD, queueCapacity, cacheMaxSize);
     nodeConfigCollector.addTag(TAG_LOCUS, LOCUS_DATA_MASTER_NODE);
     nodeConfigCollector.addAllUpstreams(Arrays.asList(threadpool_RejectedReqs, cacheMaxSize));
+    NodeConfigClusterCollector nodeConfigClusterCollector = new NodeConfigClusterCollector(nodeConfigCollector);
+    nodeConfigClusterCollector.addTag(TAG_LOCUS, LOCUS_MASTER_NODE);
+    nodeConfigClusterCollector.addAllUpstreams(Collections.singletonList(nodeConfigCollector));
+    nodeConfigClusterCollector.addTag(TAG_AGGREGATE_UPSTREAM, LOCUS_DATA_NODE);
 
     constructShardResourceUsageGraph();
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/collector/NodeConfigCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/collector/NodeConfigCollector.java
@@ -15,14 +15,17 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.collector;
 
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CacheConfigDimension.CACHE_TYPE;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolDimension.THREAD_POOL_TYPE;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.Resource;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CacheType;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolType;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.EsConfigNode;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.MetricFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.NodeConfigFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Max_Size;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_QueueCapacity;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.persist.SQLParsingUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
@@ -39,12 +42,16 @@ public class NodeConfigCollector extends EsConfigNode {
 
   private static final Logger LOG = LogManager.getLogger(NodeConfigCollector.class);
   private final ThreadPool_QueueCapacity threadPool_queueCapacity;
+  private final Cache_Max_Size cacheMaxSize;
   private final int rcaPeriod;
   private int counter;
   private final HashMap<Resource, Double> configResult;
 
-  public NodeConfigCollector(int rcaPeriod, ThreadPool_QueueCapacity threadPool_queueCapacity) {
+  public NodeConfigCollector(int rcaPeriod,
+                             ThreadPool_QueueCapacity threadPool_queueCapacity,
+                             Cache_Max_Size cacheMaxSize) {
     this.threadPool_queueCapacity = threadPool_queueCapacity;
+    this.cacheMaxSize = cacheMaxSize;
     this.rcaPeriod = rcaPeriod;
     this.counter = 0;
     this.configResult = new HashMap<>();
@@ -69,6 +76,29 @@ public class NodeConfigCollector extends EsConfigNode {
     }
   }
 
+  private void collectCacheMaxSize(MetricFlowUnit cacheMaxSize) {
+    double fieldDataCacheMaxSize = SQLParsingUtil.readDataFromSqlResult(cacheMaxSize.getData(),
+            CACHE_TYPE.getField(), CacheType.FIELD_DATA_CACHE.toString(), MetricsDB.MAX);
+    LOG.info("MOCHI, Field Data cache max size is {}", fieldDataCacheMaxSize);
+
+    if (!Double.isNaN(fieldDataCacheMaxSize)) {
+      configResult.put(ResourceUtil.FIELD_DATA_CACHE_MAX_SIZE, fieldDataCacheMaxSize);
+    }
+    else {
+      LOG.error("Field Data cache max size is NaN");
+    }
+
+    double shardRequestCacheMaxSize = SQLParsingUtil.readDataFromSqlResult(cacheMaxSize.getData(),
+            CACHE_TYPE.getField(), CacheType.SHARD_REQUEST_CACHE.toString(), MetricsDB.MAX);
+    LOG.info("MOCHI, Shard Request cache max size is {}", shardRequestCacheMaxSize);
+    if (!Double.isNaN(shardRequestCacheMaxSize)) {
+      configResult.put(ResourceUtil.SHARD_REQUEST_CACHE_MAX_SIZE, shardRequestCacheMaxSize);
+    }
+    else {
+      LOG.error("Shard Request cache max size is NaN");
+    }
+  }
+
   /**
    * collect config settings from the upstream metric flowunits and set them into the protobuf
    * message PerformanceControllerConfiguration. This will allow us to serialize / de-serialize
@@ -83,6 +113,12 @@ public class NodeConfigCollector extends EsConfigNode {
         continue;
       }
       collectQueueCapacity(flowUnit);
+    }
+    for (MetricFlowUnit flowUnit : cacheMaxSize.getFlowUnits()) {
+      if (flowUnit.isEmpty()) {
+        continue;
+      }
+      collectCacheMaxSize(flowUnit);
     }
     if (counter == rcaPeriod) {
       counter = 0;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/collector/NodeConfigCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/collector/NodeConfigCollector.java
@@ -79,8 +79,6 @@ public class NodeConfigCollector extends EsConfigNode {
   private void collectCacheMaxSize(MetricFlowUnit cacheMaxSize) {
     double fieldDataCacheMaxSize = SQLParsingUtil.readDataFromSqlResult(cacheMaxSize.getData(),
             CACHE_TYPE.getField(), CacheType.FIELD_DATA_CACHE.toString(), MetricsDB.MAX);
-    LOG.info("MOCHI, Field Data cache max size is {}", fieldDataCacheMaxSize);
-
     if (!Double.isNaN(fieldDataCacheMaxSize)) {
       configResult.put(ResourceUtil.FIELD_DATA_CACHE_MAX_SIZE, fieldDataCacheMaxSize);
     }
@@ -90,7 +88,6 @@ public class NodeConfigCollector extends EsConfigNode {
 
     double shardRequestCacheMaxSize = SQLParsingUtil.readDataFromSqlResult(cacheMaxSize.getData(),
             CACHE_TYPE.getField(), CacheType.SHARD_REQUEST_CACHE.toString(), MetricsDB.MAX);
-    LOG.info("MOCHI, Shard Request cache max size is {}", shardRequestCacheMaxSize);
     if (!Double.isNaN(shardRequestCacheMaxSize)) {
       configResult.put(ResourceUtil.SHARD_REQUEST_CACHE_MAX_SIZE, shardRequestCacheMaxSize);
     }

--- a/src/main/proto/inter_node_rpc_service.proto
+++ b/src/main/proto/inter_node_rpc_service.proto
@@ -94,6 +94,7 @@ enum MetricEnum {
   // cache
   CACHE_EVICTION = 10 [(additional_fields).name = "cache eviction", (additional_fields).description = "cache eviction count"];
   CACHE_HIT = 11 [(additional_fields).name = "cache hit", (additional_fields).description = "cache hit count"];
+  CACHE_MAX_SIZE = 12 [(additional_fields).name = "cache max size", (additional_fields).description = "max cache size in KB"];
 }
 
 /*

--- a/src/main/proto/inter_node_rpc_service.proto
+++ b/src/main/proto/inter_node_rpc_service.proto
@@ -94,7 +94,7 @@ enum MetricEnum {
   // cache
   CACHE_EVICTION = 10 [(additional_fields).name = "cache eviction", (additional_fields).description = "cache eviction count"];
   CACHE_HIT = 11 [(additional_fields).name = "cache hit", (additional_fields).description = "cache hit count"];
-  CACHE_MAX_SIZE = 12 [(additional_fields).name = "cache max size", (additional_fields).description = "max cache size in KB"];
+  CACHE_MAX_SIZE = 12 [(additional_fields).name = "cache max size", (additional_fields).description = "max cache size in bytes"];
 }
 
 /*


### PR DESCRIPTION

*Issue #:* https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/issues/311

*Description of changes:*
1. Add the Cache MaxSize metric to Node Config Collector. The collector will cache these metric values inside the configCache (accessible via AppContext), which is how the cache decider will get access to them.
2. Add the Node Config Collector to Analysis Graph.

*Tests:* Unit Tests, tested on local stack.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
