### PR TITLE
Fix error on heap_max

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/collector/NodeConfigCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/collector/NodeConfigCollector.java
@@ -105,7 +105,7 @@ public class NodeConfigCollector extends EsConfigNode {
 
   private void collectHeapMaxSize(MetricFlowUnit heapMax) {
     double heapMaxSize = SQLParsingUtil.readDataFromSqlResult(heapMax.getData(),
-            MEM_TYPE.getField(), AllMetrics.HeapValue.HEAP_MAX.toString(), MetricsDB.MAX);
+            MEM_TYPE.getField(), AllMetrics.GCType.HEAP.toString(), MetricsDB.MAX);
     if (!Double.isNaN(heapMaxSize)) {
       configResult.put(ResourceUtil.HEAP_MAX_SIZE, heapMaxSize);
     }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/collector/NodeConfigCollectorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/collector/NodeConfigCollectorTest.java
@@ -16,7 +16,6 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.store.collector;
 
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.HeapDimension.MEM_TYPE;
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.HeapValue.HEAP_MAX;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolDimension.THREAD_POOL_TYPE;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
@@ -85,7 +84,7 @@ public class NodeConfigCollectorTest {
     MetricFlowUnit flowUnit =
         MetricFlowUnitTestHelper.createFlowUnit(
             Arrays.asList(MEM_TYPE.toString(), MetricsDB.MAX),
-            Arrays.asList(HEAP_MAX.toString(), String.valueOf(heapMaxSize)));
+            Arrays.asList(AllMetrics.GCType.HEAP.toString(), String.valueOf(heapMaxSize)));
     heapMax.setLocalFlowUnit(flowUnit);
   }
 


### PR DESCRIPTION
*Issue #:* https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/issues/343

*Description of changes:*
Fix the error of incorrect row name to collect heap_max in NodeConfigCollector 
```
sqlite> select * from Heap_Max;
MemType     sum          avg          min          max        
----------  -----------  -----------  -----------  -----------
Eden        279183360.0  279183360.0  279183360.0  279183360.0
Heap        8555069440.  8555069440.  8555069440.  8555069440.
NonHeap     -1.0         -1.0         -1.0         -1.0       
OldGen      8241020928.  8241020928.  8241020928.  8241020928.
PermGen     -1.0         -1.0         -1.0         -1.0       
Survivor    34865152.0   34865152.0   34865152.0   34865152.0 
totFullGC   -2.0         -2.0         -2.0         -2.0       
totYoungGC  -2.0         -2.0         -2.0         -2.0 
```
```
[2020-08-05T11:54:03,369][INFO][c.a.o.e.p.r.s.c.NodeConfigCollector] Heap value is present 8,555,069,440.00
```

*Tests:*
Tested in AES. Printed the heap values and checked it with value in the table.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

