### PR TITLE
Retrieve the node role in a consistent way across the controller and the scheduler.

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -273,7 +273,7 @@ public class RcaController {
           tick = 0;
           final InstanceDetails nodeDetails = appContext.getMyInstanceDetails();
           if (nodeDetails.getRole() !=  NodeRole.UNKNOWN) {
-            checkUpdateNodeRole(nodeDetails);
+            currentRole = nodeDetails.getRole();
           }
         }
 
@@ -298,12 +298,6 @@ public class RcaController {
       }
       tick++;
     }
-  }
-
-  private void checkUpdateNodeRole(final InstanceDetails currentNode) {
-    final NodeRole currentNodeRole = currentNode.getRole();
-    boolean isMasterNode = currentNode.getIsMaster();
-    currentRole = isMasterNode ? NodeRole.ELECTED_MASTER : currentNodeRole;
   }
 
   /**

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/InstanceDetails.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/InstanceDetails.java
@@ -17,6 +17,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.ut
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.core.Util;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.NodeRole;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
@@ -129,7 +130,7 @@ public class InstanceDetails {
   }
 
   public AllMetrics.NodeRole getRole() {
-    return role;
+    return isMaster ? NodeRole.ELECTED_MASTER : role;
   }
 
   public Id getInstanceId() {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
@@ -301,11 +301,13 @@ public class RcaControllerTest {
     setMyIp(masterIP, AllMetrics.NodeRole.ELECTED_MASTER);
     Assert.assertTrue(check(new NodeRoleEval(rcaController), AllMetrics.NodeRole.ELECTED_MASTER));
     Assert.assertEquals(rcaController.getCurrentRole(), AllMetrics.NodeRole.ELECTED_MASTER);
+    Assert.assertEquals(rcaController.getCurrentRole(), rcaController.getRcaScheduler().getRole());
 
     AllMetrics.NodeRole nodeRole = AllMetrics.NodeRole.MASTER;
     setMyIp("10.10.192.200", nodeRole);
     Assert.assertTrue(check(new NodeRoleEval(rcaController), nodeRole));
     Assert.assertEquals(rcaController.getCurrentRole(), nodeRole);
+    Assert.assertEquals(rcaController.getCurrentRole(), rcaController.getRcaScheduler().getRole());
   }
 
   /**


### PR DESCRIPTION
*Issue #:*
Resolves #344 

The controller enters a restart cycle because the node role retrieved in the scheduler and the node retrieved in the controller don't match.

*Description of changes:*
This change fixes the way in which we retrieve the current node's role and makes it consistent across the rca controller and the rca scheduler.

*Tests:*
Tested by running ./gradlew runDocker and making sure that the scheduler is not restarting constantly.

Added an `assert` in the RcaControllerTest to catch this beahvior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
