### PR TITLE
Fixing the summary serialization issue for cache RCAs

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/cache/FieldDataCacheRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/cache/FieldDataCacheRca.java
@@ -112,7 +112,7 @@ public class FieldDataCacheRca extends Rca<ResourceFlowUnit<HotNodeSummary>> {
         cacheEvictionCollector.collect(currTimestamp);
         if (counter >= rcaPeriod) {
             ResourceContext context;
-            HotNodeSummary nodeSummary;
+            HotNodeSummary nodeSummary = new HotNodeSummary(instanceDetails.getInstanceId(), instanceDetails.getInstanceIp());
 
             InstanceDetails instanceDetails = getInstanceDetails();
             double fieldDataCacheMaxSizeInBytes = getCacheMaxSize(
@@ -121,12 +121,10 @@ public class FieldDataCacheRca extends Rca<ResourceFlowUnit<HotNodeSummary>> {
                     fieldDataCacheSizeGroupByOperation, fieldDataCacheMaxSizeInBytes, cacheSizeThreshold);
             if (cacheEvictionCollector.isUnhealthy(currTimestamp) && exceedsSizeThreshold) {
                 context = new ResourceContext(Resources.State.UNHEALTHY);
-                nodeSummary = new HotNodeSummary(instanceDetails.getInstanceId(), instanceDetails.getInstanceIp());
                 nodeSummary.appendNestedSummary(cacheEvictionCollector.generateSummary(currTimestamp));
             }
             else {
                 context = new ResourceContext(Resources.State.HEALTHY);
-                nodeSummary = null;
             }
 
             counter = 0;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/cache/FieldDataCacheRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/cache/FieldDataCacheRca.java
@@ -112,9 +112,9 @@ public class FieldDataCacheRca extends Rca<ResourceFlowUnit<HotNodeSummary>> {
         cacheEvictionCollector.collect(currTimestamp);
         if (counter >= rcaPeriod) {
             ResourceContext context;
+            InstanceDetails instanceDetails = getInstanceDetails();
             HotNodeSummary nodeSummary = new HotNodeSummary(instanceDetails.getInstanceId(), instanceDetails.getInstanceIp());
 
-            InstanceDetails instanceDetails = getInstanceDetails();
             double fieldDataCacheMaxSizeInBytes = getCacheMaxSize(
                     getAppContext(), new NodeKey(instanceDetails), ResourceUtil.FIELD_DATA_CACHE_MAX_SIZE);
             Boolean exceedsSizeThreshold = isSizeThresholdExceeded(

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/cache/ShardRequestCacheRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/cache/ShardRequestCacheRca.java
@@ -124,7 +124,7 @@ public class ShardRequestCacheRca extends Rca<ResourceFlowUnit<HotNodeSummary>> 
         cacheHitCollector.collect(currTimestamp);
         if (counter >= rcaPeriod) {
             ResourceContext context;
-            HotNodeSummary nodeSummary;
+            HotNodeSummary nodeSummary = new HotNodeSummary(instanceDetails.getInstanceId(), instanceDetails.getInstanceIp());
 
             InstanceDetails instanceDetails = getInstanceDetails();
             double shardRequestCacheMaxSizeInBytes = getCacheMaxSize(
@@ -138,11 +138,9 @@ public class ShardRequestCacheRca extends Rca<ResourceFlowUnit<HotNodeSummary>> 
                     && cacheHitCollector.isUnhealthy(currTimestamp)
                     && exceedsSizeThreshold) {
                 context = new ResourceContext(Resources.State.UNHEALTHY);
-                nodeSummary = new HotNodeSummary(instanceDetails.getInstanceId(), instanceDetails.getInstanceIp());
                 nodeSummary.appendNestedSummary(cacheEvictionCollector.generateSummary(currTimestamp));
             } else {
                 context = new ResourceContext(Resources.State.HEALTHY);
-                nodeSummary = null;
             }
 
             counter = 0;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/cache/ShardRequestCacheRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/cache/ShardRequestCacheRca.java
@@ -124,9 +124,9 @@ public class ShardRequestCacheRca extends Rca<ResourceFlowUnit<HotNodeSummary>> 
         cacheHitCollector.collect(currTimestamp);
         if (counter >= rcaPeriod) {
             ResourceContext context;
+            InstanceDetails instanceDetails = getInstanceDetails();
             HotNodeSummary nodeSummary = new HotNodeSummary(instanceDetails.getInstanceId(), instanceDetails.getInstanceIp());
 
-            InstanceDetails instanceDetails = getInstanceDetails();
             double shardRequestCacheMaxSizeInBytes = getCacheMaxSize(
                     getAppContext(), new NodeKey(instanceDetails), ResourceUtil.SHARD_REQUEST_CACHE_MAX_SIZE);
             Boolean exceedsSizeThreshold = isSizeThresholdExceeded(


### PR DESCRIPTION
*Issue #:* https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/issues/347

*Description of changes:* Serialization failing for Cache RCAs because of `null HotNodeSummary` when Resource is Healthy.
Updated the default initialization and removed the Null assignment for `HotNodeSummary`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
