### PR TITLE
Use StringUtils instead of NumberUtils to check timestamp string

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/overrides/ConfigOverridesApplier.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/overrides/ConfigOverridesApplier.java
@@ -22,7 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
-import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -115,7 +115,7 @@ public class ConfigOverridesApplier {
       return false;
     }
 
-    return NumberUtils.isCreatable(timestamp);
+    return StringUtils.isNumeric(timestamp);
   }
 
   @VisibleForTesting

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyCacheMaxSizeActionTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyCacheMaxSizeActionTest.java
@@ -31,12 +31,10 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.Resource;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.configs.CacheDeciderConfig;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Stats;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
 import com.google.common.collect.ImmutableSet;
 import java.util.Map;
-import org.checkerframework.checker.units.qual.Temperature;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
*Issue #:*
Fixes #359 

*Description of changes:*
This change updates a check where we used `NumberUtils.isCreatable(timestamp);` to `StringUtils.isNumeric(timestamp);`

The check we want to do is that the value we received from the writer is actually an epoch which is checked more strongly with the `.isNumeric()` check than `.isCreatable()` as the latter allows other forms of numbers(signed, hexadecimal, scientific notation, decimals) as valid numbers.


Removes some unused imports as well.
*Tests:*
build passes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
