### PR TITLE
Refactor ModifyQueueCapacityAction to follow builder pattern

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyQueueCapacityAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyQueueCapacityAction.java
@@ -126,7 +126,7 @@ public class ModifyQueueCapacityAction extends SuppressibleAction {
     public static final boolean DEFAULT_CAN_UPDATE = true;
 
     private int stepSize;
-    private boolean isIncrease;
+    private boolean increase;
     private boolean canUpdate;
     private long coolOffPeriodInMillis;
     private int upperBound;
@@ -144,7 +144,7 @@ public class ModifyQueueCapacityAction extends SuppressibleAction {
       this.appContext = appContext;
       this.coolOffPeriodInMillis = DEFAULT_COOL_OFF_PERIOD_IN_MILLIS;
       this.stepSize = DEFAULT_STEP_SIZE;
-      this.isIncrease = DEFAULT_IS_INCREASE;
+      this.increase = DEFAULT_IS_INCREASE;
       this.canUpdate = DEFAULT_CAN_UPDATE;
       this.desiredCapacity = null;
       this.currentCapacity =
@@ -173,8 +173,8 @@ public class ModifyQueueCapacityAction extends SuppressibleAction {
       return this;
     }
 
-    public Builder increase(boolean isInrease) {
-      this.isIncrease = isInrease;
+    public Builder increase(boolean increase) {
+      this.increase = increase;
       return this;
     }
 
@@ -214,7 +214,7 @@ public class ModifyQueueCapacityAction extends SuppressibleAction {
       // skip the step size bound check if we set desiredCapacity
       // explicitly in action builder
       if (desiredCapacity == null) {
-        desiredCapacity = isIncrease ? currentCapacity + stepSize : currentCapacity - stepSize;
+        desiredCapacity = increase ? currentCapacity + stepSize : currentCapacity - stepSize;
       }
       desiredCapacity = Math.min(desiredCapacity, upperBound);
       desiredCapacity = Math.max(desiredCapacity, lowerBound);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyQueueCapacityAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyQueueCapacityAction.java
@@ -27,9 +27,12 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.uti
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class ModifyQueueCapacityAction extends SuppressibleAction {
 
+  private static final Logger LOG = LogManager.getLogger(ModifyQueueCapacityAction.class);
   public static final String NAME = "ModifyQueueCapacity";
 
   private final ResourceEnum threadPool;
@@ -204,6 +207,7 @@ public class ModifyQueueCapacityAction extends SuppressibleAction {
       // fail to read capacity from node config cache
       // return an empty non-actionable action object
       if (currentCapacity == null) {
+        LOG.error("Action: Fail to read queue capacity from node config cache. Return an non-actionable action");
         return new ModifyQueueCapacityAction(esNode, threadPool, appContext,
             -1, -1, coolOffPeriodInMillis, lowerBound, upperBound, false);
       }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/QueueHealthDecider.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/QueueHealthDecider.java
@@ -17,8 +17,6 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.de
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.Action;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ModifyQueueCapacityAction;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.MetricEnum;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.Resource;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotClusterSummary;
@@ -95,20 +93,10 @@ public class QueueHealthDecider extends Decider {
    */
   private Action computeBestAction(NodeKey esNode, ResourceEnum threadPool) {
     Action action = null;
-    int currQueueCapacity;
-    try {
-        currQueueCapacity = getNodeQueueCapacity(esNode, threadPool);
-    } catch (Exception e) {
-      // No action if value not present in the cache.
-      // Assumption here is the cache has been wiped off due to
-      // unforeseen events and we dont want to trigger any action.
-      LOG.error("Exception while reading values from Node Config Cache", e);
-      return null;
-    }
 
     for (String actionName : actionsByUserPriority) {
       action =
-        getAction(actionName, esNode, threadPool, currQueueCapacity, true);
+        getAction(actionName, esNode, threadPool, true);
       if (action != null) {
         break;
       }
@@ -116,26 +104,23 @@ public class QueueHealthDecider extends Decider {
     return action;
   }
 
-  private Action getAction(String actionName, NodeKey esNode, ResourceEnum threadPool, int currCapacity, boolean increase) {
+  private Action getAction(String actionName, NodeKey esNode, ResourceEnum threadPool, boolean increase) {
     switch (actionName) {
       case ModifyQueueCapacityAction.NAME:
-        return configureQueueCapacity(esNode, threadPool, currCapacity, increase);
+        return configureQueueCapacity(esNode, threadPool, increase);
       default:
         return null;
     }
   }
 
-  private ModifyQueueCapacityAction configureQueueCapacity(NodeKey esNode, ResourceEnum threadPool, int currentCapacity, boolean increase) {
-    ModifyQueueCapacityAction action = ModifyQueueCapacityAction.newBuilder(esNode, threadPool, getAppContext()).build();
+  private ModifyQueueCapacityAction configureQueueCapacity(NodeKey esNode, ResourceEnum threadPool, boolean increase) {
+    ModifyQueueCapacityAction action = ModifyQueueCapacityAction
+            .newBuilder(esNode, threadPool, getAppContext())
+            .setIncrease(increase)
+            .build();
     if (action != null && action.isActionable()) {
       return action;
     }
     return null;
-  }
-
-  private int getNodeQueueCapacity(NodeKey esNode, ResourceEnum threadPool) {
-      return (int) getAppContext().getNodeConfigCache().get(esNode, Resource.newBuilder()
-              .setResourceEnum(threadPool)
-              .setMetricEnum(MetricEnum.QUEUE_CAPACITY).build());
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/QueueHealthDecider.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/QueueHealthDecider.java
@@ -116,7 +116,7 @@ public class QueueHealthDecider extends Decider {
   private ModifyQueueCapacityAction configureQueueCapacity(NodeKey esNode, ResourceEnum threadPool, boolean increase) {
     ModifyQueueCapacityAction action = ModifyQueueCapacityAction
             .newBuilder(esNode, threadPool, getAppContext())
-            .setIncrease(increase)
+            .increase(increase)
             .build();
     if (action != null && action.isActionable()) {
       return action;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/QueueHealthDecider.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/QueueHealthDecider.java
@@ -126,9 +126,8 @@ public class QueueHealthDecider extends Decider {
   }
 
   private ModifyQueueCapacityAction configureQueueCapacity(NodeKey esNode, ResourceEnum threadPool, int currentCapacity, boolean increase) {
-    ModifyQueueCapacityAction action = new ModifyQueueCapacityAction(esNode, threadPool,
-        currentCapacity, increase, getAppContext());
-    if (action.isActionable()) {
+    ModifyQueueCapacityAction action = ModifyQueueCapacityAction.newBuilder(esNode, threadPool, getAppContext()).build();
+    if (action != null && action.isActionable()) {
       return action;
     }
     return null;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyQueueCapacityActionTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyQueueCapacityActionTest.java
@@ -49,7 +49,7 @@ public class ModifyQueueCapacityActionTest {
     dummyCache.put(node1, ResourceUtil.WRITE_QUEUE_CAPACITY, 500);
     ModifyQueueCapacityAction.Builder builder =
         ModifyQueueCapacityAction.newBuilder(node1, ResourceEnum.WRITE_THREADPOOL, testAppContext);
-    ModifyQueueCapacityAction modifyQueueCapacityAction = builder.setIncrease(true).build();
+    ModifyQueueCapacityAction modifyQueueCapacityAction = builder.increase(true).build();
     Assert.assertNotNull(modifyQueueCapacityAction);
     assertTrue(modifyQueueCapacityAction.getDesiredCapacity() > modifyQueueCapacityAction.getCurrentCapacity());
     assertTrue(modifyQueueCapacityAction.isActionable());
@@ -72,7 +72,7 @@ public class ModifyQueueCapacityActionTest {
     dummyCache.put(node1, ResourceUtil.SEARCH_QUEUE_CAPACITY, 1500);
     ModifyQueueCapacityAction.Builder builder =
         ModifyQueueCapacityAction.newBuilder(node1, ResourceEnum.SEARCH_THREADPOOL, testAppContext);
-    ModifyQueueCapacityAction modifyQueueCapacityAction = builder.setIncrease(false).build();
+    ModifyQueueCapacityAction modifyQueueCapacityAction = builder.increase(false).build();
     Assert.assertNotNull(modifyQueueCapacityAction);
     assertTrue(modifyQueueCapacityAction.getDesiredCapacity() < modifyQueueCapacityAction.getCurrentCapacity());
     assertTrue(modifyQueueCapacityAction.isActionable());
@@ -96,28 +96,28 @@ public class ModifyQueueCapacityActionTest {
     dummyCache.put(node1, ResourceUtil.SEARCH_QUEUE_CAPACITY, 3000);
     ModifyQueueCapacityAction.Builder builder =
         ModifyQueueCapacityAction.newBuilder(node1, ResourceEnum.SEARCH_THREADPOOL, testAppContext);
-    ModifyQueueCapacityAction searchQueueIncrease = builder.setIncrease(true).build();
+    ModifyQueueCapacityAction searchQueueIncrease = builder.increase(true).build();
     assertEquals(searchQueueIncrease.getDesiredCapacity(), searchQueueIncrease.getCurrentCapacity());
     assertFalse(searchQueueIncrease.isActionable());
     assertNoImpact(node1, searchQueueIncrease);
 
     dummyCache.put(node1, ResourceUtil.SEARCH_QUEUE_CAPACITY, 1000);
     builder = ModifyQueueCapacityAction.newBuilder(node1, ResourceEnum.SEARCH_THREADPOOL, testAppContext);
-    ModifyQueueCapacityAction searchQueueDecrease = builder.setIncrease(false).build();
+    ModifyQueueCapacityAction searchQueueDecrease = builder.increase(false).build();
     assertEquals(searchQueueDecrease.getDesiredCapacity(), searchQueueDecrease.getCurrentCapacity());
     assertFalse(searchQueueDecrease.isActionable());
     assertNoImpact(node1, searchQueueDecrease);
 
     dummyCache.put(node1, ResourceUtil.WRITE_QUEUE_CAPACITY, 1000);
     builder = ModifyQueueCapacityAction.newBuilder(node1, ResourceEnum.WRITE_THREADPOOL, testAppContext);
-    ModifyQueueCapacityAction writeQueueIncrease = builder.setIncrease(true).build();
+    ModifyQueueCapacityAction writeQueueIncrease = builder.increase(true).build();
     assertEquals(writeQueueIncrease.getDesiredCapacity(), writeQueueIncrease.getCurrentCapacity());
     assertFalse(writeQueueIncrease.isActionable());
     assertNoImpact(node1, writeQueueIncrease);
 
     dummyCache.put(node1, ResourceUtil.WRITE_QUEUE_CAPACITY, 100);
     builder = ModifyQueueCapacityAction.newBuilder(node1, ResourceEnum.WRITE_THREADPOOL, testAppContext);
-    ModifyQueueCapacityAction writeQueueDecrease = builder.setIncrease(false).build();
+    ModifyQueueCapacityAction writeQueueDecrease = builder.increase(false).build();
     assertEquals(writeQueueDecrease.getDesiredCapacity(), writeQueueDecrease.getCurrentCapacity());
     assertFalse(writeQueueDecrease.isActionable());
     assertNoImpact(node1, writeQueueDecrease);
@@ -129,7 +129,7 @@ public class ModifyQueueCapacityActionTest {
     dummyCache.put(node1, ResourceUtil.SEARCH_QUEUE_CAPACITY, 2000);
     ModifyQueueCapacityAction.Builder builder =
         ModifyQueueCapacityAction.newBuilder(node1, ResourceEnum.SEARCH_THREADPOOL, testAppContext);
-    ModifyQueueCapacityAction modifyQueueCapacityAction = builder.setIncrease(true).build();
+    ModifyQueueCapacityAction modifyQueueCapacityAction = builder.increase(true).build();
 
     testAppContext.updateMutedActions(ImmutableSet.of(modifyQueueCapacityAction.name()));
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyQueueCapacityActionTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyQueueCapacityActionTest.java
@@ -27,26 +27,33 @@ import static org.junit.Assert.assertTrue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ImpactVector.Dimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ImpactVector.Impact;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ModifyQueueCapacityAction.Builder;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Stats;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.collector.NodeConfigCache;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
 import com.google.common.collect.ImmutableSet;
 import java.util.Map;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class ModifyQueueCapacityActionTest {
 
   private AppContext testAppContext = new AppContext();
+  private NodeConfigCache dummyCache = testAppContext.getNodeConfigCache();
 
   @Test
   public void testIncreaseCapacity() {
     NodeKey node1 = new NodeKey(new InstanceDetails.Id("node-1"), new InstanceDetails.Ip("1.2.3.4"));
-    ModifyQueueCapacityAction modifyQueueCapacityAction = new ModifyQueueCapacityAction(node1,
-        ResourceEnum.WRITE_THREADPOOL, 300, true, testAppContext);
+    dummyCache.put(node1, ResourceUtil.WRITE_QUEUE_CAPACITY, 500);
+    ModifyQueueCapacityAction.Builder builder =
+        ModifyQueueCapacityAction.newBuilder(node1, ResourceEnum.WRITE_THREADPOOL, testAppContext);
+    ModifyQueueCapacityAction modifyQueueCapacityAction = builder.setIncrease(true).build();
+    Assert.assertNotNull(modifyQueueCapacityAction);
     assertTrue(modifyQueueCapacityAction.getDesiredCapacity() > modifyQueueCapacityAction.getCurrentCapacity());
     assertTrue(modifyQueueCapacityAction.isActionable());
-    assertEquals(ModifyQueueCapacityAction.COOL_OFF_PERIOD_IN_MILLIS,
+    assertEquals(Builder.DEFAULT_COOL_OFF_PERIOD_IN_MILLIS,
             modifyQueueCapacityAction.coolOffPeriodInMillis());
     assertEquals(ResourceEnum.WRITE_THREADPOOL, modifyQueueCapacityAction.getThreadPool());
     assertEquals(1, modifyQueueCapacityAction.impactedNodes().size());
@@ -62,11 +69,14 @@ public class ModifyQueueCapacityActionTest {
   @Test
   public void testDecreaseCapacity() {
     NodeKey node1 = new NodeKey(new InstanceDetails.Id("node-1"), new InstanceDetails.Ip("1.2.3.4"));
-    ModifyQueueCapacityAction modifyQueueCapacityAction = new ModifyQueueCapacityAction(node1,
-        ResourceEnum.SEARCH_THREADPOOL, 1500, false, testAppContext);
+    dummyCache.put(node1, ResourceUtil.SEARCH_QUEUE_CAPACITY, 1500);
+    ModifyQueueCapacityAction.Builder builder =
+        ModifyQueueCapacityAction.newBuilder(node1, ResourceEnum.SEARCH_THREADPOOL, testAppContext);
+    ModifyQueueCapacityAction modifyQueueCapacityAction = builder.setIncrease(false).build();
+    Assert.assertNotNull(modifyQueueCapacityAction);
     assertTrue(modifyQueueCapacityAction.getDesiredCapacity() < modifyQueueCapacityAction.getCurrentCapacity());
     assertTrue(modifyQueueCapacityAction.isActionable());
-    assertEquals(ModifyQueueCapacityAction.COOL_OFF_PERIOD_IN_MILLIS,
+    assertEquals(Builder.DEFAULT_COOL_OFF_PERIOD_IN_MILLIS,
             modifyQueueCapacityAction.coolOffPeriodInMillis());
     assertEquals(ResourceEnum.SEARCH_THREADPOOL, modifyQueueCapacityAction.getThreadPool());
     assertEquals(1, modifyQueueCapacityAction.impactedNodes().size());
@@ -83,26 +93,31 @@ public class ModifyQueueCapacityActionTest {
   public void testBounds() {
     // TODO: Move to work with test rcaConf when bounds moved to config
     NodeKey node1 = new NodeKey(new InstanceDetails.Id("node-1"), new InstanceDetails.Ip("1.2.3.4"));
-    ModifyQueueCapacityAction searchQueueIncrease = new ModifyQueueCapacityAction(node1,
-        ResourceEnum.SEARCH_THREADPOOL, 3000, true, testAppContext);
+    dummyCache.put(node1, ResourceUtil.SEARCH_QUEUE_CAPACITY, 3000);
+    ModifyQueueCapacityAction.Builder builder =
+        ModifyQueueCapacityAction.newBuilder(node1, ResourceEnum.SEARCH_THREADPOOL, testAppContext);
+    ModifyQueueCapacityAction searchQueueIncrease = builder.setIncrease(true).build();
     assertEquals(searchQueueIncrease.getDesiredCapacity(), searchQueueIncrease.getCurrentCapacity());
     assertFalse(searchQueueIncrease.isActionable());
     assertNoImpact(node1, searchQueueIncrease);
 
-    ModifyQueueCapacityAction searchQueueDecrease = new ModifyQueueCapacityAction(node1,
-        ResourceEnum.SEARCH_THREADPOOL, 1000, false, testAppContext);
-    assertEquals(searchQueueIncrease.getDesiredCapacity(), searchQueueIncrease.getCurrentCapacity());
-    assertFalse(searchQueueIncrease.isActionable());
+    dummyCache.put(node1, ResourceUtil.SEARCH_QUEUE_CAPACITY, 1000);
+    builder = ModifyQueueCapacityAction.newBuilder(node1, ResourceEnum.SEARCH_THREADPOOL, testAppContext);
+    ModifyQueueCapacityAction searchQueueDecrease = builder.setIncrease(false).build();
+    assertEquals(searchQueueDecrease.getDesiredCapacity(), searchQueueDecrease.getCurrentCapacity());
+    assertFalse(searchQueueDecrease.isActionable());
     assertNoImpact(node1, searchQueueDecrease);
 
-    ModifyQueueCapacityAction writeQueueIncrease = new ModifyQueueCapacityAction(node1,
-        ResourceEnum.WRITE_THREADPOOL, 1000, true, testAppContext);
+    dummyCache.put(node1, ResourceUtil.WRITE_QUEUE_CAPACITY, 1000);
+    builder = ModifyQueueCapacityAction.newBuilder(node1, ResourceEnum.WRITE_THREADPOOL, testAppContext);
+    ModifyQueueCapacityAction writeQueueIncrease = builder.setIncrease(true).build();
     assertEquals(writeQueueIncrease.getDesiredCapacity(), writeQueueIncrease.getCurrentCapacity());
     assertFalse(writeQueueIncrease.isActionable());
     assertNoImpact(node1, writeQueueIncrease);
 
-    ModifyQueueCapacityAction writeQueueDecrease = new ModifyQueueCapacityAction(node1,
-        ResourceEnum.WRITE_THREADPOOL, 100, false, testAppContext);
+    dummyCache.put(node1, ResourceUtil.WRITE_QUEUE_CAPACITY, 100);
+    builder = ModifyQueueCapacityAction.newBuilder(node1, ResourceEnum.WRITE_THREADPOOL, testAppContext);
+    ModifyQueueCapacityAction writeQueueDecrease = builder.setIncrease(false).build();
     assertEquals(writeQueueDecrease.getDesiredCapacity(), writeQueueDecrease.getCurrentCapacity());
     assertFalse(writeQueueDecrease.isActionable());
     assertNoImpact(node1, writeQueueDecrease);
@@ -111,8 +126,10 @@ public class ModifyQueueCapacityActionTest {
   @Test
   public void testMutedAction() {
     NodeKey node1 = new NodeKey(new InstanceDetails.Id("node-1"), new InstanceDetails.Ip("1.2.3.4"));
-    ModifyQueueCapacityAction modifyQueueCapacityAction = new ModifyQueueCapacityAction(node1,
-        ResourceEnum.SEARCH_THREADPOOL, 3000, true, testAppContext);
+    dummyCache.put(node1, ResourceUtil.SEARCH_QUEUE_CAPACITY, 2000);
+    ModifyQueueCapacityAction.Builder builder =
+        ModifyQueueCapacityAction.newBuilder(node1, ResourceEnum.SEARCH_THREADPOOL, testAppContext);
+    ModifyQueueCapacityAction modifyQueueCapacityAction = builder.setIncrease(true).build();
 
     testAppContext.updateMutedActions(ImmutableSet.of(modifyQueueCapacityAction.name()));
 


### PR DESCRIPTION
*Issue #:*

*Description of changes:*
Refactor ModifyQueueCapacityAction to follow builder pattern. the current constructor in Modify**Action does not allow decider to make changes to some parameters in Action object. So I am creating this PR to add a Builder into the Modify**Action class to expose more parameters for decider to tune

*Tests:*
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
