### PR TITLE
For debugging purpose get access to the data in all the tables in a host

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
@@ -17,11 +17,12 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.response.RcaResponse;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.JsonElement;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Map;
 import org.jooq.Record;
 import org.jooq.Result;
 
@@ -62,4 +63,11 @@ public interface Persistable {
    * @return A list of RCAs.
    */
   List<String> getAllPersistedRcas();
+
+  /**
+   * Get records for all the tables
+   * @return A map of table and all the data contained in the table.
+   */
+  @VisibleForTesting
+  Map<String, Result<Record>> getRecordsForAllTables();
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistorBase.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistorBase.java
@@ -18,6 +18,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import java.io.File;
@@ -32,6 +33,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
@@ -115,7 +117,8 @@ public abstract class PersistorBase implements Persistable {
 
   abstract void createNewDSLContext();
 
-  public abstract List<Result<Record>> getRecordsForAllTables();
+  @VisibleForTesting
+  public abstract Map<String, Result<Record>> getRecordsForAllTables();
 
   // Not required for now.
   @Override

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
@@ -27,6 +27,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.uti
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.response.RcaResponse;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.ClusterTemperatureRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.NodeTemperatureRca;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -197,10 +198,11 @@ class SQLitePersistor extends PersistorBase {
     return tablesObject.toString();
   }
 
-  public synchronized List<Result<Record>> getRecordsForAllTables() {
-    List<Result<Record>> results = new ArrayList<>();
+  @VisibleForTesting
+  public synchronized Map<String, Result<Record>> getRecordsForAllTables() {
+    Map<String, Result<Record>> results = new HashMap<>();
     super.tableNames.forEach(
-            table -> results.add(getRecords(table))
+            table -> results.put(table, getRecords(table))
     );
     return results;
   }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Cluster.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Cluster.java
@@ -36,6 +36,8 @@ import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import org.apache.commons.io.FileUtils;
+import org.jooq.Record;
+import org.jooq.Result;
 
 public class Cluster {
   // A cluster can have 0 (single node) to 5 (multi node with dedicated masters) hosts. The following three
@@ -273,6 +275,10 @@ public class Cluster {
 
   public String getRcaRestResponse(final Map<String, String> params, HostTag hostByTag) {
     return verifyTag(hostByTag).makeRestRequest(params);
+  }
+
+  public Map<String, Result<Record>> getRecordsForAllTablesOnHost(HostTag hostTag) {
+    return verifyTag(hostTag).getRecordsForAllTables();
   }
 
   private Host verifyTag(HostTag hostTag) {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Host.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Host.java
@@ -368,6 +368,10 @@ public class Host {
     return obj;
   }
 
+  public Map<String, Result<Record>> getRecordsForAllTables() {
+    return this.rcaController.getPersistenceProvider().getRecordsForAllTables();
+  }
+
   public String makeRestRequest(final Map<String, String> kvRequestParams) {
     StringBuilder queryString = new StringBuilder();
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/api/TestApi.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/api/TestApi.java
@@ -44,4 +44,14 @@ public class TestApi {
     Objects.requireNonNull(params);
     return cluster.getRcaRestResponse(params, hostByTag);
   }
+
+  /**
+   * This can be used to get all the records from all the tables in a host. This can be used for validation of
+   * what gets persisted in the rca.sqlite tables.
+   * @param hostTag The host whose rca.sqlite will be queried.
+   * @return A list of all the data stored in all the tables in the particular host.
+   */
+  public Map<String, Result<Record>> getRecordsForAllTablesOnHost(HostTag hostTag) {
+    return cluster.getRecordsForAllTablesOnHost(hostTag);
+  }
 }


### PR DESCRIPTION
*Fixes #:* #376

*Description of changes:* A way for test writers to debug the data being pumped into RCA graph by being able to read the data from all the tables on a host.

*Tests:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
