### PR TITLE
Create a PersistableAction base class to persist actions into database

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/Consts.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/Consts.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions;
+
+public class Consts {
+
+  /**
+   * SQL tables persisted in rca.sqlite
+   */
+  public static final class Table {
+    public static final String ACTION_TABLE = "Action";
+    public static final String PUBLISHER_EVENT_TABLE = "PublisherEvent";
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyQueueCapacityAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyQueueCapacityAction.java
@@ -20,6 +20,7 @@ import static com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionma
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ImpactVector.Dimension.NETWORK;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.PersistableAction.SQL_SCHEMA_CONSTANTS.ActionField;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
 
@@ -30,7 +31,7 @@ import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class ModifyQueueCapacityAction extends SuppressibleAction {
+public class ModifyQueueCapacityAction extends PersistableAction {
 
   private static final Logger LOG = LogManager.getLogger(ModifyQueueCapacityAction.class);
   public static final String NAME = "ModifyQueueCapacity";
@@ -56,6 +57,7 @@ public class ModifyQueueCapacityAction extends SuppressibleAction {
     this.lowerBound = lowerBound;
     this.upperBound = upperBound;
     this.canUpdate = canUpdate;
+    persistValues();
   }
 
   public static Builder newBuilder(NodeKey esNode, ResourceEnum threadPool, AppContext appContext) {
@@ -117,6 +119,17 @@ public class ModifyQueueCapacityAction extends SuppressibleAction {
 
   public ResourceEnum getThreadPool() {
     return threadPool;
+  }
+
+  //persist values into SQL tuple
+  private void persistValues() {
+    setRowValue(ActionField.RESOURCE_TYPE_FIELD.getField(), threadPool.getNumber());
+    setRowValue(ActionField.NODE_ID_FIELD.getField(), esNode.getNodeId().toString());
+    setRowValue(ActionField.NODE_IP_FIELD.getField(), esNode.getHostAddress().toString());
+    setRowValue(ActionField.ACTIONABLE_FIELD.getField(), isActionable());
+    setRowValue(ActionField.COOL_OFF_PERIOD_FIELD.getField(), coolOffPeriodInMillis);
+    setRowValue(ActionField.CURRENT_VALUE_FIELD.getField(), currentCapacity);
+    setRowValue(ActionField.DESIRED_VALUE_FIELD.getField(), desiredCapacity);
   }
 
   public static final class Builder {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/PersistableAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/PersistableAction.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.Consts.Table;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.PersistableAction.SQL_SCHEMA_CONSTANTS.ActionField;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.persist.JooqFieldValue;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.PersistableObject;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.PersistorBase;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.TableInfo;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jooq.Field;
+import org.jooq.impl.DSL;
+
+/**
+ * Actions that can be persisted in SQL
+ *
+ * <p>Table name : Action
+ *
+ * <p>schema :
+ * | ID(primary key) |     action_name     | resource_type | resource_metric | node_id |
+ * |      1          | ModifyQueueCapacity |      1        |       5         |  node1  |
+ * | node_ip   | actionable | cool_off_period | current_value | desired_value | additional_json |
+ * | 127.0.0.1 |  true      |  300            |   100         |  150          |                 |
+ */
+public abstract class PersistableAction extends SuppressibleAction implements PersistableObject {
+  private static final Logger LOG = LogManager.getLogger(PersistableAction.class);
+  private static final List<Field<?>> schema;
+  private final Map<Field<?>, Object> rowValues;
+
+  public PersistableAction(final AppContext appContext) {
+    super(appContext);
+    this.rowValues = new HashMap<>();
+    initializeRowValues();
+  }
+
+  static {
+    List<Field<?>> fields = new ArrayList<>();
+    fields.add(ActionField.ACTION_NAME_FIELD.getField());
+    fields.add(ActionField.RESOURCE_TYPE_FIELD.getField());
+    fields.add(ActionField.NODE_ID_FIELD.getField());
+    fields.add(ActionField.NODE_IP_FIELD.getField());
+    fields.add(ActionField.ACTIONABLE_FIELD.getField());
+    fields.add(ActionField.COOL_OFF_PERIOD_FIELD.getField());
+    fields.add(ActionField.CURRENT_VALUE_FIELD.getField());
+    fields.add(ActionField.DESIRED_VALUE_FIELD.getField());
+    fields.add(ActionField.ADDITIONAL_JSON_FIELD.getField());
+    schema = Collections.unmodifiableList(fields);
+  }
+
+  private void initializeRowValues() {
+    rowValues.put(ActionField.ACTION_NAME_FIELD.getField(), name());
+    rowValues.put(ActionField.RESOURCE_TYPE_FIELD.getField(), -1);
+    rowValues.put(ActionField.NODE_ID_FIELD.getField(), "unknown");
+    rowValues.put(ActionField.NODE_IP_FIELD.getField(), "unknown");
+    rowValues.put(ActionField.ACTIONABLE_FIELD.getField(), false);
+    rowValues.put(ActionField.COOL_OFF_PERIOD_FIELD.getField(), -1);
+    rowValues.put(ActionField.CURRENT_VALUE_FIELD.getField(), -1);
+    rowValues.put(ActionField.DESIRED_VALUE_FIELD.getField(), -1);
+    rowValues.put(ActionField.ADDITIONAL_JSON_FIELD.getField(), "");
+  }
+
+  protected void setRowValue(Field<?> field, Object object) {
+    assert rowValues.containsKey(field) : "unrecognized field " + field.getName()
+        + " in table " + table();
+    this.rowValues.put(field, object);
+  }
+
+  private List<Object> getSqlValues() {
+    List<Object> values = new ArrayList<>();
+    schema.forEach(field -> values.add(rowValues.get(field)));
+    return values;
+  }
+
+  @Override
+  public String table() {
+    return Table.ACTION_TABLE;
+  }
+
+  @Override
+  public void write(PersistorBase persistorBase, TableInfo referenceTableInfo) throws SQLException {
+    if (referenceTableInfo == null) {
+      LOG.error("Action: Table {} is linked to a null reference table", table());
+      throw new SQLException();
+    }
+    if (!persistorBase.hasTable(table())) {
+      LOG.info("Action: Table '{}' does not exist. Creating one with schema: {}", table(), schema);
+      persistorBase.createTable(table(), schema, referenceTableInfo.getTableName());
+    }
+    List<Object> values = getSqlValues();
+    values.add(referenceTableInfo.getMostRecentPrimaryKey());
+    persistorBase.insertRow(table(), getSqlValues());
+  }
+
+  public static class SQL_SCHEMA_CONSTANTS {
+    public static final String ACTION_NAME_COL_NAME = "action_name";
+    public static final String RESOURCE_TYPE_COL_NAME = "resource_type";
+    public static final String NODE_ID_COL_NAME = "node_id";
+    public static final String NODE_IP_COL_NAME = "node_ip";
+    public static final String ACTIONABLE_COL_NAME = "actionable";
+    public static final String COOL_OFF_PERIOD_COL_NAME = "cool_off_period";
+    public static final String CURRENT_VALUE_COL_NAME = "current_value";
+    public static final String DESIRED_VALUE_COL_NAME = "desired_value";
+    public static final String ADDITIONAL_JSON_COL_NAME = "additional_json";
+
+    /**
+     * SQL fields
+     */
+    public enum ActionField implements JooqFieldValue {
+      ACTION_NAME_FIELD(SQL_SCHEMA_CONSTANTS.ACTION_NAME_COL_NAME, String.class),
+      RESOURCE_TYPE_FIELD(SQL_SCHEMA_CONSTANTS.RESOURCE_TYPE_COL_NAME, Integer.class),
+      NODE_ID_FIELD(SQL_SCHEMA_CONSTANTS.NODE_ID_COL_NAME, String.class),
+      NODE_IP_FIELD(SQL_SCHEMA_CONSTANTS.NODE_IP_COL_NAME, String.class),
+      ACTIONABLE_FIELD(SQL_SCHEMA_CONSTANTS.ACTIONABLE_COL_NAME, Boolean.class),
+      COOL_OFF_PERIOD_FIELD(SQL_SCHEMA_CONSTANTS.COOL_OFF_PERIOD_COL_NAME, Long.class),
+      CURRENT_VALUE_FIELD(SQL_SCHEMA_CONSTANTS.CURRENT_VALUE_COL_NAME, Long.class),
+      DESIRED_VALUE_FIELD(SQL_SCHEMA_CONSTANTS.DESIRED_VALUE_COL_NAME, Long.class),
+      ADDITIONAL_JSON_FIELD(SQL_SCHEMA_CONSTANTS.ADDITIONAL_JSON_COL_NAME, String.class);
+
+      private String name;
+      private Class<?> clazz;
+
+      ActionField(final String name, Class<?> clazz) {
+        this.name = name;
+        this.clazz = clazz;
+      }
+
+      @Override
+      public Field<?> getField() {
+        return DSL.field(DSL.name(this.name), this.clazz);
+      }
+
+      @Override
+      public String getName() {
+        return this.name;
+      }
+    }
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/PublisherEvent.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/PublisherEvent.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.Consts.Table;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.PersistableAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.persist.JooqFieldValue;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.PersistableObject;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.PersistorBase;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.TableInfo;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jooq.Field;
+import org.jooq.impl.DSL;
+
+/**
+ * A persistable object that persists all actionable actions published by Publisher
+ * This object will be inserted as a tuple in "PublisherEvent" table. And any actionable actions will
+ * be persisted separately in Action table and linked to this tuple via foreign key.
+ * By joining one PublisherEvent with the Action table, we can map one decision(here it is PublisherEvent)
+ * to a list of actions that were received and published as a batch from Collator
+ *
+ * <p>Table name : PublisherEvent
+ *
+ * <p>schema :
+ * | ID(primary key) | timestamp | event_name | number_of_actions |
+ * |      1          | 123       | Publisher  |       5           |
+ */
+public class PublisherEvent implements PersistableObject {
+  private static final Logger LOG = LogManager.getLogger(PublisherEvent.class);
+  private final String eventName;
+  private final long timeStamp;
+  private final int numOfActions;
+  private final List<PersistableAction> actions;
+  private static final List<Field<?>> schema;
+
+  public PublisherEvent(String eventName, long timeStamp, List<PersistableAction> actions) {
+    this.eventName = eventName;
+    this.timeStamp = timeStamp;
+    this.numOfActions = actions == null ? 0 : actions.size();
+    this.actions = actions;
+  }
+
+  static {
+    List<Field<?>> fields = new ArrayList<>();
+    fields.add(PublisherEventField.TIMESTAMP_FIELD.getField());
+    fields.add(PublisherEventField.EVENT_FIELD.getField());
+    fields.add(PublisherEventField.NUM_OF_ACTIONS_FIELD.getField());
+    schema = Collections.unmodifiableList(fields);
+  }
+
+  public boolean isPersistable() {
+    return numOfActions != 0;
+  }
+
+  @Override
+  public String table() {
+    return Table.PUBLISHER_EVENT_TABLE;
+  }
+
+  @Override
+  public void write(PersistorBase persistorBase, TableInfo referenceTableInfo) throws SQLException {
+    if (!persistorBase.hasTable(table())) {
+      LOG.info("Action: Table '{}' does not exist. Creating one with schema: {}", table(), schema);
+      persistorBase.createTable(table(), schema);
+    }
+    int lastPrimaryKey = persistorBase.insertRow(table(), getSqlValues());
+    TableInfo tableInfo = new TableInfo(table(), lastPrimaryKey);
+    for (PersistableObject action : actions) {
+      action.write(persistorBase, tableInfo);
+    }
+  }
+
+  private List<Object> getSqlValues() {
+    List<Object> values = new ArrayList<>();
+    values.add(timeStamp);
+    values.add(eventName);
+    values.add(numOfActions);
+    return values;
+  }
+
+  public enum PublisherEventField implements JooqFieldValue {
+    TIMESTAMP_FIELD(SQL_SCHEMA_CONSTANTS.TIMESTAMP_COL_NAME, Long.class),
+    EVENT_FIELD(SQL_SCHEMA_CONSTANTS.EVENT_COL_NAME, String.class),
+    NUM_OF_ACTIONS_FIELD(SQL_SCHEMA_CONSTANTS.NUM_OF_ACTIONS_COL_NAME, String.class);
+
+    private String name;
+    private Class<?> clazz;
+    PublisherEventField(final String name, Class<?> clazz) {
+      this.name = name;
+      this.clazz = clazz;
+    }
+
+    @Override
+    public Field<?> getField() {
+      return DSL.field(DSL.name(this.name), this.clazz);
+    }
+
+    @Override
+    public String getName() {
+      return this.name;
+    }
+  }
+
+  public static class SQL_SCHEMA_CONSTANTS {
+
+    public static final String TIMESTAMP_COL_NAME = "timestamp";
+    public static final String EVENT_COL_NAME = "event_name";
+    public static final String NUM_OF_ACTIONS_COL_NAME = "number_of_actions";
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/PublisherEventFlowUnit.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/PublisherEventFlowUnit.java
@@ -1,0 +1,52 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.Consts.Table;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.PublisherEvent;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.GenericFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.PersistableObject;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.PersistorBase;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.TableInfo;
+import java.sql.SQLException;
+
+/**
+ * A flowunit that carries PublisherEvent to downstream. The purpose of creating this flowunit is
+ * to leverage the persistor in RCA framework to persist PublisherEvent and its nested actions.
+ * This is because only flowunit can be persisted into SQL in RCA framework.
+ */
+public class PublisherEventFlowUnit extends GenericFlowUnit implements PersistableObject {
+  private final PublisherEvent publisherEvent;
+
+  public PublisherEventFlowUnit(long timeStamp) {
+    this(timeStamp, null);
+  }
+
+  public PublisherEventFlowUnit(long timeStamp, PublisherEvent publisherEvent) {
+    super(timeStamp);
+    this.publisherEvent = publisherEvent;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return publisherEvent == null || (!publisherEvent.isPersistable());
+  }
+
+  @Override
+  public FlowUnitMessage buildFlowUnitMessage(String graphNode, InstanceDetails.Id esNode) {
+    throw new IllegalStateException(this.getClass().getSimpleName() + " not expected to be passed over wire");
+  }
+
+  @Override
+  public String table() {
+    return Table.PUBLISHER_EVENT_TABLE;
+  }
+
+  @Override
+  public void write(PersistorBase persistorBase, TableInfo referenceTableInfo) throws SQLException {
+    if (isEmpty()) {
+      return;
+    }
+    publisherEvent.write(persistorBase, referenceTableInfo);
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/ResourceFlowUnit.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/flow_units/ResourceFlowUnit.java
@@ -17,7 +17,6 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.ap
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.FlowUnitMessage;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.contexts.ResourceContext;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.temperature.CompactNodeTemperatureFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.persist.JooqFieldValue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.PersistableAction;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
 import com.google.common.annotations.VisibleForTesting;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistableObject.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PersistableObject.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence;
+
+import java.sql.SQLException;
+
+public interface PersistableObject {
+
+  /**
+   * return the SQL table that this object will be persisted into
+   * @return
+   */
+  String table();
+
+  /**
+   * write function to persist the object
+   * @param persistorBase the persistor
+   * @param referenceTableInfo the reference table that links to this object
+   * @throws SQLException SQL exception will be throw if fails to write into persistor
+   */
+  void write(PersistorBase persistorBase, TableInfo referenceTableInfo) throws SQLException;
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
@@ -91,7 +91,7 @@ class SQLitePersistor extends PersistorBase {
   }
 
   @Override
-  synchronized void createTable(String tableName, List<Field<?>> columns) throws SQLException {
+  public synchronized void createTable(String tableName, List<Field<?>> columns) throws SQLException {
     CreateTableConstraintStep constraintStep = create.createTable(tableName)
         //sqlite does not support identity. use plain sql string instead.
         .column(DSL.field(getPrimaryKeyColumnName(tableName) + PRIMARY_KEY_AUTOINCREMENT_POSTFIX))
@@ -118,8 +118,9 @@ class SQLitePersistor extends PersistorBase {
    * create table with foreign key
    */
   @Override
-  synchronized void createTable(String tableName, List<Field<?>> columns, String referenceTableName,
-                                String referenceTablePrimaryKeyFieldName) throws SQLException {
+  public synchronized void createTable(String tableName, List<Field<?>> columns, String referenceTableName)
+      throws SQLException {
+    String referenceTablePrimaryKeyFieldName = getPrimaryKeyColumnName(referenceTableName);
     Field foreignKeyField = DSL.field(referenceTablePrimaryKeyFieldName, Integer.class);
     columns.add(foreignKeyField);
 
@@ -150,7 +151,7 @@ class SQLitePersistor extends PersistorBase {
   }
 
   @Override
-  synchronized int insertRow(String tableName, List<Object> row) throws SQLException {
+  public synchronized int insertRow(String tableName, List<Object> row) throws SQLException {
     int lastPrimaryKey = -1;
     String sqlQuery = "SELECT " + LAST_INSERT_ROWID;
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/TableInfo.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/TableInfo.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence;
+
+public class TableInfo {
+  private String tableName;
+  private int mostRecentPrimaryKey;
+
+  public TableInfo(String tableName, int mostRecentPrimaryKey) {
+    this.tableName = tableName;
+    this.mostRecentPrimaryKey = mostRecentPrimaryKey;
+  }
+
+  public String getTableName() {
+    return tableName;
+  }
+
+  public int getMostRecentPrimaryKey() {
+    return mostRecentPrimaryKey;
+  }
+}


### PR DESCRIPTION
*Fixes #:*

*Description of changes:*
This PR allows us to persist Action into "Action" table in SQL. So we create a base class PersistableAction to store SQL schema/tuple and the method to persist tuple into the corresponding table and extend Modify*Action from the PersistableAction. 

Since a Decision made by decider can have multiple actions so we want to create a PersistEvent to keep the one-to-many relation into DB as well. So we create a separate table namely "PersistorEvent" to store decisions emit by collator and link actions in Action table to this element.

*Tests:*
UTs is still in progress  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
