### PR TITLE
Fix cache IT failure

### DIFF
--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/RcaItCacheTuning.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/RcaItCacheTuning.java
@@ -213,7 +213,10 @@ public class RcaItCacheTuning {
           reason = "Node Config Cache are expected to be missing in this integ test.")
   @AErrorPatternIgnored(
           pattern = "CacheUtil:getCacheMaxSize()",
-          reason = "Node Config Cache are are expected to be missing during startup.")
+          reason = "Node Config Cache is expected to be missing during startup.")
+  @AErrorPatternIgnored(
+          pattern = "ModifyCacheMaxSizeAction:build()",
+          reason = "Heap metrics is expected to be missing in this integ test.")
   public void testFieldDataCacheRca() {}
 
   // Test ShardRequestCacheClusterRca.
@@ -236,6 +239,9 @@ public class RcaItCacheTuning {
           reason = "Node config cache metrics are expected to be missing in this integ test.")
   @AErrorPatternIgnored(
           pattern = "CacheUtil:getCacheMaxSize()",
-          reason = "Node Config Cache are are expected to be missing during startup.")
+          reason = "Node Config Cache is expected to be missing during startup.")
+  @AErrorPatternIgnored(
+          pattern = "ModifyCacheMaxSizeAction:build()",
+          reason = "Heap metrics is expected to be missing in this integ test.")
   public void testShardRequestCacheRca() {}
 }


### PR DESCRIPTION
*Description of changes:*
Due to refactoring cache action, it throws IllegalArgumentException when heap metrics are not available.
This causes cache IT failure. 
Fix IT test to filter this error out.

*Tests:*
IT test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
