### PR TITLE
Move RcaConf into AppContext

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/AppContext.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/AppContext.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.collector.NodeConfigCache;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
@@ -41,11 +42,13 @@ public class AppContext {
   // to store node config settings from ES
   private final NodeConfigCache nodeConfigCache;
   private volatile Set<String> mutedActions;
+  private volatile RcaConf rcaConf;
 
   public AppContext() {
     this.clusterDetailsEventProcessor = null;
     this.nodeConfigCache = new NodeConfigCache();
     this.mutedActions = ImmutableSet.of();
+    this.rcaConf = null;
   }
 
   public AppContext(AppContext other) {
@@ -54,6 +57,7 @@ public class AppContext {
     // Initializing this as we don't want to copy the entire cache.
     this.nodeConfigCache = new NodeConfigCache();
     this.mutedActions = ImmutableSet.copyOf(other.getMutedActions());
+    this.rcaConf = other.rcaConf;
   }
 
   public void setClusterDetailsEventProcessor(final ClusterDetailsEventProcessor clusterDetailsEventProcessor) {
@@ -138,5 +142,17 @@ public class AppContext {
 
   public Set<String> getMutedActions() {
     return this.mutedActions;
+  }
+
+  /**
+   * thread-safe setter for RcaConf
+   * @param rcaConf RcaConf object
+   */
+  public void setRcaConf(RcaConf rcaConf) {
+    this.rcaConf = rcaConf;
+  }
+
+  public RcaConf getRcaConf() {
+    return rcaConf;
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/CacheHealthDecider.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/CacheHealthDecider.java
@@ -145,22 +145,12 @@ public class CacheHealthDecider extends Decider {
       final NodeKey esNode, final ResourceEnum cacheType, final boolean increase) {
     final ModifyCacheMaxSizeAction action =
         ModifyCacheMaxSizeAction
-            .newBuilder(esNode, cacheType, getAppContext(), getCacheUpperBound(cacheType))
+            .newBuilder(esNode, cacheType, getAppContext())
             .increase(increase)
             .build();
     if (action.isActionable()) {
       return action;
     }
     return null;
-  }
-
-  private double getCacheUpperBound(final ResourceEnum cacheType) {
-    if (cacheType.equals(ResourceEnum.FIELD_DATA_CACHE)) {
-      return getFieldDataCacheUpperBound();
-    } else if (cacheType.equals(ResourceEnum.SHARD_REQUEST_CACHE)) {
-      return getShardRequestCacheUpperBound();
-    }
-    throw new IllegalArgumentException(
-        String.format("Unable to get cache upper bound for cacheType=[%s]", cacheType.toString()));
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/Decider.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/Decider.java
@@ -112,14 +112,6 @@ public abstract class Decider extends NonLeafNode<Decision> {
     configObj = conf.getDeciderConfig();
   }
 
-  public double getFieldDataCacheUpperBound() {
-    return configObj != null ? configObj.getFieldDataCacheUpperBound() : getDefaultFieldDataCacheUpperBound();
-  }
-
-  public double getShardRequestCacheUpperBound() {
-    return configObj != null ? configObj.getShardRequestCacheUpperBound() : getDefaultShardRequestCacheUpperBound();
-  }
-
   public List<String> getWorkLoadPriority() {
     return configObj != null ? configObj.getWorkloadPriorityOrder() : getDefaultWorkloadPriority();
   }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyCacheMaxSizeActionTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyCacheMaxSizeActionTest.java
@@ -32,9 +32,12 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.act
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.Resource;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
 import com.google.common.collect.ImmutableSet;
+import java.nio.file.Paths;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,6 +52,9 @@ public class ModifyCacheMaxSizeActionTest {
   @Before
   public void setUp() {
     appContext = new AppContext();
+    String rcaConfPath = Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca.conf").toString();
+    RcaConf rcaConf = new RcaConf(rcaConfPath);
+    appContext.setRcaConf(rcaConf);
   }
 
   @Test
@@ -58,7 +64,7 @@ public class ModifyCacheMaxSizeActionTest {
         new NodeKey(new InstanceDetails.Id("node-1"), new InstanceDetails.Ip("1.2.3.4"));
     ModifyCacheMaxSizeAction.Builder builder =
         ModifyCacheMaxSizeAction.newBuilder(
-            node1, ResourceEnum.FIELD_DATA_CACHE, appContext, getDefaultFieldDataCacheUpperBound());
+            node1, ResourceEnum.FIELD_DATA_CACHE, appContext);
     ModifyCacheMaxSizeAction fieldDataCacheIncrease = builder.increase(true).build();
 
     assertTrue(
@@ -84,7 +90,7 @@ public class ModifyCacheMaxSizeActionTest {
         new NodeKey(new InstanceDetails.Id("node-1"), new InstanceDetails.Ip("1.2.3.4"));
     ModifyCacheMaxSizeAction.Builder builder =
         ModifyCacheMaxSizeAction.newBuilder(
-            node1, ResourceEnum.FIELD_DATA_CACHE, appContext, getDefaultFieldDataCacheUpperBound());
+            node1, ResourceEnum.FIELD_DATA_CACHE, appContext);
     ModifyCacheMaxSizeAction fieldDataCacheNoIncrease = builder.increase(false).build();
     assertEquals(
         fieldDataCacheNoIncrease.getDesiredCacheMaxSizeInBytes(),
@@ -108,7 +114,7 @@ public class ModifyCacheMaxSizeActionTest {
         new NodeKey(new InstanceDetails.Id("node-1"), new InstanceDetails.Ip("1.2.3.4"));
     ModifyCacheMaxSizeAction.Builder builder =
         ModifyCacheMaxSizeAction.newBuilder(
-            node1, ResourceEnum.FIELD_DATA_CACHE, appContext, getDefaultFieldDataCacheUpperBound());
+            node1, ResourceEnum.FIELD_DATA_CACHE, appContext);
     ModifyCacheMaxSizeAction fieldDataCacheIncrease = builder.increase(false).build();
     assertEquals(
         fieldDataCacheIncrease.getDesiredCacheMaxSizeInBytes(),
@@ -123,8 +129,7 @@ public class ModifyCacheMaxSizeActionTest {
         ModifyCacheMaxSizeAction.newBuilder(
             node1,
             ResourceEnum.SHARD_REQUEST_CACHE,
-            appContext,
-            getDefaultShardRequestCacheUpperBound());
+            appContext);
     ModifyCacheMaxSizeAction shardRequestCacheIncrease = builder.increase(true).build();
     assertEquals(
         shardRequestCacheIncrease.getDesiredCacheMaxSizeInBytes(),
@@ -140,7 +145,7 @@ public class ModifyCacheMaxSizeActionTest {
         new NodeKey(new InstanceDetails.Id("node-1"), new InstanceDetails.Ip("1.2.3.4"));
     ModifyCacheMaxSizeAction.Builder builder =
         ModifyCacheMaxSizeAction.newBuilder(
-            node1, ResourceEnum.FIELD_DATA_CACHE, appContext, getDefaultFieldDataCacheUpperBound());
+            node1, ResourceEnum.FIELD_DATA_CACHE, appContext);
     ModifyCacheMaxSizeAction modifyCacheSizeAction = builder.increase(true).build();
 
     appContext.updateMutedActions(ImmutableSet.of(modifyCacheSizeAction.name()));
@@ -155,7 +160,7 @@ public class ModifyCacheMaxSizeActionTest {
         new NodeKey(new InstanceDetails.Id("node-1"), new InstanceDetails.Ip("1.2.3.4"));
     ModifyCacheMaxSizeAction.Builder builder =
             ModifyCacheMaxSizeAction.newBuilder(
-                    node1, ResourceEnum.FIELD_DATA_CACHE, appContext, getDefaultFieldDataCacheUpperBound());
+                    node1, ResourceEnum.FIELD_DATA_CACHE, appContext);
     ModifyCacheMaxSizeAction fieldDataCacheNoAction = builder.increase(true).build();
     assertEquals(
             fieldDataCacheNoAction.getDesiredCacheMaxSizeInBytes(),
@@ -174,7 +179,7 @@ public class ModifyCacheMaxSizeActionTest {
         new NodeKey(new InstanceDetails.Id("node-1"), new InstanceDetails.Ip("1.2.3.4"));
     ModifyCacheMaxSizeAction.Builder builder =
         ModifyCacheMaxSizeAction.newBuilder(
-            node1, ResourceEnum.FIELD_DATA_CACHE, appContext, getDefaultFieldDataCacheUpperBound());
+            node1, ResourceEnum.FIELD_DATA_CACHE, appContext);
     ModifyCacheMaxSizeAction fieldDataCacheNoAction = builder.increase(true).build();
     assertEquals(
         fieldDataCacheNoAction.getDesiredCacheMaxSizeInBytes(),

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaControllerTest.java
@@ -60,6 +60,7 @@ public class RcaControllerTest {
   private String masterIP;
   private Thread controllerThread;
   private ThreadProvider threadProvider;
+  private AppContext appContext;
 
   @Before
   public void setUp() throws Exception {
@@ -82,7 +83,7 @@ public class RcaControllerTest {
                     "127.0.0.1",
                     false))
     );
-    AppContext appContext = new AppContext();
+    appContext = new AppContext();
     appContext.setClusterDetailsEventProcessor(clusterDetailsEventProcessor);
 
     clientServers = PerformanceAnalyzerApp.createClientServers(connectionManager, appContext);
@@ -137,9 +138,7 @@ public class RcaControllerTest {
     // since we are using 2 rca.conf files here for testing, 'rca_muted.conf' for testing Muted RCAs
     // and 'rca.conf' for remainging tests, use reflection to access the private rcaConf class variable.
     String rcaConfPath = Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca.conf").toString();
-    Field field = rcaController.getClass().getDeclaredField("rcaConf");
-    field.setAccessible(true);
-    field.set(rcaController, new RcaConf(rcaConfPath));
+    appContext.setRcaConf(new RcaConf(rcaConfPath));
 
     controllerThread =
         threadProvider.createThreadForRunnable(() -> rcaController.run(),
@@ -194,9 +193,7 @@ public class RcaControllerTest {
     readAndUpdateMutesRcas.setAccessible(true);
 
     String rcaConfPath = Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca_muted.conf").toString();
-    Field rcaConfField = rcaController.getClass().getDeclaredField("rcaConf");
-    rcaConfField.setAccessible(true);
-    rcaConfField.set(rcaController, new RcaConf(rcaConfPath));
+    appContext.setRcaConf(new RcaConf(rcaConfPath));
     updateConfFileForMutedRcas(rcaConfPath, Arrays.asList("CPU_Utilization", "Heap_AllocRate"));
 
     Field mutedGraphNodesField = Stats.class.getDeclaredField("mutedGraphNodes");

--- a/src/test/resources/rca/rca.conf
+++ b/src/test/resources/rca/rca.conf
@@ -82,8 +82,8 @@
     },
     // cache decider - Needs to be updated as per the performance test results
     "cache-bounds": {
-      "field-data-cache-upper-bound" : 10.4,
-      "shard-request-cache-upper-bound" : 10.05
+      "field-data-cache-upper-bound" : 0.4,
+      "shard-request-cache-upper-bound" : 0.05
     }
   }
 }


### PR DESCRIPTION
*Fixes #:*

*Description of changes:*
Move RcaConf into AppContext. The current rcaconf object can only be read from vertices in RCA graph. By moving this into AppContext, we can read it from any other places(action object etc.) 

*Tests:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
