### PR TITLE
Use absolute path for configFilePath

### DIFF
--- a/pa_bin/performance-analyzer-agent
+++ b/pa_bin/performance-analyzer-agent
@@ -24,11 +24,11 @@ else
 fi
 
 if ! echo $* | grep -E '(^-d |-d$| -d |--daemonize$|--daemonize )' > /dev/null; then
-    export JAVA_OPTS=-Des.path.home=$ES_HOME\ -Dlog4j.configurationFile=$ES_HOME/performance-analyzer-rca/pa_config/log4j2.xml\ -DconfigFilePath=pa_config/performance-analyzer.properties
+    export JAVA_OPTS=-Des.path.home=$ES_HOME\ -Dlog4j.configurationFile=$ES_HOME/performance-analyzer-rca/pa_config/log4j2.xml
     exec $ES_HOME/performance-analyzer-rca/bin/performance-analyzer-rca
 else
     echo 'Starting deamon'
-    export JAVA_OPTS=-Des.path.home=$ES_HOME\ -Dlog4j.configurationFile=$ES_HOME/performance-analyzer-rca/pa_config/log4j2.xml\ -DconfigFilePath=pa_config/performance-analyzer.properties
+    export JAVA_OPTS=-Des.path.home=$ES_HOME\ -Dlog4j.configurationFile=$ES_HOME/performance-analyzer-rca/pa_config/log4j2.xml
     exec $ES_HOME/performance-analyzer-rca/bin/performance-analyzer-rca &
 
     pid=$!

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerApp.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerApp.java
@@ -107,21 +107,26 @@ public class PerformanceAnalyzerApp {
         (MetricsConfiguration.CONFIG_MAP.get(StatsCollector.class).samplingInterval) / 2,
         TimeUnit.MILLISECONDS);
     PluginSettings settings = PluginSettings.instance();
-    StatsCollector.STATS_TYPE = "agent-stats-metadata";
-    METRIC_COLLECTOR_EXECUTOR.addScheduledMetricCollector(StatsCollector.instance());
-    StatsCollector.instance().addDefaultExceptionCode(StatExceptionCode.READER_RESTART_PROCESSING);
-    METRIC_COLLECTOR_EXECUTOR.setEnabled(true);
-    METRIC_COLLECTOR_EXECUTOR.start();
+    if (ConfigStatus.INSTANCE.haveValidConfig()) {
+      StatsCollector.STATS_TYPE = "agent-stats-metadata";
+      METRIC_COLLECTOR_EXECUTOR.addScheduledMetricCollector(StatsCollector.instance());
+      StatsCollector.instance()
+          .addDefaultExceptionCode(StatExceptionCode.READER_RESTART_PROCESSING);
+      METRIC_COLLECTOR_EXECUTOR.setEnabled(true);
+      METRIC_COLLECTOR_EXECUTOR.start();
 
-    final GRPCConnectionManager connectionManager = new GRPCConnectionManager(
-        settings.getHttpsEnabled());
-    final ClientServers clientServers = createClientServers(connectionManager, appContext);
-    startErrorHandlingThread(THREAD_PROVIDER, exceptionQueue);
+      final GRPCConnectionManager connectionManager =
+          new GRPCConnectionManager(settings.getHttpsEnabled());
+      final ClientServers clientServers = createClientServers(connectionManager, appContext);
+      startErrorHandlingThread(THREAD_PROVIDER, exceptionQueue);
 
-    startReaderThread(appContext, THREAD_PROVIDER);
-    startGrpcServerThread(clientServers.getNetServer(), THREAD_PROVIDER);
-    startWebServerThread(clientServers.getHttpServer(), THREAD_PROVIDER);
-    startRcaTopLevelThread(clientServers, connectionManager, appContext, THREAD_PROVIDER);
+      startReaderThread(appContext, THREAD_PROVIDER);
+      startGrpcServerThread(clientServers.getNetServer(), THREAD_PROVIDER);
+      startWebServerThread(clientServers.getHttpServer(), THREAD_PROVIDER);
+      startRcaTopLevelThread(clientServers, connectionManager, appContext, THREAD_PROVIDER);
+    } else {
+      LOG.error("Performance analyzer app stopped due to invalid config status.");
+    }
   }
 
   private static void startRcaTopLevelThread(final ClientServers clientServers,

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/PluginSettings.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/PluginSettings.java
@@ -34,7 +34,7 @@ public class PluginSettings {
   private static PluginSettings instance;
   public static final String CONFIG_FILES_PATH = "pa_config/";
   private static final String DEFAULT_CONFIG_FILE_PATH =
-      "pa_config/performance-analyzer.properties";
+      Util.PLUGIN_LOCATION + "pa_config/performance-analyzer.properties";
   private static final String METRICS_LOCATION_KEY = "metrics-location";
   private static final String METRICS_LOCATION_DEFAULT = "/dev/shm/performanceanalyzer/";
   private static final String DELETION_INTERVAL_KEY = "metrics-deletion-interval";
@@ -60,7 +60,7 @@ public class PluginSettings {
   private final String configFilePath;
 
   static {
-    Util.invokePrivilegedAndLogError(() -> createInstance());
+    Util.invokePrivilegedAndLogError(PluginSettings::createInstance);
   }
 
   public String getMetricsLocation() {
@@ -144,9 +144,10 @@ public class PluginSettings {
       loadMetricsDBFilesCleanupEnabled();
     } catch (ConfigFileException e) {
       LOG.error(
-          "Loading config file {} failed with error: {}. Using default values.",
+          "Loading config file {} failed with error: {}. Disabling plugin.",
           this.configFilePath,
           e.toString());
+      ConfigStatus.INSTANCE.setConfigurationInvalid();
     } catch (ConfigFatalException e) {
       LOG.error("Having issue to load all config items. Disabling plugin.", e);
       ConfigStatus.INSTANCE.setConfigurationInvalid();

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/SettingsHelper.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/SettingsHelper.java
@@ -15,17 +15,16 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.config;
 
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.core.Util;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
 public class SettingsHelper {
-  public static Properties getSettings(final String fileRelativePath) throws IOException {
+  public static Properties getSettings(final String fileAbsolutePath) throws IOException {
     Properties prop = new Properties();
 
-    try (InputStream input = new FileInputStream(Util.PLUGIN_LOCATION + fileRelativePath); ) {
+    try (InputStream input = new FileInputStream(fileAbsolutePath); ) {
       // load a properties file
       prop.load(input);
     }


### PR DESCRIPTION
*Description of changes:*
Use absolute path for configFilePath instead of relativePath. 
In case file does not exist, pa does not startup.

*Tests:*
Spun a docker and tested.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
