### PR TITLE
Improve WaitFor utility logic

### DIFF
--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopperTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/WireHopperTest.java
@@ -194,7 +194,7 @@ public class WireHopperTest {
         WaitFor.waitFor(() -> {
                 ImmutableSet<InstanceDetails.Id> subscribers = subscriptionManager.getSubscribersFor(node.name());
                 return subscribers.size() == 1 && subscribers.asList().get(0).toString().equals(LOCALHOST_INSTANCE);
-            }, 1, TimeUnit.SECONDS);
+            }, 10, TimeUnit.SECONDS);
         // Verify resilience to RejectedExecutionException
         clientExecutor.set(rejectingExecutor);
         uut.readFromWire(node);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/util/WaitFor.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/util/WaitFor.java
@@ -32,16 +32,17 @@ public class WaitFor {
     public static void waitFor(Callable<Boolean> task, long maxWait, TimeUnit unit, String message)
         throws Exception {
         long maxWaitMillis = TimeUnit.MILLISECONDS.convert(maxWait, unit);
-        Instant start = Instant.now();
-        while (!task.call() && maxWaitMillis >= 0) {
-            Instant finish = Instant.now();
-            maxWaitMillis -= Duration.between(start, finish).toMillis();
-            start = finish;
+        do {
+            Instant start = Instant.now();
+            if (task.call()) {
+                break;
+            }
+            maxWaitMillis -= Duration.between(start, Instant.now()).toMillis();
             // Wait for a fixed amount before calling the task again
-            Thread.sleep(500L);
-        }
+            Thread.sleep(100L);
+        } while (maxWaitMillis >= 0);
         // Check the task one last time before throwing an exception
-        if (!task.call() && maxWaitMillis < 0) {
+        if (!task.call()) {
             throw new TimeoutException(message);
         }
     }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/util/WaitFor.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/util/WaitFor.java
@@ -35,11 +35,11 @@ public class WaitFor {
         do {
             Instant start = Instant.now();
             if (task.call()) {
-                break;
+                return;
             }
-            maxWaitMillis -= Duration.between(start, Instant.now()).toMillis();
             // Wait for a fixed amount before calling the task again
             Thread.sleep(100L);
+            maxWaitMillis -= Duration.between(start, Instant.now()).toMillis();
         } while (maxWaitMillis >= 0);
         // Check the task one last time before throwing an exception
         if (!task.call()) {


### PR DESCRIPTION
*Fixes #:* N/A

*Description of changes:*
- WaitFor uses Instant.now() instead of System.currentTimeMillis() to
get a system independent time measurement
- WaitFor now has a fixed wait before retesting the provided callable.
It also checks the callable one final time before throwing an exception
- A 1s WaitFor() call in WireHopperTest has been increased to 10s

*Tests:* N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
