### PR TITLE
Refactoring the persistence layer to be able to persist any Java Object

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
@@ -20,9 +20,12 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.JsonElement;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jooq.Record;
 import org.jooq.Result;
 
@@ -49,12 +52,53 @@ public interface Persistable {
   JsonElement read(String rca);
 
   /**
+   * This API reads the latest row from the table corresponding to the Object.
+   * @param clz The Class whose Object is desired.
+   * @param <T> The generic type of the class
+   * @return An instantiated Object of the class with the fields populated with the data from the latest row in the table and other
+   *     referenced tables or null if the table does not exist yet.
+   * @throws NoSuchMethodException If the expected setter does not exist.
+   * @throws IllegalAccessException If the setter is not Public
+   * @throws InvocationTargetException If invoking the setter by reflection threw an exception.
+   * @throws InstantiationException Creating an Object of the class failed for some reason.
+   */
+  <T> @Nullable T read(Class<T> clz)
+      throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException;
+
+  /**
    * Write data to the database.
    *
    * @param node Node whose flow unit is persisted.
    * @param flowUnit The flow unit that is persisted.
    */
   <T extends ResourceFlowUnit> void write(Node<?> node, T flowUnit) throws SQLException, IOException;
+
+  /**
+   * This API helps us write any Java Object into the Database and it does not need to be a Graph node anymore.
+   * This is required because:
+   * - in future we would like to persist 'remediation Actions' and they are not necessarily
+   *    FlowUnits or Graph nodes.
+   * - This removes de-coupling of the persistence layer from the RCA runtime.
+   * Restrictions on the Object
+   * --------------------------
+   * The Object that can be persisted has certain restrictions:
+   * - The Fields of the class that are to be persisted should be annotated with '@ValueColumn' or '@RefColumn'.
+   *    A Field should be annotated as @ValueColumn if the field type is a Java primitive type or String type.
+   *    The accepted types are boolean, byte, char, short, int, long, float, and double and their Boxed counterparts.
+   *    A Column can be marked as @RefColumn if the class Field is an user defined Java Class or a collection of the same.
+   * - The annotated Fields should have a 'getter' and a 'setter'. getters are expected to be named as 'get' or 'is'
+   *     prepended to the _capitalized_ fieldName.
+   * - The annotated fields and the getter/setters should be declared in the Object and not in a Super class of it.
+   * @param object The Object that needs to be persisted.
+   * @param <T> The type of the Object.
+   * @throws SQLException This is thrown if the underlying DB throws an error.
+   * @throws IOException This is thrown in case the DB file rotation fails.
+   * @throws IllegalAccessException If the getters and setters of the fields to be persisted are not Public.
+   * @throws NoSuchMethodException If getter or setters don't exist with the expected naming convention.
+   * @throws InvocationTargetException Invoking the getter or setter throws an exception.
+   */
+  <T> void write(@NonNull T object) throws SQLException, IOException, IllegalAccessException, NoSuchMethodException,
+      InvocationTargetException;
 
   void close() throws SQLException;
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
@@ -28,6 +28,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jooq.Record;
 import org.jooq.Result;
+import org.jooq.exception.DataAccessException;
 
 public interface Persistable {
   /**
@@ -61,9 +62,10 @@ public interface Persistable {
    * @throws IllegalAccessException If the setter is not Public
    * @throws InvocationTargetException If invoking the setter by reflection threw an exception.
    * @throws InstantiationException Creating an Object of the class failed for some reason.
+   * @throws DataAccessException Thrown by the DB layer.
    */
   <T> @Nullable T read(Class<T> clz)
-      throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException;
+      throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException, DataAccessException;
 
   /**
    * Write data to the database.

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
@@ -87,7 +87,10 @@ public interface Persistable {
    *    The accepted types are boolean, byte, char, short, int, long, float, and double and their Boxed counterparts.
    *    A Column can be marked as @RefColumn if the class Field is an user defined Java Class or a collection of the same.
    * - The annotated Fields should have a 'getter' and a 'setter'. getters are expected to be named as 'get' or 'is'
-   *     prepended to the _capitalized_ fieldName.
+   *     prepended to the _capitalized_ fieldName. And the setters are expected to be named 'set' and the capitalized
+   *     field name. The type of the field should match the type of the getter's return type or the setter's argument
+   *     type. Remember, int and Integer are two different types. Therefore, if the field is of type 'int' and your
+   *     'getter' returns a value of type Integer, you will still get NoSuchMethodException.
    * - The annotated fields and the getter/setters should be declared in the Object and not in a Super class of it.
    * @param object The Object that needs to be persisted.
    * @param <T> The type of the Object.

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/RefColumn.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/RefColumn.java
@@ -1,0 +1,11 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface RefColumn {
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/ValueColumn.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/ValueColumn.java
@@ -1,0 +1,11 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ValueColumn {
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SqliteObjectPersistor.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SqliteObjectPersistor.java
@@ -179,9 +179,12 @@ public class SqliteObjectPersistor {
     sqlite.write(new NotPersistable());
   }
 
-  //@Test
+  @Test
   public void testCollectionOfPrimitives()
       throws IOException, SQLException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+    exceptionRule.expect(IllegalStateException.class);
+    exceptionRule.expectMessage("persisting Primitives or Strings as Parameterized Types is not supported");
+
     class CollectionOfPrimitives {
       @ValueColumn
       List<Integer> ll = new ArrayList<>();

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SqliteObjectPersistor.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SqliteObjectPersistor.java
@@ -1,0 +1,195 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.pck1.TestPersist;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SqliteObjectPersistor {
+  private Path testLocation = null;
+  private final String baseFilename = "rca.test.file";
+
+  @Before
+  public void init() throws IOException {
+    String cwd = System.getProperty("user.dir");
+    testLocation = Paths.get(cwd, "src", "test", "resources", "tmp", "file_rotate");
+    Files.createDirectories(testLocation);
+    FileUtils.cleanDirectory(testLocation.toFile());
+  }
+
+  @After
+  public void cleanup() throws IOException {
+    FileUtils.cleanDirectory(testLocation.toFile());
+  }
+
+  @Test
+  public void testWriteObject() throws Exception {
+    SQLitePersistor sqlite = new SQLitePersistor(
+        testLocation.toString(), baseFilename, String.valueOf(1), TimeUnit.SECONDS, 1);
+    Outer outer = new Outer();
+    sqlite.write(outer);
+
+    Outer outerOut = sqlite.read(Outer.class);
+
+    Assert.assertEquals(outer.x, outerOut.x);
+    Assert.assertEquals(outer.name, outerOut.name);
+    Assert.assertEquals(outer.bObj.x, outerOut.bObj.x, 0.01);
+  }
+
+  @Rule
+  public ExpectedException exceptionRule = ExpectedException.none();
+
+  @Test
+  public void persistTwoClassesWithSameName() throws Exception {
+    exceptionRule.expect(IllegalStateException.class);
+    exceptionRule.expectMessage("There is already a table in the Database with the same name");
+
+    TestPersist testPersist1 = new TestPersist();
+    com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.pck2.TestPersist testPersist2 =
+        new com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.pck2.TestPersist();
+
+    SQLitePersistor sqlite = new SQLitePersistor(
+        testLocation.toString(), baseFilename, String.valueOf(1), TimeUnit.SECONDS, 1);
+    sqlite.write(testPersist1);
+    sqlite.write(testPersist2);
+  }
+
+  static class Outer {
+    @ValueColumn
+    int x;
+
+    int y;
+
+    @ValueColumn
+    String name;
+
+    @RefColumn
+    B bObj;
+
+    @RefColumn
+    List<ITest> myList;
+
+    public Outer() {
+      this.x = 10;
+      this.y = 20;
+      this.name = "test-name";
+      this.bObj = new B();
+      this.myList = new ArrayList<>();
+      myList.add(new ITestImpl1());
+      myList.add(new ITestImpl1());
+      myList.add(new ITestImpl2());
+    }
+
+    public void setY(Integer y) {
+      this.y = y;
+    }
+
+    public void setBObj(B bObj) {
+      this.bObj = bObj;
+    }
+
+    public void setMyList(List<ITest> myList) {
+      this.myList = myList;
+    }
+
+    public int getX() {
+      return x;
+    }
+
+    public void setX(int x) {
+      this.x = x;
+    }
+
+    public int getY() {
+      return y;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public B getBObj() {
+      return bObj;
+    }
+
+    public List<ITest> getMyList() {
+      return myList;
+    }
+  }
+
+  static class B {
+    @ValueColumn
+    double x = 5.55;
+    int y = 7;
+
+    public B() {
+    }
+
+    public void setX(double x) {
+      this.x = x;
+    }
+
+    public void setY(Integer y) {
+      this.y = y;
+    }
+
+    public double getX() {
+      return x;
+    }
+
+    public int getY() {
+      return y;
+    }
+  }
+
+  interface ITest {
+
+  }
+
+  static class ITestImpl1 implements ITest {
+    @ValueColumn
+    boolean yes = true;
+
+    public void setYes(boolean yes) {
+      this.yes = yes;
+    }
+
+    public ITestImpl1() {
+    }
+
+    public boolean isYes() {
+      return yes;
+    }
+  }
+
+  static class ITestImpl2 implements ITest {
+    @ValueColumn
+    boolean no = false;
+
+    public ITestImpl2() {
+    }
+
+    public void setNo(boolean no) {
+      this.no = no;
+    }
+
+    public boolean isNo() {
+      return no;
+    }
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SqliteObjectPersistor.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SqliteObjectPersistor.java
@@ -39,14 +39,14 @@ public class SqliteObjectPersistor {
   public void testWriteObject() throws Exception {
     SQLitePersistor sqlite = new SQLitePersistor(
         testLocation.toString(), baseFilename, String.valueOf(1), TimeUnit.SECONDS, 1);
-    Outer outer = new Outer();
-    sqlite.write(outer);
+    PersistorTestExample persistorTestExample = new PersistorTestExample();
+    sqlite.write(persistorTestExample);
 
-    Outer outerOut = sqlite.read(Outer.class);
+    PersistorTestExample persistorTestExampleOut = sqlite.read(PersistorTestExample.class);
 
-    Assert.assertEquals(outer.x, outerOut.x);
-    Assert.assertEquals(outer.name, outerOut.name);
-    Assert.assertEquals(outer.bObj.x, outerOut.bObj.x, 0.01);
+    Assert.assertEquals(persistorTestExample.x, persistorTestExampleOut.x);
+    Assert.assertEquals(persistorTestExample.name, persistorTestExampleOut.name);
+    Assert.assertEquals(persistorTestExample.bObj.x, persistorTestExampleOut.bObj.x, 0.01);
   }
 
   /**
@@ -58,7 +58,7 @@ public class SqliteObjectPersistor {
       throws IOException, SQLException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
     SQLitePersistor sqlite = new SQLitePersistor(
         testLocation.toString(), baseFilename, String.valueOf(1), TimeUnit.SECONDS, 1);
-    Assert.assertNull(sqlite.read(Outer.class));
+    Assert.assertNull(sqlite.read(PersistorTestExample.class));
   }
 
   @Rule
@@ -173,13 +173,34 @@ public class SqliteObjectPersistor {
     class NotPersistable {
       int x;
     }
-    
+
     SQLitePersistor sqlite = new SQLitePersistor(
         testLocation.toString(), baseFilename, String.valueOf(1), TimeUnit.SECONDS, 1);
     sqlite.write(new NotPersistable());
   }
 
-  static class Outer {
+  //@Test
+  public void testCollectionOfPrimitives()
+      throws IOException, SQLException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+    class CollectionOfPrimitives {
+      @ValueColumn
+      List<Integer> ll = new ArrayList<>();
+
+      public List<Integer> getLl() {
+        return ll;
+      }
+
+      public void setLl(List<Integer> x) {
+        this.ll = x;
+      }
+    }
+
+    SQLitePersistor sqlite = new SQLitePersistor(
+        testLocation.toString(), baseFilename, String.valueOf(1), TimeUnit.SECONDS, 1);
+    sqlite.write(new CollectionOfPrimitives());
+  }
+
+  static class PersistorTestExample {
     @ValueColumn
     int x;
 
@@ -194,7 +215,7 @@ public class SqliteObjectPersistor {
     @RefColumn
     List<ITest> myList;
 
-    public Outer() {
+    public PersistorTestExample() {
       this.x = 10;
       this.y = 20;
       this.name = "test-name";

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/pck1/TestPersist.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/pck1/TestPersist.java
@@ -1,0 +1,20 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.pck1;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.ValueColumn;
+
+public class TestPersist {
+  @ValueColumn
+  int x;
+
+  public TestPersist() {
+    this.x = 1;
+  }
+
+  public int getX() {
+    return x;
+  }
+
+  public void setX(int x) {
+    x = x;
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/pck2/TestPersist.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/pck2/TestPersist.java
@@ -1,0 +1,16 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.pck2;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.ValueColumn;
+
+public class TestPersist {
+  @ValueColumn
+  int x;
+
+  public TestPersist() {
+    this.x = 2;
+  }
+
+  public int getX() {
+    return x;
+  }
+}


### PR DESCRIPTION
*Fixes #:* #399 

*Description of changes:*

The persistence layer takes care of durably storing the RCA results (and in future decisions from deciders) and providing them when asked for it. The layer also takes care of periodic file rotations and cleaning up old DB files.

Although, it wasn't intended, the _Persistence_ layer is tightly coupled with the _RCA graph_ today. If you look at the `write()` method in  `Persistable` interface, you will find this signature:
`<T extends ResourceFlowUnit> void write(Node<?> node, T flowUnit) throws SQLException, IOException;`

So the `Persistable` Object knows about the graph node. Therefore, in future as the remediation system evolves and we have components, that are not nodes in the RCA-Graph, we might still want to persist their outputs. But this interface can't do that.

Therefore, the goal is to make the methods of Persistable generic, so that it can persist any object given to it and be able to read out any object the caller asks for.


Say we have to persist this class:
```java

Outer.java
________________

class Outer {
  int x;
  int y;
  boolean z;
  String name;
  List<T> myList;
  B b_obj;
}
-------------------------------------------------------

A.java
_______

class B {
  int x;
  String y;
}
```

when the above code is annotated as:
```java

Outer.java
________________

// This will create a table named "Outer"
class Outer {
  @ValueColumn
  int x;

  @ValueColumn
  int y;
  // Its not annotated as column, therefore, it will not be persisted.
  boolean z;

  @ValueColumn
  String name;

  @RefColumn
  B b_obj;

  @RefColumn
  List<T> myList;

  // Add a column named x to Outer table. The value stored in the row for that column will be the value of x.
  int getX() { .. }
  void setX(int x) { .. }

  int getY() { .. }
  String getName() { .. }
  void setName(String name) { .. }

  // For all fields that are not [primitive types](https://docs.oracle.com/javase/6/docs/api/java/lang/Class.html#isPrimitive()), they will be persisted in their own tables as a new row. The auto-increment ID
for this row will be persisted as a value of the column named "__table__B", so that we have a link to the nested element/table from this table.
  B getBObj() {..}
  void setBObj(B b) {..}

// If the Column annotation exists for a collection type, then they will be written to a table of their own. 
// The name of the table is obtained by calling T.class.getSimpleName(). If all of them evaluates to the same 
// table name, then they get written to the same table as different rows. And the corresponding Outer table's
// column will have a string [<rowId1]>, <rowId2>].
// If `T.class.getSimpleName()` evaluates to different names, then they are linked back in Outer table as 
// different columns.
  List<T> getMyList() { .. }
  void setMyList(List<T> list) { .. }
}
-------------------------------------------------------

B.java
_______

class B {
  @ValueColumn
  int x;
  String y;

  int getX() { .. }
  void setX(int x) { .. }
}
```

this creates these set of tables:
Here assuming that

`getMyList()` returns a list of three elements where 

```java
for (T in getMyList) {
  // T.getClass().getSimpleName() returns `T` for two of the objects and `TT` for the third.
}
```

Table Outer
ID|X|Y|Name|__table__BObj|__table__T|__table__TT
--|--|-|------|--------------|----------------|---
53|1|2|name|34|[{"tableName":"ITestImpl2","rowIds":[1]},{"tableName":"ITestImpl1","rowIds":[1,2]}]|32

Table B
ID|X|
--|--|
34|23|

Table T
ID| col2| ..
---|-|--------
23|24|..
24|24|..

Table TT
ID| col2| ..
---|-|--------
32|24|..


### What this buys us

- The Java code resembles how the tables and nested tables will be laid out.
- Because the nested table can be obtained just by reading the column name, someone can write a tool to read the RCAs from the SQLite files. The won't need the java package to figure out the nesting.
- If new columns or nestings are added, they can also be added in the DB without schema mismatch. This is because, we create a new SQLite file on each restart of the RCA agent process (on top of periodic file rotations).
- The table name and column names are derived from the classname and getter name (methodName with `get` stripped out). This provides a 1-1 mapping from the persistor class and fields to the table name and column names. 
- Over and above, we are able to persist any Java Object.

*Tests:*
Added unit tests


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
