### PR TITLE
Change SubscribeResponseHandler#onError to log at WARN level

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/SubscribeResponseHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/net/SubscribeResponseHandler.java
@@ -105,7 +105,7 @@ public class SubscribeResponseHandler implements StreamObserver<SubscribeRespons
    */
   @Override
   public void onError(Throwable t) {
-    LOG.error("Encountered an error while processing subscription stream", t);
+    LOG.warn("Encountered an error while processing subscription stream", t);
   }
 
   /**


### PR DESCRIPTION
*Fixes #:* N/A

*Description of changes:*
- The Performance Analyzer IT Framework throws an exception if it sees
error logs. A unit test expressly calls
SubscribeResponseHandler#onError, which writes an error log. Therefore,
if this unit test runs before the RCA IT, we'll get an Exception for no
good reason. This commit changes the log level to WARN, which avoids
this behavior.

*Tests:* SubscribeResponseHandlerTest


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
