### PR TITLE
Fix a minor bug found in SQLitePersistor

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
@@ -315,7 +315,7 @@ class SQLitePersistor extends PersistorBase {
 
           // This gives the type of the setter parameter.
           Class<?> setterType = setter.getParameterTypes()[0];
-          int nestedRowId = (int)jooqField.getValue(record);
+          int nestedRowId = jooqField.cast(Integer.class).getValue(record);
 
           // Now that we have the Type of the parameter and the rowID specifying the data the object
           // is to be filled with; we call the read method recursively to create the referenced Object


### PR DESCRIPTION
*Fixes #:*

*Description of changes:*
Fix a minor bug found in SQLitePersistor. Some java compiler does not allow the use of unchecked casting and thus throws an error. 

*Tests:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
