### PR TITLE
Re enable config overrides test

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/RcaConf.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/RcaConf.java
@@ -243,7 +243,7 @@ public class RcaConf {
     return setting;
   }
 
-  public static boolean updateAllRcaConfFiles(final Set<String> mutedRcas, final Set<String> mutedDeciders,
+  public boolean updateAllRcaConfFiles(final Set<String> mutedRcas, final Set<String> mutedDeciders,
       final Set<String> mutedActions) {
     boolean updateStatus = true;
     // update all rca.conf files
@@ -260,7 +260,7 @@ public class RcaConf {
     return updateStatus;
   }
 
-  private static boolean updateRcaConf(String originalFilePath, final Set<String> mutedRcas,
+  private boolean updateRcaConf(String originalFilePath, final Set<String> mutedRcas,
       final Set<String> mutedDeciders, final Set<String> mutedActions) {
 
     String updatedPath = originalFilePath + ".updated";

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/overrides/ConfigOverridesApplierTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/overrides/ConfigOverridesApplierTest.java
@@ -35,13 +35,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 
-@Ignore
 public class ConfigOverridesApplierTest {
 
   private static final String RCA1 = "rca1";


### PR DESCRIPTION
*Fixes #:*
#422 

*Description of changes:*
This change makes the two methods: `updateAllRcaConfs` and `updateRcaConf` non static even though they don't mutate any state so that the unit tests for ConfigOverridesApplier can be enabled again.

While it is easy to refactor it out into a static helper, mocking static objects is currently not a simple fix in our codebase as PowerMockRunner is not ignoring log4j classes and is causing initialization issues for a lot of classes during unit testing(#426)

This is a simple fix for enabling the tests until #426 is resolved.

*Tests:*
`./gradlew build`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
