### PR TITLE
Read from sqlite in IT and add cache decider IT

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyCacheMaxSizeAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyCacheMaxSizeAction.java
@@ -29,7 +29,6 @@ import com.google.gson.JsonParser;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyCacheMaxSizeAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyCacheMaxSizeAction.java
@@ -21,11 +21,15 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.configs.CacheActionConfig;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.util.NodeConfigCacheReaderUtil;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -104,15 +108,30 @@ public class ModifyCacheMaxSizeAction extends SuppressibleAction {
 
   @Override
   public String summary() {
-    if (!isActionable()) {
-      return String.format("No action to take for: [%s]", NAME);
-    }
-    return String.format(
-        "Update [%s] capacity from [%d] to [%d] on node [%s]",
-        cacheType.toString(),
-        currentCacheMaxSizeInBytes,
-        desiredCacheMaxSizeInBytes,
-        esNode.getNodeId());
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("Id", esNode.getNodeId().toString());
+    jsonObject.addProperty("Ip", esNode.getHostAddress().toString());
+    jsonObject.addProperty("resource", cacheType.getNumber());
+    jsonObject.addProperty("desiredCacheMaxSizeInBytes", desiredCacheMaxSizeInBytes);
+    jsonObject.addProperty("currentCacheMaxSizeInBytes", currentCacheMaxSizeInBytes);
+    jsonObject.addProperty("coolOffPeriodInMillis", coolOffPeriodInMillis);
+    jsonObject.addProperty("canUpdate", canUpdate);
+    return jsonObject.toString();
+  }
+
+  // Generates action from summary. Passing in appContext because it contains dynamic settings
+  public static ModifyCacheMaxSizeAction fromSummary(String jsonRepr, AppContext appContext) {
+    final JsonObject jsonObject = JsonParser.parseString(jsonRepr).getAsJsonObject();
+    NodeKey esNode = new NodeKey(new InstanceDetails.Id(jsonObject.get("Id").getAsString()),
+            new InstanceDetails.Ip(jsonObject.get("Ip").getAsString()));
+    ResourceEnum cacheType = ResourceEnum.forNumber(jsonObject.get("resource").getAsInt());
+    long desiredCacheMaxSizeInBytes = jsonObject.get("desiredCacheMaxSizeInBytes").getAsLong();
+    long currentCacheMaxSizeInBytes = jsonObject.get("currentCacheMaxSizeInBytes").getAsLong();
+    long coolOffPeriodInMillis = jsonObject.get("coolOffPeriodInMillis").getAsLong();
+    boolean canUpdate = jsonObject.get("canUpdate").getAsBoolean();
+
+    return new ModifyCacheMaxSizeAction(esNode, cacheType, appContext,
+            desiredCacheMaxSizeInBytes, currentCacheMaxSizeInBytes, coolOffPeriodInMillis, canUpdate);
   }
 
   @Override

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyQueueCapacityAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyQueueCapacityAction.java
@@ -23,12 +23,16 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.configs.QueueActionConfig;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.util.NodeConfigCacheReaderUtil;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -92,11 +96,31 @@ public class ModifyQueueCapacityAction extends SuppressibleAction {
 
   @Override
   public String summary() {
-    if (!isActionable()) {
-      return String.format("No action to take for: [%s]", NAME);
-    }
-    return String.format("Update [%s] queue capacity from [%d] to [%d] on node [%s]",
-        threadPool.toString(), currentCapacity, desiredCapacity, esNode.getNodeId());
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("Id", esNode.getNodeId().toString());
+    jsonObject.addProperty("Ip", esNode.getHostAddress().toString());
+    jsonObject.addProperty("resource", threadPool.getNumber());
+    jsonObject.addProperty("desiredCapacity", desiredCapacity);
+    jsonObject.addProperty("currentCapacity", currentCapacity);
+    jsonObject.addProperty("coolOffPeriodInMillis", coolOffPeriodInMillis);
+    jsonObject.addProperty("canUpdate", canUpdate);
+    return jsonObject.toString();
+  }
+
+  // Generates action from summary. Passing in appContext because it contains dynamic settings
+  public static ModifyQueueCapacityAction fromSummary(String jsonRepr, AppContext appContext) {
+    final JsonObject jsonObject = JsonParser.parseString(jsonRepr).getAsJsonObject();
+
+    NodeKey esNode = new NodeKey(new InstanceDetails.Id(jsonObject.get("Id").getAsString()),
+            new InstanceDetails.Ip(jsonObject.get("Ip").getAsString()));
+    ResourceEnum threadPool = ResourceEnum.forNumber(jsonObject.get("resource").getAsInt());
+    int desiredCapacity = jsonObject.get("desiredCapacity").getAsInt();
+    int currentCapacity = jsonObject.get("currentCapacity").getAsInt();
+    long coolOffPeriodInMillis = jsonObject.get("coolOffPeriodInMillis").getAsLong();
+    boolean canUpdate = jsonObject.get("canUpdate").getAsBoolean();
+
+    return new ModifyQueueCapacityAction(esNode, threadPool, appContext,
+            desiredCapacity, currentCapacity, coolOffPeriodInMillis, canUpdate);
   }
 
   @Override

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyQueueCapacityAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyQueueCapacityAction.java
@@ -25,14 +25,12 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
-
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.util.NodeConfigCacheReaderUtil;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/Heap_Max.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/Heap_Max.java
@@ -19,6 +19,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetric
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
 
 public class Heap_Max extends Metric {
+  public static final String NAME = AllMetrics.HeapValue.HEAP_MAX.name();
+
   public Heap_Max(long evaluationIntervalSeconds) {
     super(AllMetrics.HeapValue.HEAP_MAX.name(), evaluationIntervalSeconds);
   }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyCacheMaxSizeActionTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyCacheMaxSizeActionTest.java
@@ -285,6 +285,21 @@ public class ModifyCacheMaxSizeActionTest {
         decreaseAction.getDesiredCacheMaxSizeInBytes(), 10);
   }
 
+  @Test
+  public void testSummary() {
+    NodeKey node1 = new NodeKey(new InstanceDetails.Id("node-1"), new InstanceDetails.Ip("1.2.3.4"));
+    populateNodeConfigCache();
+    ModifyCacheMaxSizeAction.Builder builder =
+            ModifyCacheMaxSizeAction.newBuilder(node1, ResourceEnum.FIELD_DATA_CACHE, appContext, rcaConf);
+    ModifyCacheMaxSizeAction modifyCacheMaxSizeAction = builder.increase(true).build();
+    String summary = modifyCacheMaxSizeAction.summary();
+
+    ModifyCacheMaxSizeAction objectFromSummary = ModifyCacheMaxSizeAction.fromSummary(summary, appContext);
+    assertEquals(modifyCacheMaxSizeAction.getCurrentCacheMaxSizeInBytes(), objectFromSummary.getCurrentCacheMaxSizeInBytes());
+    assertEquals(modifyCacheMaxSizeAction.getDesiredCacheMaxSizeInBytes(), objectFromSummary.getDesiredCacheMaxSizeInBytes());
+    assertEquals(modifyCacheMaxSizeAction.getCacheType(), objectFromSummary.getCacheType());
+  }
+
   private void assertNoImpact(NodeKey node, ModifyCacheMaxSizeAction modifyCacheSizeAction) {
     Map<Dimension, Impact> impact = modifyCacheSizeAction.impact().get(node).getImpact();
     assertEquals(Impact.NO_IMPACT, impact.get(HEAP));

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyQueueCapacityActionTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyQueueCapacityActionTest.java
@@ -209,6 +209,21 @@ public class ModifyQueueCapacityActionTest {
     assertFalse(modifyQueueCapacityAction.isActionable());
   }
 
+  @Test
+  public void testSummary() {
+    NodeKey node1 = new NodeKey(new InstanceDetails.Id("node-1"), new InstanceDetails.Ip("1.2.3.4"));
+    dummyCache.put(node1, ResourceUtil.WRITE_QUEUE_CAPACITY, 500);
+    ModifyQueueCapacityAction.Builder builder =
+            ModifyQueueCapacityAction.newBuilder(node1, ResourceEnum.WRITE_THREADPOOL, testAppContext, rcaConf);
+    ModifyQueueCapacityAction modifyQueueCapacityAction = builder.increase(true).build();
+    String summary = modifyQueueCapacityAction.summary();
+
+    ModifyQueueCapacityAction objectFromSummary = ModifyQueueCapacityAction.fromSummary(summary, testAppContext);
+    assertEquals(modifyQueueCapacityAction.getCurrentCapacity(), objectFromSummary.getCurrentCapacity());
+    assertEquals(modifyQueueCapacityAction.getDesiredCapacity(), objectFromSummary.getDesiredCapacity());
+    assertEquals(modifyQueueCapacityAction.getThreadPool(), objectFromSummary.getThreadPool());
+  }
+
   private void assertNoImpact(NodeKey node, ModifyQueueCapacityAction modifyQueueCapacityAction) {
     Map<Dimension, Impact> impact = modifyQueueCapacityAction.impact().get(node).getImpact();
     assertEquals(Impact.NO_IMPACT, impact.get(HEAP));

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/CacheHealthDeciderTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/CacheHealthDeciderTest.java
@@ -34,7 +34,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.clu
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.ShardRequestCacheClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
-
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import java.nio.file.Paths;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -185,12 +186,14 @@ public class CacheHealthDeciderTest {
       assertEquals(1, action.impactedNodes().size());
       String nodeId = action.impactedNodes().get(0).getNodeId().toString();
       String summary = action.summary();
-      if (summary.contains(ResourceEnum.FIELD_DATA_CACHE.toString())) {
+      JsonObject jsonObject = JsonParser.parseString(summary).getAsJsonObject();
+
+      if (jsonObject.get("resource").getAsInt() == ResourceEnum.FIELD_DATA_CACHE.getNumber()) {
         nodeActionCounter
             .computeIfAbsent(nodeId, k -> new HashMap<>())
             .merge(ResourceEnum.FIELD_DATA_CACHE, 1, Integer::sum);
       }
-      if (summary.contains(ResourceEnum.SHARD_REQUEST_CACHE.toString())) {
+      if (jsonObject.get("resource").getAsInt() == ResourceEnum.SHARD_REQUEST_CACHE.getNumber()) {
         nodeActionCounter
             .computeIfAbsent(nodeId, k -> new HashMap<>())
             .merge(ResourceEnum.SHARD_REQUEST_CACHE, 1, Integer::sum);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/QueueHealthDeciderTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/QueueHealthDeciderTest.java
@@ -35,6 +35,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.uti
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.QueueRejectionClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -121,10 +123,12 @@ public class QueueHealthDeciderTest {
       assertEquals(1, action.impactedNodes().size());
       String nodeId = action.impactedNodes().get(0).getNodeId().toString();
       String summary = action.summary();
-      if (summary.contains(ResourceEnum.WRITE_THREADPOOL.toString())) {
+      JsonObject jsonObject = JsonParser.parseString(summary).getAsJsonObject();
+
+      if (jsonObject.get("resource").getAsInt() == ResourceEnum.WRITE_THREADPOOL.getNumber()) {
         nodeActionCounter.computeIfAbsent(nodeId, k -> new HashMap<>()).merge(ResourceEnum.WRITE_THREADPOOL, 1, Integer::sum);
       }
-      if (summary.contains(ResourceEnum.SEARCH_THREADPOOL.toString())) {
+      if (jsonObject.get("resource").getAsInt() == ResourceEnum.SEARCH_THREADPOOL.getNumber()) {
         nodeActionCounter.computeIfAbsent(nodeId, k -> new HashMap<>()).merge(ResourceEnum.SEARCH_THREADPOOL, 1, Integer::sum);
       }
     }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Cluster.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Cluster.java
@@ -273,7 +273,7 @@ public class Cluster {
     return tagToHostMapping.get(hostTag).getDataForRca(rcaName);
   }
 
-  public <T> T constructObjectFromDBOnHost(HostTag hostTag, Class<T> className) {
+  public <T> Object constructObjectFromDBOnHost(HostTag hostTag, Class<T> className) throws Exception {
     return tagToHostMapping.get(hostTag).constructObjectFromDB(className);
   }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Cluster.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Cluster.java
@@ -273,6 +273,10 @@ public class Cluster {
     return tagToHostMapping.get(hostTag).getDataForRca(rcaName);
   }
 
+  public <T> T constructObjectFromDBOnHost(HostTag hostTag, Class<T> className) {
+    return tagToHostMapping.get(hostTag).constructObjectFromDB(className);
+  }
+
   public String getRcaRestResponse(final Map<String, String> params, HostTag hostByTag) {
     return verifyTag(hostByTag).makeRestRequest(params);
   }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Host.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Host.java
@@ -368,12 +368,8 @@ public class Host {
     return obj;
   }
 
-  public <T> T constructObjectFromDB(Class<T> className) {
-    try {
+  public <T> Object constructObjectFromDB(Class<T> className) throws Exception {
       return this.rcaController.getPersistenceProvider().read(className);
-    } catch (Exception e) {
-      return null;
-    }
   }
 
   public Map<String, Result<Record>> getRecordsForAllTables() {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Host.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Host.java
@@ -36,7 +36,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.threads.ThreadPro
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileWriter;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Host.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Host.java
@@ -368,6 +368,14 @@ public class Host {
     return obj;
   }
 
+  public <T> T constructObjectFromDB(Class<T> className) {
+    try {
+      return this.rcaController.getPersistenceProvider().read(className);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
   public Map<String, Result<Record>> getRecordsForAllTables() {
     return this.rcaController.getPersistenceProvider().getRecordsForAllTables();
   }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/annotations/AExpect.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/annotations/AExpect.java
@@ -54,7 +54,7 @@ public @interface AExpect {
    */
   enum Type {
     REST_API,
-    SQLITE
+    DB_QUERY
   }
 
   @Retention(RetentionPolicy.RUNTIME)

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/annotations/AExpect.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/annotations/AExpect.java
@@ -53,7 +53,8 @@ public @interface AExpect {
    * Currently supported places to look for RCA outputs are the SQLite file or by hitting the rest endpoint.
    */
   enum Type {
-    REST_API
+    REST_API,
+    SQLITE
   }
 
   @Retention(RetentionPolicy.RUNTIME)

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/api/IValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/api/IValidator.java
@@ -13,8 +13,20 @@ public interface IValidator {
   /**
    * Based on what is required to be validated,
    *
-   * @param response The REST response returns JSONElement and sqlite response returns the class type.
-   * @return true, if this matches expectation.
+   * @param response The REST response returns JSONElement.
+   * @return By default, return false. Implementations returns true, if this matches expectation.
    */
-  <T> boolean check(T response);
+  default boolean checkJsonResp(JsonElement response) {
+    return false;
+  }
+
+  /**
+   * Based on what is required to be validated,
+   *
+   * @param object On querying the db returns an object of the required class.
+   * @return By default, return false. Implementations returns true, if this matches expectation.
+   */
+  default boolean checkDbObj(Object object) {
+    return false;
+  }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/api/IValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/api/IValidator.java
@@ -13,7 +13,7 @@ public interface IValidator {
   /**
    * Based on what is required to be validated,
    *
-   * @param response The REST response returns JSONElement and sqlite response returns </T> (class type).
+   * @param response The REST response returns JSONElement and sqlite response returns the class type.
    * @return true, if this matches expectation.
    */
   <T> boolean check(T response);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/api/IValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/api/IValidator.java
@@ -1,8 +1,6 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.api;
 
 import com.google.gson.JsonElement;
-import org.jooq.Record;
-import org.jooq.Result;
 
 /**
  * This interface specifies a Validator that can used for validation of results. Based on what is required to be validated

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/api/IValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/api/IValidator.java
@@ -13,8 +13,8 @@ public interface IValidator {
   /**
    * Based on what is required to be validated,
    *
-   * @param response This REST response as a JSONElement.
+   * @param response The REST response returns JSONElement and sqlite response returns </T> (class type).
    * @return true, if this matches expectation.
    */
-  boolean check(JsonElement response);
+  <T> boolean check(T response);
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/api/TestApi.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/api/TestApi.java
@@ -31,6 +31,10 @@ public class TestApi {
     return cluster.getAllRcaDataOnHost(hostTag, rcaName);
   }
 
+  public <T> T constructObjectFromDBOnHost(HostTag hostTag, Class<T> clz) {
+    return cluster.constructObjectFromDBOnHost(hostTag, clz);
+  }
+
   /**
    * This let's you make a REST request to the REST endpoint of a particular host identified by
    * the host tag.

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/api/TestApi.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/api/TestApi.java
@@ -31,7 +31,7 @@ public class TestApi {
     return cluster.getAllRcaDataOnHost(hostTag, rcaName);
   }
 
-  public <T> T constructObjectFromDBOnHost(HostTag hostTag, Class<T> clz) {
+  public <T> Object constructObjectFromDBOnHost(HostTag hostTag, Class<T> clz) throws Exception {
     return cluster.constructObjectFromDBOnHost(hostTag, clz);
   }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/runners/RcaItRunnerBase.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/runners/RcaItRunnerBase.java
@@ -263,13 +263,15 @@ public abstract class RcaItRunnerBase extends Runner implements IRcaItRunner, Fi
           switch (what) {
             case REST_API:
               successful = validator.check(testApi.getRcaDataOnHost(expect.on(), rca.getSimpleName()));
-              if (!successful) {
-                failedValidations.add(validator.getClass());
-              }
+              break;
+            case SQLITE:
+              successful = validator.check(testApi.constructObjectFromDBOnHost(expect.on(), rca));
               break;
           }
           if (successful) {
             passedCount += 1;
+          } else {
+            failedValidations.add(validator.getClass());
           }
         }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/runners/RcaItRunnerBase.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/runners/RcaItRunnerBase.java
@@ -262,10 +262,16 @@ public abstract class RcaItRunnerBase extends Runner implements IRcaItRunner, Fi
 
           switch (what) {
             case REST_API:
-              successful = validator.check(testApi.getRcaDataOnHost(expect.on(), rca.getSimpleName()));
+              successful = validator.checkJsonResp(testApi.getRcaDataOnHost(expect.on(), rca.getSimpleName()));
               break;
-            case SQLITE:
-              successful = validator.check(testApi.constructObjectFromDBOnHost(expect.on(), rca));
+            case DB_QUERY:
+              try {
+                successful = validator.checkDbObj(testApi.constructObjectFromDBOnHost(expect.on(), rca));
+              } catch (Exception e) {
+                // if any exceptions occur on reading from the DB, we want to continue.
+                // exceptions might also mean the data is not yet available in the DB.
+                // successful will remain false.
+              }
               break;
           }
           if (successful) {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/CacheRcaITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/CacheRcaITest.java
@@ -15,8 +15,8 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning;
 
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.RcaItCacheTuning.INDEX_NAME;
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.RcaItCacheTuning.SHARD_ID;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.CacheRcaITest.INDEX_NAME;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.CacheRcaITest.SHARD_ID;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Eviction;
@@ -25,7 +25,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Eviction;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Hit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Size;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AClusterType;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AErrorPatternIgnored;
@@ -41,7 +40,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.fr
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.validator.FieldDataCacheValidator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.validator.ShardRequestCacheValidator;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.RcaItQueueTuning;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.ElasticSearchAnalysisGraph;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.FieldDataCacheClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.ShardRequestCacheClusterRca;
@@ -54,7 +52,7 @@ import org.junit.runner.RunWith;
 @AClusterType(ClusterType.MULTI_NODE_CO_LOCATED_MASTER)
 @ARcaGraph(ElasticSearchAnalysisGraph.class)
 //specify a custom rca.conf to set the collector time periods to 5s to reduce runtime
-@ARcaConf(dataNode = RcaItCacheTuning.CACHE_TUNING_RESOURCES_DIR + "rca.conf")
+@ARcaConf(dataNode = CacheRcaITest.CACHE_TUNING_RESOURCES_DIR + "rca.conf")
 @AMetric(
     name = Cache_FieldData_Size.class,
     dimensionNames = {
@@ -193,14 +191,13 @@ import org.junit.runner.RunWith;
                 sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
           })
     })
-public class RcaItCacheTuning {
+public class CacheRcaITest {
   public static final String CACHE_TUNING_RESOURCES_DIR = Consts.INTEG_TESTS_SRC_DIR + "./tests/cache_tuning/resource/";
   public static final String INDEX_NAME = "MockIndex";
   public static final String SHARD_ID = "1";
 
   // Test FieldDataCacheClusterRca.
   // This rca should be un-healthy when cache size is higher than threshold with evictions.
-  // TODO : extend this integ test to cover Decision Maker framework and queue remediation actions
   @Test
   @AExpect(
       what = AExpect.Type.REST_API,

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/Constants.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/Constants.java
@@ -1,0 +1,9 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.Consts;
+
+public class Constants {
+    public static final String CACHE_TUNING_RESOURCES_DIR = Consts.INTEG_TESTS_SRC_DIR + "./tests/cache_tuning/resource/";
+    public static final String INDEX_NAME = "MockIndex";
+    public static final String SHARD_ID = "1";
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/FieldDataCacheDeciderITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/FieldDataCacheDeciderITest.java
@@ -222,7 +222,7 @@ public class FieldDataCacheDeciderITest {
     // The cache decider should emit modify cache size action as field data rca is unhealthy.
     @Test
     @AExpect(
-            what = AExpect.Type.SQLITE,
+            what = AExpect.Type.DB_QUERY,
             on = HostTag.ELECTED_MASTER,
             validator = FieldDataCacheDeciderValidator.class,
             forRca = PersistedAction.class,

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/FieldDataCacheDeciderITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/FieldDataCacheDeciderITest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.FieldDataCacheDeciderITest.INDEX_NAME;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.FieldDataCacheDeciderITest.SHARD_ID;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Eviction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Size;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Max_Size;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Eviction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Hit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Size;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Max;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AErrorPatternIgnored;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AExpect;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AMetric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaGraph;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.Consts;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.validator.FieldDataCacheDeciderValidator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.ElasticSearchAnalysisGraph;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@Category(RcaItMarker.class)
+@RunWith(RcaItNotEncryptedRunner.class)
+@AClusterType(ClusterType.MULTI_NODE_CO_LOCATED_MASTER)
+@ARcaGraph(ElasticSearchAnalysisGraph.class)
+//specify a custom rca.conf to set the collector time periods to 5s to reduce runtime
+@ARcaConf(dataNode = FieldDataCacheDeciderITest.CACHE_TUNING_RESOURCES_DIR + "rca.conf")
+@AMetric(
+        name = Cache_FieldData_Size.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 8500.0, avg = 8500.0, min = 8500.0, max = 8500.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                        })
+        })
+@AMetric(
+        name = Cache_FieldData_Eviction.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        })
+        })
+@AMetric(
+        name = Cache_Request_Size.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 50.0, avg = 50.0, min = 50.0, max = 50.0),
+                        })
+        })
+@AMetric(
+        name = Cache_Request_Eviction.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        })
+        })
+@AMetric(
+        name = Cache_Request_Hit.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        })
+        })
+@AMetric(
+        name = Cache_Max_Size.class,
+        dimensionNames = {AllMetrics.CacheConfigDimension.Constants.TYPE_VALUE},
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0),
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0),
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
+                        })
+        })
+@AMetric(
+        name = Heap_Max.class,
+        dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0),
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0),
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
+                        })
+        })
+
+public class FieldDataCacheDeciderITest {
+    public static final String CACHE_TUNING_RESOURCES_DIR = Consts.INTEG_TESTS_SRC_DIR + "./tests/cache_tuning/resource/";
+    public static final String INDEX_NAME = "MockIndex";
+    public static final String SHARD_ID = "1";
+
+    // Test CacheDecider for ModifyCacheAction (field data cache).
+    // The cache decider should emit modify cache size action as field data rca is unhealthy.
+    @Test
+    @AExpect(
+            what = AExpect.Type.SQLITE,
+            on = HostTag.ELECTED_MASTER,
+            validator = FieldDataCacheDeciderValidator.class,
+            forRca = PersistedAction.class,
+            timeoutSeconds = 1000)
+    @AErrorPatternIgnored(
+            pattern = "AggregateMetric:gather()",
+            reason = "CPU metrics are expected to be missing in this integ test")
+    @AErrorPatternIgnored(
+            pattern = "Metric:gather()",
+            reason = "Metrics are expected to be missing in this integ test")
+    @AErrorPatternIgnored(
+            pattern = "NodeConfigCacheReaderUtil",
+            reason = "Node Config Cache are expected to be missing in this integ test.")
+    @AErrorPatternIgnored(
+            pattern = "CacheUtil:getCacheMaxSize()",
+            reason = "Node Config Cache is expected to be missing during startup.")
+    @AErrorPatternIgnored(
+            pattern = "SubscribeResponseHandler:onError()",
+            reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+    @AErrorPatternIgnored(
+            pattern = "SQLParsingUtil:readDataFromSqlResult()",
+            reason = "Old gen metrics is expected to be missing in this integ test.")
+    @AErrorPatternIgnored(
+            pattern = "HighHeapUsageOldGenRca:operate()",
+            reason = "Old gen rca is expected to be missing in this integ test.")
+    @AErrorPatternIgnored(
+            pattern = "ModifyCacheMaxSizeAction:build()",
+            reason = "Node Config Cache metrics is expected to be missing during startup")
+    public void testFieldDataCacheAction() {}
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/ShardRequestCacheDeciderITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/ShardRequestCacheDeciderITest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.ShardRequestCacheDeciderITest.INDEX_NAME;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.ShardRequestCacheDeciderITest.SHARD_ID;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Eviction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Size;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Max_Size;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Eviction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Hit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Size;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Max;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AErrorPatternIgnored;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AExpect;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AMetric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaGraph;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.Consts;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.validator.ShardRequestCacheDeciderValidator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.ElasticSearchAnalysisGraph;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@Category(RcaItMarker.class)
+@RunWith(RcaItNotEncryptedRunner.class)
+@AClusterType(ClusterType.MULTI_NODE_CO_LOCATED_MASTER)
+@ARcaGraph(ElasticSearchAnalysisGraph.class)
+//specify a custom rca.conf to set the collector time periods to 5s to reduce runtime
+@ARcaConf(dataNode = ShardRequestCacheDeciderITest.CACHE_TUNING_RESOURCES_DIR + "rca.conf")
+@AMetric(
+        name = Cache_FieldData_Size.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 8500.0, avg = 8500.0, min = 8500.0, max = 8500.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                        })
+        })
+@AMetric(
+        name = Cache_FieldData_Eviction.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        })
+        })
+@AMetric(
+        name = Cache_Request_Size.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 50.0, avg = 50.0, min = 50.0, max = 50.0),
+                        })
+        })
+@AMetric(
+        name = Cache_Request_Eviction.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        })
+        })
+@AMetric(
+        name = Cache_Request_Hit.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        })
+        })
+@AMetric(
+        name = Cache_Max_Size.class,
+        dimensionNames = {AllMetrics.CacheConfigDimension.Constants.TYPE_VALUE},
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0),
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0),
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
+                        })
+        })
+@AMetric(
+        name = Heap_Max.class,
+        dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0),
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0),
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
+                        })
+        })
+
+public class ShardRequestCacheDeciderITest {
+    public static final String CACHE_TUNING_RESOURCES_DIR = Consts.INTEG_TESTS_SRC_DIR + "./tests/cache_tuning/resource/";
+    public static final String INDEX_NAME = "MockIndex";
+    public static final String SHARD_ID = "1";
+
+    // Test CacheDecider for ModifyCacheAction (shard request cache).
+    // The cache decider should emit modify cache size action as shard request cache rca is unhealthy.
+    @Test
+    @AExpect(
+            what = AExpect.Type.SQLITE,
+            on = HostTag.ELECTED_MASTER,
+            validator = ShardRequestCacheDeciderValidator.class,
+            forRca = PersistedAction.class,
+            timeoutSeconds = 1000)
+    @AErrorPatternIgnored(
+            pattern = "AggregateMetric:gather()",
+            reason = "CPU metrics are expected to be missing in this integ test")
+    @AErrorPatternIgnored(
+            pattern = "Metric:gather()",
+            reason = "Metrics are expected to be missing in this integ test")
+    @AErrorPatternIgnored(
+            pattern = "NodeConfigCacheReaderUtil",
+            reason = "Node Config Cache are expected to be missing in this integ test.")
+    @AErrorPatternIgnored(
+            pattern = "CacheUtil:getCacheMaxSize()",
+            reason = "Node Config Cache is expected to be missing during startup.")
+    @AErrorPatternIgnored(
+            pattern = "SubscribeResponseHandler:onError()",
+            reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+    @AErrorPatternIgnored(
+            pattern = "SQLParsingUtil:readDataFromSqlResult()",
+            reason = "Old gen metrics is expected to be missing in this integ test.")
+    @AErrorPatternIgnored(
+            pattern = "HighHeapUsageOldGenRca:operate()",
+            reason = "Old gen rca is expected to be missing in this integ test.")
+    @AErrorPatternIgnored(
+            pattern = "ModifyCacheMaxSizeAction:build()",
+            reason = "Node Config Cache metrics is expected to be missing during startup")
+    public void testShardRequestCacheAction() {
+    }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/ShardRequestCacheDeciderITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/ShardRequestCacheDeciderITest.java
@@ -222,7 +222,7 @@ public class ShardRequestCacheDeciderITest {
     // The cache decider should emit modify cache size action as shard request cache rca is unhealthy.
     @Test
     @AExpect(
-            what = AExpect.Type.SQLITE,
+            what = AExpect.Type.DB_QUERY,
             on = HostTag.ELECTED_MASTER,
             validator = ShardRequestCacheDeciderValidator.class,
             forRca = PersistedAction.class,

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/dedicated_master/CacheRcaDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/dedicated_master/CacheRcaDedicatedMasterITest.java
@@ -70,14 +70,7 @@ import org.junit.runner.RunWith;
                                         sum = 8500.0, avg = 8500.0, min = 8500.0, max = 8500.0)
                         }),
                 @ATable(
-                        hostTag = {HostTag.STANDBY_MASTER_0},
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
-                        }),
-                @ATable(
-                        hostTag = {HostTag.STANDBY_MASTER_1},
+                        hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
@@ -99,14 +92,7 @@ import org.junit.runner.RunWith;
                                         sum = 1.0, avg = 1.0, min = 1.0, max = 1.0)
                         }),
                 @ATable(
-                        hostTag = {HostTag.STANDBY_MASTER_0},
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
-                        }),
-                @ATable(
-                        hostTag = {HostTag.STANDBY_MASTER_1},
+                        hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
@@ -128,14 +114,7 @@ import org.junit.runner.RunWith;
                                         sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
                         }),
                 @ATable(
-                        hostTag = {HostTag.STANDBY_MASTER_0},
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 50.0, avg = 50.0, min = 50.0, max = 50.0)
-                        }),
-                @ATable(
-                        hostTag = {HostTag.STANDBY_MASTER_0},
+                        hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
@@ -157,14 +136,7 @@ import org.junit.runner.RunWith;
                                         sum = 1.0, avg = 1.0, min = 1.0, max = 1.0)
                         }),
                 @ATable(
-                        hostTag = {HostTag.STANDBY_MASTER_0},
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
-                        }),
-                @ATable(
-                        hostTag = {HostTag.STANDBY_MASTER_0},
+                        hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
@@ -186,14 +158,7 @@ import org.junit.runner.RunWith;
                                         sum = 1.0, avg = 1.0, min = 1.0, max = 1.0)
                         }),
                 @ATable(
-                        hostTag = {HostTag.STANDBY_MASTER_0},
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
-                        }),
-                @ATable(
-                        hostTag = {HostTag.STANDBY_MASTER_1},
+                        hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
@@ -215,17 +180,7 @@ import org.junit.runner.RunWith;
                                         sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
                         }),
                 @ATable(
-                        hostTag = {HostTag.STANDBY_MASTER_0},
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
-                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0),
-                                @ATuple(
-                                        dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
-                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
-                        }),
-                @ATable(
-                        hostTag = {HostTag.STANDBY_MASTER_1},
+                        hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
@@ -286,7 +241,7 @@ public class CacheRcaDedicatedMasterITest {
             reason = "Node config cache metrics are expected to be missing in this integ test.")
     @AErrorPatternIgnored(
             pattern = "CacheUtil:getCacheMaxSize()",
-            reason = "Node Config Cache is expected to be missing during startup.")
+            reason = "Node Config Cache is expected to be missing during shutdown.")
     @AErrorPatternIgnored(
             pattern = "ModifyCacheMaxSizeAction:build()",
             reason = "Heap metrics is expected to be missing in this integ test.")

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/dedicated_master/CacheRcaDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/dedicated_master/CacheRcaDedicatedMasterITest.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.dedicated_master;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.CacheRcaMultiNodeITest.INDEX_NAME;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.CacheRcaMultiNodeITest.SHARD_ID;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Eviction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Size;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Max_Size;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Eviction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Hit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Size;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AErrorPatternIgnored;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AExpect;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AMetric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaGraph;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.Consts;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.validator.FieldDataCacheValidator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.validator.ShardRequestCacheValidator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.ElasticSearchAnalysisGraph;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.FieldDataCacheClusterRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.ShardRequestCacheClusterRca;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@Category(RcaItMarker.class)
+@RunWith(RcaItNotEncryptedRunner.class)
+@AClusterType(ClusterType.MULTI_NODE_DEDICATED_MASTER)
+@ARcaGraph(ElasticSearchAnalysisGraph.class)
+//specify a custom rca.conf to set the collector time periods to 5s to reduce runtime
+@ARcaConf(dataNode = CacheRcaDedicatedMasterITest.CACHE_TUNING_RESOURCES_DIR + "rca.conf")
+@AMetric(
+        name = Cache_FieldData_Size.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 8500.0, avg = 8500.0, min = 8500.0, max = 8500.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.STANDBY_MASTER_0},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.STANDBY_MASTER_1},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                        })
+        })
+@AMetric(
+        name = Cache_FieldData_Eviction.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.STANDBY_MASTER_0},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.STANDBY_MASTER_1},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        })
+        })
+@AMetric(
+        name = Cache_Request_Size.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.STANDBY_MASTER_0},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 50.0, avg = 50.0, min = 50.0, max = 50.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.STANDBY_MASTER_0},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 50.0, avg = 50.0, min = 50.0, max = 50.0),
+                        })
+        })
+@AMetric(
+        name = Cache_Request_Eviction.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.STANDBY_MASTER_0},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.STANDBY_MASTER_0},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        })
+        })
+@AMetric(
+        name = Cache_Request_Hit.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.STANDBY_MASTER_0},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.STANDBY_MASTER_1},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        })
+        })
+@AMetric(
+        name = Cache_Max_Size.class,
+        dimensionNames = {AllMetrics.CacheConfigDimension.Constants.TYPE_VALUE},
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0),
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
+                        }),
+                @ATable(
+                        hostTag = {HostTag.STANDBY_MASTER_0},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0),
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
+                        }),
+                @ATable(
+                        hostTag = {HostTag.STANDBY_MASTER_1},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0),
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
+                        })
+        })
+public class CacheRcaDedicatedMasterITest {
+    public static final String CACHE_TUNING_RESOURCES_DIR = Consts.INTEG_TESTS_SRC_DIR + "./tests/cache_tuning/resource/";
+    public static final String INDEX_NAME = "MockIndex";
+    public static final String SHARD_ID = "1";
+
+    // Test FieldDataCacheClusterRca.
+    // This rca should be un-healthy when cache size is higher than threshold with evictions.
+    @Test
+    @AExpect(
+            what = AExpect.Type.REST_API,
+            on = HostTag.ELECTED_MASTER,
+            validator = FieldDataCacheValidator.class,
+            forRca = FieldDataCacheClusterRca.class,
+            timeoutSeconds = 700)
+    @AErrorPatternIgnored(
+            pattern = "AggregateMetric:gather()",
+            reason = "CPU metrics are expected to be missing in this integ test")
+    @AErrorPatternIgnored(
+            pattern = "Metric:gather()",
+            reason = "Metrics are expected to be missing in this integ test")
+    @AErrorPatternIgnored(
+            pattern = "NodeConfigCacheReaderUtil",
+            reason = "Node Config Cache are expected to be missing in this integ test.")
+    @AErrorPatternIgnored(
+            pattern = "CacheUtil:getCacheMaxSize()",
+            reason = "Node Config Cache is expected to be missing during startup.")
+    @AErrorPatternIgnored(
+            pattern = "ModifyCacheMaxSizeAction:build()",
+            reason = "Heap metrics is expected to be missing in this integ test.")
+    @AErrorPatternIgnored(
+            pattern = "SubscribeResponseHandler:onError()",
+            reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+    public void testFieldDataCacheRca() {
+    }
+
+    // Test ShardRequestCacheClusterRca.
+    // This rca should be un-healthy when cache size is higher than threshold with evictions and hits.
+    @Test
+    @AExpect(
+            what = AExpect.Type.REST_API,
+            on = HostTag.ELECTED_MASTER,
+            validator = ShardRequestCacheValidator.class,
+            forRca = ShardRequestCacheClusterRca.class,
+            timeoutSeconds = 700)
+    @AErrorPatternIgnored(
+            pattern = "AggregateMetric:gather()",
+            reason = "CPU metrics are expected to be missing in this integ test")
+    @AErrorPatternIgnored(
+            pattern = "Metric:gather()",
+            reason = "Metrics are expected to be missing in this integ test")
+    @AErrorPatternIgnored(
+            pattern = "NodeConfigCacheReaderUtil",
+            reason = "Node config cache metrics are expected to be missing in this integ test.")
+    @AErrorPatternIgnored(
+            pattern = "CacheUtil:getCacheMaxSize()",
+            reason = "Node Config Cache is expected to be missing during startup.")
+    @AErrorPatternIgnored(
+            pattern = "ModifyCacheMaxSizeAction:build()",
+            reason = "Heap metrics is expected to be missing in this integ test.")
+    @AErrorPatternIgnored(
+            pattern = "SubscribeResponseHandler:onError()",
+            reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+    public void testShardRequestCacheRca() {
+    }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/dedicated_master/CacheRcaDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/dedicated_master/CacheRcaDedicatedMasterITest.java
@@ -15,8 +15,9 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.dedicated_master;
 
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.CacheRcaMultiNodeITest.INDEX_NAME;
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.CacheRcaMultiNodeITest.SHARD_ID;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.Constants.CACHE_TUNING_RESOURCES_DIR;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.Constants.INDEX_NAME;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.Constants.SHARD_ID;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Eviction;
@@ -38,6 +39,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.fr
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.Consts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.Constants;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.validator.FieldDataCacheValidator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.validator.ShardRequestCacheValidator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.ElasticSearchAnalysisGraph;
@@ -52,7 +54,7 @@ import org.junit.runner.RunWith;
 @AClusterType(ClusterType.MULTI_NODE_DEDICATED_MASTER)
 @ARcaGraph(ElasticSearchAnalysisGraph.class)
 //specify a custom rca.conf to set the collector time periods to 5s to reduce runtime
-@ARcaConf(dataNode = CacheRcaDedicatedMasterITest.CACHE_TUNING_RESOURCES_DIR + "rca.conf")
+@ARcaConf(dataNode = CACHE_TUNING_RESOURCES_DIR + "rca.conf")
 @AMetric(
         name = Cache_FieldData_Size.class,
         dimensionNames = {
@@ -65,21 +67,21 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 8500.0, avg = 8500.0, min = 8500.0, max = 8500.0),
+                                        sum = 8500.0, avg = 8500.0, min = 8500.0, max = 8500.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.STANDBY_MASTER_0},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.STANDBY_MASTER_1},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
                         })
         })
 @AMetric(
@@ -94,21 +96,21 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.STANDBY_MASTER_0},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.STANDBY_MASTER_1},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
                         })
         })
 @AMetric(
@@ -123,21 +125,21 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.STANDBY_MASTER_0},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 50.0, avg = 50.0, min = 50.0, max = 50.0),
+                                        sum = 50.0, avg = 50.0, min = 50.0, max = 50.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.STANDBY_MASTER_0},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 50.0, avg = 50.0, min = 50.0, max = 50.0),
+                                        sum = 50.0, avg = 50.0, min = 50.0, max = 50.0)
                         })
         })
 @AMetric(
@@ -152,21 +154,21 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.STANDBY_MASTER_0},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.STANDBY_MASTER_0},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
                         })
         })
 @AMetric(
@@ -181,21 +183,21 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.STANDBY_MASTER_0},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.STANDBY_MASTER_1},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
                         })
         })
 @AMetric(
@@ -234,10 +236,6 @@ import org.junit.runner.RunWith;
                         })
         })
 public class CacheRcaDedicatedMasterITest {
-    public static final String CACHE_TUNING_RESOURCES_DIR = Consts.INTEG_TESTS_SRC_DIR + "./tests/cache_tuning/resource/";
-    public static final String INDEX_NAME = "MockIndex";
-    public static final String SHARD_ID = "1";
-
     // Test FieldDataCacheClusterRca.
     // This rca should be un-healthy when cache size is higher than threshold with evictions.
     @Test

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/dedicated_master/FieldDataCacheDeciderDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/dedicated_master/FieldDataCacheDeciderDedicatedMasterITest.java
@@ -15,8 +15,9 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.dedicated_master;
 
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.FieldDataCacheDeciderMultiNodeITest.INDEX_NAME;
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.FieldDataCacheDeciderMultiNodeITest.SHARD_ID;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.Constants.CACHE_TUNING_RESOURCES_DIR;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.Constants.INDEX_NAME;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.Constants.SHARD_ID;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Eviction;
@@ -36,7 +37,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.fr
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.Consts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.validator.FieldDataCacheDeciderValidator;
@@ -51,7 +51,7 @@ import org.junit.runner.RunWith;
 @AClusterType(ClusterType.MULTI_NODE_CO_LOCATED_MASTER)
 @ARcaGraph(ElasticSearchAnalysisGraph.class)
 //specify a custom rca.conf to set the collector time periods to 5s to reduce runtime
-@ARcaConf(dataNode = FieldDataCacheDeciderDedicatedMasterITest.CACHE_TUNING_RESOURCES_DIR + "rca.conf")
+@ARcaConf(dataNode = CACHE_TUNING_RESOURCES_DIR + "rca.conf")
 @AMetric(
         name = Cache_FieldData_Size.class,
         dimensionNames = {
@@ -214,10 +214,6 @@ import org.junit.runner.RunWith;
         })
 
 public class FieldDataCacheDeciderDedicatedMasterITest {
-    public static final String CACHE_TUNING_RESOURCES_DIR = Consts.INTEG_TESTS_SRC_DIR + "./tests/cache_tuning/resource/";
-    public static final String INDEX_NAME = "MockIndex";
-    public static final String SHARD_ID = "1";
-
     // Test CacheDecider for ModifyCacheAction (field data cache).
     // The cache decider should emit modify cache size action as field data rca is unhealthy.
     @Test
@@ -245,5 +241,8 @@ public class FieldDataCacheDeciderDedicatedMasterITest {
     @AErrorPatternIgnored(
             pattern = "HighHeapUsageOldGenRca:operate()",
             reason = "Old gen rca is expected to be missing in this integ test.")
+    @AErrorPatternIgnored(
+            pattern = "ModifyCacheMaxSizeAction:build()",
+            reason = "Node config cache is expected to be missing during shutdown")
     public void testFieldDataCacheAction() {}
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/dedicated_master/FieldDataCacheDeciderDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/dedicated_master/FieldDataCacheDeciderDedicatedMasterITest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.dedicated_master;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.FieldDataCacheDeciderMultiNodeITest.INDEX_NAME;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.FieldDataCacheDeciderMultiNodeITest.SHARD_ID;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Eviction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Size;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Max_Size;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Eviction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Hit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Size;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Max;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AErrorPatternIgnored;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AExpect;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AMetric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaGraph;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.Consts;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.validator.FieldDataCacheDeciderValidator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.ElasticSearchAnalysisGraph;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@Category(RcaItMarker.class)
+@RunWith(RcaItNotEncryptedRunner.class)
+@AClusterType(ClusterType.MULTI_NODE_CO_LOCATED_MASTER)
+@ARcaGraph(ElasticSearchAnalysisGraph.class)
+//specify a custom rca.conf to set the collector time periods to 5s to reduce runtime
+@ARcaConf(dataNode = FieldDataCacheDeciderDedicatedMasterITest.CACHE_TUNING_RESOURCES_DIR + "rca.conf")
+@AMetric(
+        name = Cache_FieldData_Size.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 8500.0, avg = 8500.0, min = 8500.0, max = 8500.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                        })
+        })
+@AMetric(
+        name = Cache_FieldData_Eviction.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        })
+        })
+@AMetric(
+        name = Cache_Request_Size.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 50.0, avg = 50.0, min = 50.0, max = 50.0),
+                        })
+        })
+@AMetric(
+        name = Cache_Request_Eviction.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        })
+        })
+@AMetric(
+        name = Cache_Request_Hit.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        })
+        })
+@AMetric(
+        name = Cache_Max_Size.class,
+        dimensionNames = {AllMetrics.CacheConfigDimension.Constants.TYPE_VALUE},
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0),
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0),
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
+                        })
+        })
+@AMetric(
+        name = Heap_Max.class,
+        dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0),
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0),
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
+                        })
+        })
+
+public class FieldDataCacheDeciderDedicatedMasterITest {
+    public static final String CACHE_TUNING_RESOURCES_DIR = Consts.INTEG_TESTS_SRC_DIR + "./tests/cache_tuning/resource/";
+    public static final String INDEX_NAME = "MockIndex";
+    public static final String SHARD_ID = "1";
+
+    // Test CacheDecider for ModifyCacheAction (field data cache).
+    // The cache decider should emit modify cache size action as field data rca is unhealthy.
+    @Test
+    @AExpect(
+            what = AExpect.Type.DB_QUERY,
+            on = HostTag.ELECTED_MASTER,
+            validator = FieldDataCacheDeciderValidator.class,
+            forRca = PersistedAction.class,
+            timeoutSeconds = 1000)
+    @AErrorPatternIgnored(
+            pattern = "AggregateMetric:gather()",
+            reason = "CPU metrics are expected to be missing in this integ test")
+    @AErrorPatternIgnored(
+            pattern = "Metric:gather()",
+            reason = "Metrics are expected to be missing in this integ test")
+    @AErrorPatternIgnored(
+            pattern = "NodeConfigCacheReaderUtil",
+            reason = "Node Config Cache are expected to be missing in this integ test.")
+    @AErrorPatternIgnored(
+            pattern = "SubscribeResponseHandler:onError()",
+            reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+    @AErrorPatternIgnored(
+            pattern = "SQLParsingUtil:readDataFromSqlResult()",
+            reason = "Old gen metrics is expected to be missing in this integ test.")
+    @AErrorPatternIgnored(
+            pattern = "HighHeapUsageOldGenRca:operate()",
+            reason = "Old gen rca is expected to be missing in this integ test.")
+    public void testFieldDataCacheAction() {}
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/dedicated_master/FieldDataCacheDeciderDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/dedicated_master/FieldDataCacheDeciderDedicatedMasterITest.java
@@ -23,9 +23,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetric
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Eviction;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Size;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Max_Size;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Eviction;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Hit;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Size;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Max;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AClusterType;
@@ -64,14 +61,14 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 8500.0, avg = 8500.0, min = 8500.0, max = 8500.0),
+                                        sum = 8500.0, avg = 8500.0, min = 8500.0, max = 8500.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
                         })
         })
 @AMetric(
@@ -86,80 +83,14 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
-                        })
-        })
-@AMetric(
-        name = Cache_Request_Size.class,
-        dimensionNames = {
-                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
-                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
-        },
-        tables = {
-                @ATable(
-                        hostTag = HostTag.DATA_0,
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
-                        }),
-                @ATable(
-                        hostTag = {HostTag.ELECTED_MASTER},
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 50.0, avg = 50.0, min = 50.0, max = 50.0),
-                        })
-        })
-@AMetric(
-        name = Cache_Request_Eviction.class,
-        dimensionNames = {
-                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
-                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
-        },
-        tables = {
-                @ATable(
-                        hostTag = HostTag.DATA_0,
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
-                        }),
-                @ATable(
-                        hostTag = {HostTag.ELECTED_MASTER},
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
-                        })
-        })
-@AMetric(
-        name = Cache_Request_Hit.class,
-        dimensionNames = {
-                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
-                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
-        },
-        tables = {
-                @ATable(
-                        hostTag = HostTag.DATA_0,
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
-                        }),
-                @ATable(
-                        hostTag = {HostTag.ELECTED_MASTER},
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
                         })
         })
 @AMetric(
@@ -171,20 +102,14 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
-                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0),
-                                @ATuple(
-                                        dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
-                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
-                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0),
-                                @ATuple(
-                                        dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
-                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0)
                         })
         })
 @AMetric(
@@ -196,17 +121,11 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
-                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0),
-                                @ATuple(
-                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
                                         sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
-                                @ATuple(
-                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
-                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0),
                                 @ATuple(
                                         dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
                                         sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
@@ -244,5 +163,11 @@ public class FieldDataCacheDeciderDedicatedMasterITest {
     @AErrorPatternIgnored(
             pattern = "ModifyCacheMaxSizeAction:build()",
             reason = "Node config cache is expected to be missing during shutdown")
+    @AErrorPatternIgnored(
+            pattern = "NodeConfigCollector:collectAndPublishMetric()",
+            reason = "Shard request cache metrics is expected to be missing")
+    @AErrorPatternIgnored(
+            pattern = "CacheUtil:getCacheMaxSize()",
+            reason = "Shard request cache metrics is expected to be missing.")
     public void testFieldDataCacheAction() {}
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/dedicated_master/ShardRequestCacheDeciderDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/dedicated_master/ShardRequestCacheDeciderDedicatedMasterITest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.dedicated_master;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.ShardRequestCacheDeciderMultiNodeITest.INDEX_NAME;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.ShardRequestCacheDeciderMultiNodeITest.SHARD_ID;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Eviction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Size;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Max_Size;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Eviction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Hit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Size;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Max;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AErrorPatternIgnored;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AExpect;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AMetric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaGraph;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.Consts;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.validator.ShardRequestCacheDeciderValidator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.ElasticSearchAnalysisGraph;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@Category(RcaItMarker.class)
+@RunWith(RcaItNotEncryptedRunner.class)
+@AClusterType(ClusterType.MULTI_NODE_CO_LOCATED_MASTER)
+@ARcaGraph(ElasticSearchAnalysisGraph.class)
+//specify a custom rca.conf to set the collector time periods to 5s to reduce runtime
+@ARcaConf(dataNode = ShardRequestCacheDeciderDedicatedMasterITest.CACHE_TUNING_RESOURCES_DIR + "rca.conf")
+@AMetric(
+        name = Cache_FieldData_Size.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 8500.0, avg = 8500.0, min = 8500.0, max = 8500.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                        })
+        })
+@AMetric(
+        name = Cache_FieldData_Eviction.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        })
+        })
+@AMetric(
+        name = Cache_Request_Size.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 50.0, avg = 50.0, min = 50.0, max = 50.0),
+                        })
+        })
+@AMetric(
+        name = Cache_Request_Eviction.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        })
+        })
+@AMetric(
+        name = Cache_Request_Hit.class,
+        dimensionNames = {
+                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
+                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
+        },
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {INDEX_NAME, SHARD_ID},
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                        })
+        })
+@AMetric(
+        name = Cache_Max_Size.class,
+        dimensionNames = {AllMetrics.CacheConfigDimension.Constants.TYPE_VALUE},
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0),
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0),
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
+                        })
+        })
+@AMetric(
+        name = Heap_Max.class,
+        dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0),
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0),
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
+                        })
+        })
+
+public class ShardRequestCacheDeciderDedicatedMasterITest {
+    public static final String CACHE_TUNING_RESOURCES_DIR = Consts.INTEG_TESTS_SRC_DIR + "./tests/cache_tuning/resource/";
+    public static final String INDEX_NAME = "MockIndex";
+    public static final String SHARD_ID = "1";
+
+    // Test CacheDecider for ModifyCacheAction (shard request cache).
+    // The cache decider should emit modify cache size action as shard request cache rca is unhealthy.
+    @Test
+    @AExpect(
+            what = AExpect.Type.DB_QUERY,
+            on = HostTag.ELECTED_MASTER,
+            validator = ShardRequestCacheDeciderValidator.class,
+            forRca = PersistedAction.class,
+            timeoutSeconds = 1000)
+    @AErrorPatternIgnored(
+            pattern = "AggregateMetric:gather()",
+            reason = "CPU metrics are expected to be missing in this integ test")
+    @AErrorPatternIgnored(
+            pattern = "Metric:gather()",
+            reason = "Metrics are expected to be missing in this integ test")
+    @AErrorPatternIgnored(
+            pattern = "NodeConfigCacheReaderUtil",
+            reason = "Node Config Cache are expected to be missing in this integ test.")
+    @AErrorPatternIgnored(
+            pattern = "SubscribeResponseHandler:onError()",
+            reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+    @AErrorPatternIgnored(
+            pattern = "SQLParsingUtil:readDataFromSqlResult()",
+            reason = "Old gen metrics is expected to be missing in this integ test.")
+    @AErrorPatternIgnored(
+            pattern = "HighHeapUsageOldGenRca:operate()",
+            reason = "Old gen rca is expected to be missing in this integ test.")
+    public void testShardRequestCacheAction() {
+    }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/dedicated_master/ShardRequestCacheDeciderDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/dedicated_master/ShardRequestCacheDeciderDedicatedMasterITest.java
@@ -15,8 +15,9 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.dedicated_master;
 
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.ShardRequestCacheDeciderMultiNodeITest.INDEX_NAME;
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.ShardRequestCacheDeciderMultiNodeITest.SHARD_ID;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.Constants.CACHE_TUNING_RESOURCES_DIR;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.Constants.INDEX_NAME;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.Constants.SHARD_ID;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Eviction;
@@ -51,7 +52,7 @@ import org.junit.runner.RunWith;
 @AClusterType(ClusterType.MULTI_NODE_CO_LOCATED_MASTER)
 @ARcaGraph(ElasticSearchAnalysisGraph.class)
 //specify a custom rca.conf to set the collector time periods to 5s to reduce runtime
-@ARcaConf(dataNode = ShardRequestCacheDeciderDedicatedMasterITest.CACHE_TUNING_RESOURCES_DIR + "rca.conf")
+@ARcaConf(dataNode = CACHE_TUNING_RESOURCES_DIR + "rca.conf")
 @AMetric(
         name = Cache_FieldData_Size.class,
         dimensionNames = {
@@ -214,10 +215,6 @@ import org.junit.runner.RunWith;
         })
 
 public class ShardRequestCacheDeciderDedicatedMasterITest {
-    public static final String CACHE_TUNING_RESOURCES_DIR = Consts.INTEG_TESTS_SRC_DIR + "./tests/cache_tuning/resource/";
-    public static final String INDEX_NAME = "MockIndex";
-    public static final String SHARD_ID = "1";
-
     // Test CacheDecider for ModifyCacheAction (shard request cache).
     // The cache decider should emit modify cache size action as shard request cache rca is unhealthy.
     @Test
@@ -245,6 +242,9 @@ public class ShardRequestCacheDeciderDedicatedMasterITest {
     @AErrorPatternIgnored(
             pattern = "HighHeapUsageOldGenRca:operate()",
             reason = "Old gen rca is expected to be missing in this integ test.")
+    @AErrorPatternIgnored(
+            pattern = "ModifyCacheMaxSizeAction:build()",
+            reason = "Node config cache is expected to be missing during shutdown")
     public void testShardRequestCacheAction() {
     }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/dedicated_master/ShardRequestCacheDeciderDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/dedicated_master/ShardRequestCacheDeciderDedicatedMasterITest.java
@@ -20,8 +20,6 @@ import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integT
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.Constants.SHARD_ID;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Eviction;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Size;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Max_Size;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Eviction;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Hit;
@@ -37,7 +35,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.fr
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.Consts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.validator.ShardRequestCacheDeciderValidator;
@@ -54,50 +51,6 @@ import org.junit.runner.RunWith;
 //specify a custom rca.conf to set the collector time periods to 5s to reduce runtime
 @ARcaConf(dataNode = CACHE_TUNING_RESOURCES_DIR + "rca.conf")
 @AMetric(
-        name = Cache_FieldData_Size.class,
-        dimensionNames = {
-                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
-                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
-        },
-        tables = {
-                @ATable(
-                        hostTag = HostTag.DATA_0,
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 8500.0, avg = 8500.0, min = 8500.0, max = 8500.0),
-                        }),
-                @ATable(
-                        hostTag = {HostTag.ELECTED_MASTER},
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
-                        })
-        })
-@AMetric(
-        name = Cache_FieldData_Eviction.class,
-        dimensionNames = {
-                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
-                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
-        },
-        tables = {
-                @ATable(
-                        hostTag = HostTag.DATA_0,
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
-                        }),
-                @ATable(
-                        hostTag = {HostTag.ELECTED_MASTER},
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
-                        })
-        })
-@AMetric(
         name = Cache_Request_Size.class,
         dimensionNames = {
                 AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
@@ -109,14 +62,14 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 50.0, avg = 50.0, min = 50.0, max = 50.0),
+                                        sum = 50.0, avg = 50.0, min = 50.0, max = 50.0)
                         })
         })
 @AMetric(
@@ -131,14 +84,14 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
                         })
         })
 @AMetric(
@@ -153,14 +106,14 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
                         })
         })
 @AMetric(
@@ -171,18 +124,12 @@ import org.junit.runner.RunWith;
                         hostTag = HostTag.DATA_0,
                         tuple = {
                                 @ATuple(
-                                        dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
-                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0),
-                                @ATuple(
                                         dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
-                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
-                                @ATuple(
-                                        dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
-                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0),
                                 @ATuple(
                                         dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
                                         sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
@@ -197,17 +144,11 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
-                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0),
-                                @ATuple(
-                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
                                         sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
-                                @ATuple(
-                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
-                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0),
                                 @ATuple(
                                         dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
                                         sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
@@ -245,6 +186,12 @@ public class ShardRequestCacheDeciderDedicatedMasterITest {
     @AErrorPatternIgnored(
             pattern = "ModifyCacheMaxSizeAction:build()",
             reason = "Node config cache is expected to be missing during shutdown")
+    @AErrorPatternIgnored(
+            pattern = "NodeConfigCollector:collectAndPublishMetric()",
+            reason = "Field data cache metrics is expected to be missing")
+    @AErrorPatternIgnored(
+            pattern = "CacheUtil:getCacheMaxSize()",
+            reason = "Field data cache metrics is expected to be missing.")
     public void testShardRequestCacheAction() {
     }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/multi_node/CacheRcaMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/multi_node/CacheRcaMultiNodeITest.java
@@ -13,10 +13,10 @@
  *  permissions and limitations under the License.
  */
 
-package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning;
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node;
 
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.CacheRcaITest.INDEX_NAME;
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.CacheRcaITest.SHARD_ID;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.CacheRcaMultiNodeITest.INDEX_NAME;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.CacheRcaMultiNodeITest.SHARD_ID;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Eviction;
@@ -52,7 +52,7 @@ import org.junit.runner.RunWith;
 @AClusterType(ClusterType.MULTI_NODE_CO_LOCATED_MASTER)
 @ARcaGraph(ElasticSearchAnalysisGraph.class)
 //specify a custom rca.conf to set the collector time periods to 5s to reduce runtime
-@ARcaConf(dataNode = CacheRcaITest.CACHE_TUNING_RESOURCES_DIR + "rca.conf")
+@ARcaConf(dataNode = CacheRcaMultiNodeITest.CACHE_TUNING_RESOURCES_DIR + "rca.conf")
 @AMetric(
     name = Cache_FieldData_Size.class,
     dimensionNames = {
@@ -175,9 +175,6 @@ import org.junit.runner.RunWith;
                 sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0),
             @ATuple(
                 dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
-                sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
-            @ATuple(
-                dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
                 sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
           }),
       @ATable(
@@ -191,7 +188,7 @@ import org.junit.runner.RunWith;
                 sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
           })
     })
-public class CacheRcaITest {
+public class CacheRcaMultiNodeITest {
   public static final String CACHE_TUNING_RESOURCES_DIR = Consts.INTEG_TESTS_SRC_DIR + "./tests/cache_tuning/resource/";
   public static final String INDEX_NAME = "MockIndex";
   public static final String SHARD_ID = "1";

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/multi_node/CacheRcaMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/multi_node/CacheRcaMultiNodeITest.java
@@ -15,8 +15,9 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node;
 
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.CacheRcaMultiNodeITest.INDEX_NAME;
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.CacheRcaMultiNodeITest.SHARD_ID;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.Constants.CACHE_TUNING_RESOURCES_DIR;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.Constants.INDEX_NAME;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.Constants.SHARD_ID;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Eviction;
@@ -35,7 +36,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.fr
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.Consts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.validator.FieldDataCacheValidator;
@@ -52,7 +52,7 @@ import org.junit.runner.RunWith;
 @AClusterType(ClusterType.MULTI_NODE_CO_LOCATED_MASTER)
 @ARcaGraph(ElasticSearchAnalysisGraph.class)
 //specify a custom rca.conf to set the collector time periods to 5s to reduce runtime
-@ARcaConf(dataNode = CacheRcaMultiNodeITest.CACHE_TUNING_RESOURCES_DIR + "rca.conf")
+@ARcaConf(dataNode = CACHE_TUNING_RESOURCES_DIR + "rca.conf")
 @AMetric(
     name = Cache_FieldData_Size.class,
     dimensionNames = {
@@ -65,14 +65,14 @@ import org.junit.runner.RunWith;
           tuple = {
             @ATuple(
                 dimensionValues = {INDEX_NAME, SHARD_ID},
-                sum = 8500.0, avg = 8500.0, min = 8500.0, max = 8500.0),
+                sum = 8500.0, avg = 8500.0, min = 8500.0, max = 8500.0)
           }),
       @ATable(
           hostTag = {HostTag.ELECTED_MASTER},
           tuple = {
             @ATuple(
-                dimensionValues = {"Index1", "1"},
-                sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                dimensionValues = {INDEX_NAME, SHARD_ID},
+                sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
           })
     })
 @AMetric(
@@ -87,14 +87,14 @@ import org.junit.runner.RunWith;
           tuple = {
             @ATuple(
                 dimensionValues = {INDEX_NAME, SHARD_ID},
-                sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                sum = 1.0, avg = 1.0, min = 1.0, max = 1.0)
           }),
       @ATable(
           hostTag = {HostTag.ELECTED_MASTER},
           tuple = {
             @ATuple(
                 dimensionValues = {INDEX_NAME, SHARD_ID},
-                sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
           })
     })
 @AMetric(
@@ -109,14 +109,14 @@ import org.junit.runner.RunWith;
           tuple = {
             @ATuple(
                 dimensionValues = {INDEX_NAME, SHARD_ID},
-                sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
           }),
       @ATable(
           hostTag = {HostTag.ELECTED_MASTER},
           tuple = {
             @ATuple(
                 dimensionValues = {INDEX_NAME, SHARD_ID},
-                sum = 50.0, avg = 50.0, min = 50.0, max = 50.0),
+                sum = 50.0, avg = 50.0, min = 50.0, max = 50.0)
           })
     })
 @AMetric(
@@ -131,14 +131,14 @@ import org.junit.runner.RunWith;
           tuple = {
             @ATuple(
                 dimensionValues = {INDEX_NAME, SHARD_ID},
-                sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                sum = 1.0, avg = 1.0, min = 1.0, max = 1.0)
           }),
       @ATable(
           hostTag = {HostTag.ELECTED_MASTER},
           tuple = {
             @ATuple(
                 dimensionValues = {INDEX_NAME, SHARD_ID},
-                sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
           })
     })
 @AMetric(
@@ -153,14 +153,14 @@ import org.junit.runner.RunWith;
           tuple = {
             @ATuple(
                 dimensionValues = {INDEX_NAME, SHARD_ID},
-                sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                sum = 1.0, avg = 1.0, min = 1.0, max = 1.0)
           }),
       @ATable(
           hostTag = {HostTag.ELECTED_MASTER},
           tuple = {
             @ATuple(
                 dimensionValues = {INDEX_NAME, SHARD_ID},
-                sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
           })
     })
 @AMetric(
@@ -189,10 +189,6 @@ import org.junit.runner.RunWith;
           })
     })
 public class CacheRcaMultiNodeITest {
-  public static final String CACHE_TUNING_RESOURCES_DIR = Consts.INTEG_TESTS_SRC_DIR + "./tests/cache_tuning/resource/";
-  public static final String INDEX_NAME = "MockIndex";
-  public static final String SHARD_ID = "1";
-
   // Test FieldDataCacheClusterRca.
   // This rca should be un-healthy when cache size is higher than threshold with evictions.
   @Test

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/multi_node/FieldDataCacheDeciderMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/multi_node/FieldDataCacheDeciderMultiNodeITest.java
@@ -13,10 +13,10 @@
  *  permissions and limitations under the License.
  */
 
-package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning;
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node;
 
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.FieldDataCacheDeciderITest.INDEX_NAME;
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.FieldDataCacheDeciderITest.SHARD_ID;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.FieldDataCacheDeciderMultiNodeITest.INDEX_NAME;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.FieldDataCacheDeciderMultiNodeITest.SHARD_ID;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Eviction;
@@ -51,7 +51,7 @@ import org.junit.runner.RunWith;
 @AClusterType(ClusterType.MULTI_NODE_CO_LOCATED_MASTER)
 @ARcaGraph(ElasticSearchAnalysisGraph.class)
 //specify a custom rca.conf to set the collector time periods to 5s to reduce runtime
-@ARcaConf(dataNode = FieldDataCacheDeciderITest.CACHE_TUNING_RESOURCES_DIR + "rca.conf")
+@ARcaConf(dataNode = FieldDataCacheDeciderMultiNodeITest.CACHE_TUNING_RESOURCES_DIR + "rca.conf")
 @AMetric(
         name = Cache_FieldData_Size.class,
         dimensionNames = {
@@ -213,7 +213,7 @@ import org.junit.runner.RunWith;
                         })
         })
 
-public class FieldDataCacheDeciderITest {
+public class FieldDataCacheDeciderMultiNodeITest {
     public static final String CACHE_TUNING_RESOURCES_DIR = Consts.INTEG_TESTS_SRC_DIR + "./tests/cache_tuning/resource/";
     public static final String INDEX_NAME = "MockIndex";
     public static final String SHARD_ID = "1";
@@ -237,9 +237,6 @@ public class FieldDataCacheDeciderITest {
             pattern = "NodeConfigCacheReaderUtil",
             reason = "Node Config Cache are expected to be missing in this integ test.")
     @AErrorPatternIgnored(
-            pattern = "CacheUtil:getCacheMaxSize()",
-            reason = "Node Config Cache is expected to be missing during startup.")
-    @AErrorPatternIgnored(
             pattern = "SubscribeResponseHandler:onError()",
             reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
     @AErrorPatternIgnored(
@@ -248,8 +245,5 @@ public class FieldDataCacheDeciderITest {
     @AErrorPatternIgnored(
             pattern = "HighHeapUsageOldGenRca:operate()",
             reason = "Old gen rca is expected to be missing in this integ test.")
-    @AErrorPatternIgnored(
-            pattern = "ModifyCacheMaxSizeAction:build()",
-            reason = "Node Config Cache metrics is expected to be missing during startup")
     public void testFieldDataCacheAction() {}
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/multi_node/FieldDataCacheDeciderMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/multi_node/FieldDataCacheDeciderMultiNodeITest.java
@@ -15,8 +15,9 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node;
 
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.FieldDataCacheDeciderMultiNodeITest.INDEX_NAME;
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.FieldDataCacheDeciderMultiNodeITest.SHARD_ID;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.Constants.CACHE_TUNING_RESOURCES_DIR;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.Constants.INDEX_NAME;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.Constants.SHARD_ID;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Eviction;
@@ -36,7 +37,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.fr
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.Consts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.validator.FieldDataCacheDeciderValidator;
@@ -51,7 +51,7 @@ import org.junit.runner.RunWith;
 @AClusterType(ClusterType.MULTI_NODE_CO_LOCATED_MASTER)
 @ARcaGraph(ElasticSearchAnalysisGraph.class)
 //specify a custom rca.conf to set the collector time periods to 5s to reduce runtime
-@ARcaConf(dataNode = FieldDataCacheDeciderMultiNodeITest.CACHE_TUNING_RESOURCES_DIR + "rca.conf")
+@ARcaConf(dataNode = CACHE_TUNING_RESOURCES_DIR + "rca.conf")
 @AMetric(
         name = Cache_FieldData_Size.class,
         dimensionNames = {
@@ -64,14 +64,14 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 8500.0, avg = 8500.0, min = 8500.0, max = 8500.0),
+                                        sum = 8500.0, avg = 8500.0, min = 8500.0, max = 8500.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
                         })
         })
 @AMetric(
@@ -86,14 +86,14 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
                         })
         })
 @AMetric(
@@ -108,14 +108,14 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 50.0, avg = 50.0, min = 50.0, max = 50.0),
+                                        sum = 50.0, avg = 50.0, min = 50.0, max = 50.0)
                         })
         })
 @AMetric(
@@ -130,14 +130,14 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
                         })
         })
 @AMetric(
@@ -152,14 +152,14 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
                         })
         })
 @AMetric(
@@ -174,7 +174,7 @@ import org.junit.runner.RunWith;
                                         sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0),
                                 @ATuple(
                                         dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
-                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.ELECTED_MASTER},
@@ -196,9 +196,6 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
-                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0),
-                                @ATuple(
-                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
                                         sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
                         }),
                 @ATable(
@@ -206,18 +203,11 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
-                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0),
-                                @ATuple(
-                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
                                         sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
                         })
         })
 
 public class FieldDataCacheDeciderMultiNodeITest {
-    public static final String CACHE_TUNING_RESOURCES_DIR = Consts.INTEG_TESTS_SRC_DIR + "./tests/cache_tuning/resource/";
-    public static final String INDEX_NAME = "MockIndex";
-    public static final String SHARD_ID = "1";
-
     // Test CacheDecider for ModifyCacheAction (field data cache).
     // The cache decider should emit modify cache size action as field data rca is unhealthy.
     @Test
@@ -245,5 +235,8 @@ public class FieldDataCacheDeciderMultiNodeITest {
     @AErrorPatternIgnored(
             pattern = "HighHeapUsageOldGenRca:operate()",
             reason = "Old gen rca is expected to be missing in this integ test.")
+    @AErrorPatternIgnored(
+            pattern = "ModifyCacheMaxSizeAction:build()",
+            reason = "Node config cache is expected to be missing during shutdown")
     public void testFieldDataCacheAction() {}
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/multi_node/FieldDataCacheDeciderMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/multi_node/FieldDataCacheDeciderMultiNodeITest.java
@@ -23,9 +23,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetric
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Eviction;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Size;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Max_Size;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Eviction;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Hit;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Size;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Max;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AClusterType;
@@ -97,72 +94,6 @@ import org.junit.runner.RunWith;
                         })
         })
 @AMetric(
-        name = Cache_Request_Size.class,
-        dimensionNames = {
-                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
-                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
-        },
-        tables = {
-                @ATable(
-                        hostTag = HostTag.DATA_0,
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
-                        }),
-                @ATable(
-                        hostTag = {HostTag.ELECTED_MASTER},
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 50.0, avg = 50.0, min = 50.0, max = 50.0)
-                        })
-        })
-@AMetric(
-        name = Cache_Request_Eviction.class,
-        dimensionNames = {
-                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
-                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
-        },
-        tables = {
-                @ATable(
-                        hostTag = HostTag.DATA_0,
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
-                        }),
-                @ATable(
-                        hostTag = {HostTag.ELECTED_MASTER},
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
-                        })
-        })
-@AMetric(
-        name = Cache_Request_Hit.class,
-        dimensionNames = {
-                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
-                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
-        },
-        tables = {
-                @ATable(
-                        hostTag = HostTag.DATA_0,
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
-                        }),
-                @ATable(
-                        hostTag = {HostTag.ELECTED_MASTER},
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
-                        })
-        })
-@AMetric(
         name = Cache_Max_Size.class,
         dimensionNames = {AllMetrics.CacheConfigDimension.Constants.TYPE_VALUE},
         tables = {
@@ -171,20 +102,14 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
-                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0),
-                                @ATuple(
-                                        dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
-                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
-                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0),
-                                @ATuple(
-                                        dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
-                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0)
                         })
         })
 @AMetric(
@@ -238,5 +163,11 @@ public class FieldDataCacheDeciderMultiNodeITest {
     @AErrorPatternIgnored(
             pattern = "ModifyCacheMaxSizeAction:build()",
             reason = "Node config cache is expected to be missing during shutdown")
+    @AErrorPatternIgnored(
+            pattern = "NodeConfigCollector:collectAndPublishMetric()",
+            reason = "Shard request cache metrics is expected to be missing")
+    @AErrorPatternIgnored(
+            pattern = "CacheUtil:getCacheMaxSize()",
+            reason = "Shard request cache metrics is expected to be missing.")
     public void testFieldDataCacheAction() {}
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/multi_node/ShardRequestCacheDeciderMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/multi_node/ShardRequestCacheDeciderMultiNodeITest.java
@@ -20,8 +20,6 @@ import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integT
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.Constants.SHARD_ID;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Eviction;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Size;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Max_Size;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Eviction;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Hit;
@@ -37,7 +35,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.fr
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.Consts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.validator.ShardRequestCacheDeciderValidator;
@@ -54,50 +51,6 @@ import org.junit.runner.RunWith;
 //specify a custom rca.conf to set the collector time periods to 5s to reduce runtime
 @ARcaConf(dataNode = CACHE_TUNING_RESOURCES_DIR + "rca.conf")
 @AMetric(
-        name = Cache_FieldData_Size.class,
-        dimensionNames = {
-                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
-                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
-        },
-        tables = {
-                @ATable(
-                        hostTag = HostTag.DATA_0,
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 8500.0, avg = 8500.0, min = 8500.0, max = 8500.0),
-                        }),
-                @ATable(
-                        hostTag = {HostTag.ELECTED_MASTER},
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
-                        })
-        })
-@AMetric(
-        name = Cache_FieldData_Eviction.class,
-        dimensionNames = {
-                AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
-                AllMetrics.CommonDimension.Constants.SHARDID_VALUE
-        },
-        tables = {
-                @ATable(
-                        hostTag = HostTag.DATA_0,
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
-                        }),
-                @ATable(
-                        hostTag = {HostTag.ELECTED_MASTER},
-                        tuple = {
-                                @ATuple(
-                                        dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
-                        })
-        })
-@AMetric(
         name = Cache_Request_Size.class,
         dimensionNames = {
                 AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE,
@@ -109,14 +62,14 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 50.0, avg = 50.0, min = 50.0, max = 50.0),
+                                        sum = 50.0, avg = 50.0, min = 50.0, max = 50.0)
                         })
         })
 @AMetric(
@@ -131,14 +84,14 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
                         })
         })
 @AMetric(
@@ -153,14 +106,14 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                                        sum = 1.0, avg = 1.0, min = 1.0, max = 1.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {INDEX_NAME, SHARD_ID},
-                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
+                                        sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
                         })
         })
 @AMetric(
@@ -171,18 +124,12 @@ import org.junit.runner.RunWith;
                         hostTag = HostTag.DATA_0,
                         tuple = {
                                 @ATuple(
-                                        dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
-                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0),
-                                @ATuple(
                                         dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
-                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0),
+                                        sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
                         }),
                 @ATable(
                         hostTag = {HostTag.ELECTED_MASTER},
                         tuple = {
-                                @ATuple(
-                                        dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
-                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0),
                                 @ATuple(
                                         dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
                                         sum = 100.0, avg = 100.0, min = 100.0, max = 100.0)
@@ -239,6 +186,12 @@ public class ShardRequestCacheDeciderMultiNodeITest {
     @AErrorPatternIgnored(
             pattern = "ModifyCacheMaxSizeAction:build()",
             reason = "Node config cache is expected to be missing during shutdown")
+    @AErrorPatternIgnored(
+            pattern = "NodeConfigCollector:collectAndPublishMetric()",
+            reason = "Field data cache metrics is expected to be missing")
+    @AErrorPatternIgnored(
+            pattern = "CacheUtil:getCacheMaxSize()",
+            reason = "Field data cache metrics is expected to be missing.")
     public void testShardRequestCacheAction() {
     }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/multi_node/ShardRequestCacheDeciderMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/multi_node/ShardRequestCacheDeciderMultiNodeITest.java
@@ -15,8 +15,9 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node;
 
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.ShardRequestCacheDeciderMultiNodeITest.INDEX_NAME;
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.ShardRequestCacheDeciderMultiNodeITest.SHARD_ID;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.Constants.CACHE_TUNING_RESOURCES_DIR;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.Constants.INDEX_NAME;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.Constants.SHARD_ID;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Eviction;
@@ -51,7 +52,7 @@ import org.junit.runner.RunWith;
 @AClusterType(ClusterType.MULTI_NODE_CO_LOCATED_MASTER)
 @ARcaGraph(ElasticSearchAnalysisGraph.class)
 //specify a custom rca.conf to set the collector time periods to 5s to reduce runtime
-@ARcaConf(dataNode = ShardRequestCacheDeciderMultiNodeITest.CACHE_TUNING_RESOURCES_DIR + "rca.conf")
+@ARcaConf(dataNode = CACHE_TUNING_RESOURCES_DIR + "rca.conf")
 @AMetric(
         name = Cache_FieldData_Size.class,
         dimensionNames = {
@@ -196,9 +197,6 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
-                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0),
-                                @ATuple(
-                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
                                         sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
                         }),
                 @ATable(
@@ -206,18 +204,11 @@ import org.junit.runner.RunWith;
                         tuple = {
                                 @ATuple(
                                         dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
-                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0),
-                                @ATuple(
-                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
                                         sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
                         })
         })
 
 public class ShardRequestCacheDeciderMultiNodeITest {
-    public static final String CACHE_TUNING_RESOURCES_DIR = Consts.INTEG_TESTS_SRC_DIR + "./tests/cache_tuning/resource/";
-    public static final String INDEX_NAME = "MockIndex";
-    public static final String SHARD_ID = "1";
-
     // Test CacheDecider for ModifyCacheAction (shard request cache).
     // The cache decider should emit modify cache size action as shard request cache rca is unhealthy.
     @Test
@@ -245,6 +236,9 @@ public class ShardRequestCacheDeciderMultiNodeITest {
     @AErrorPatternIgnored(
             pattern = "HighHeapUsageOldGenRca:operate()",
             reason = "Old gen rca is expected to be missing in this integ test.")
+    @AErrorPatternIgnored(
+            pattern = "ModifyCacheMaxSizeAction:build()",
+            reason = "Node config cache is expected to be missing during shutdown")
     public void testShardRequestCacheAction() {
     }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/multi_node/ShardRequestCacheDeciderMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/multi_node/ShardRequestCacheDeciderMultiNodeITest.java
@@ -13,10 +13,10 @@
  *  permissions and limitations under the License.
  */
 
-package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning;
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node;
 
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.ShardRequestCacheDeciderITest.INDEX_NAME;
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.ShardRequestCacheDeciderITest.SHARD_ID;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.ShardRequestCacheDeciderMultiNodeITest.INDEX_NAME;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.ShardRequestCacheDeciderMultiNodeITest.SHARD_ID;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Eviction;
@@ -51,7 +51,7 @@ import org.junit.runner.RunWith;
 @AClusterType(ClusterType.MULTI_NODE_CO_LOCATED_MASTER)
 @ARcaGraph(ElasticSearchAnalysisGraph.class)
 //specify a custom rca.conf to set the collector time periods to 5s to reduce runtime
-@ARcaConf(dataNode = ShardRequestCacheDeciderITest.CACHE_TUNING_RESOURCES_DIR + "rca.conf")
+@ARcaConf(dataNode = ShardRequestCacheDeciderMultiNodeITest.CACHE_TUNING_RESOURCES_DIR + "rca.conf")
 @AMetric(
         name = Cache_FieldData_Size.class,
         dimensionNames = {
@@ -213,7 +213,7 @@ import org.junit.runner.RunWith;
                         })
         })
 
-public class ShardRequestCacheDeciderITest {
+public class ShardRequestCacheDeciderMultiNodeITest {
     public static final String CACHE_TUNING_RESOURCES_DIR = Consts.INTEG_TESTS_SRC_DIR + "./tests/cache_tuning/resource/";
     public static final String INDEX_NAME = "MockIndex";
     public static final String SHARD_ID = "1";
@@ -237,9 +237,6 @@ public class ShardRequestCacheDeciderITest {
             pattern = "NodeConfigCacheReaderUtil",
             reason = "Node Config Cache are expected to be missing in this integ test.")
     @AErrorPatternIgnored(
-            pattern = "CacheUtil:getCacheMaxSize()",
-            reason = "Node Config Cache is expected to be missing during startup.")
-    @AErrorPatternIgnored(
             pattern = "SubscribeResponseHandler:onError()",
             reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
     @AErrorPatternIgnored(
@@ -248,9 +245,6 @@ public class ShardRequestCacheDeciderITest {
     @AErrorPatternIgnored(
             pattern = "HighHeapUsageOldGenRca:operate()",
             reason = "Old gen rca is expected to be missing in this integ test.")
-    @AErrorPatternIgnored(
-            pattern = "ModifyCacheMaxSizeAction:build()",
-            reason = "Node Config Cache metrics is expected to be missing during startup")
     public void testShardRequestCacheAction() {
     }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/validator/FieldDataCacheDeciderValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/validator/FieldDataCacheDeciderValidator.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.validator;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ModifyCacheMaxSizeAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.api.IValidator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
+import org.junit.Assert;
+
+public class FieldDataCacheDeciderValidator implements IValidator {
+    long startTime;
+
+    public FieldDataCacheDeciderValidator() {
+        startTime = System.currentTimeMillis();
+    }
+
+    /**
+     * {"actionName":"ModifyCacheMaxSize",
+     * "resourceValue":10,
+     * "timestamp":"1599257910923",
+     * "nodeId":{node1},
+     * "nodeIp":{1.1.1.1},
+     * "actionable":1,
+     * "coolOffPeriod": 300000
+     * "muted": 1
+     * "summary": Update [FIELD_DATA_CACHE] capacity from [10000] to [100000] on node [DATA_0]
+     */
+    @Override
+    public <T> boolean check(T response) {
+        if (response == null) {
+            return false;
+        }
+        PersistedAction persistedAction = (PersistedAction) response;
+        return checkPersistedAction(persistedAction);
+    }
+
+    /**
+     * {"actionName":"ModifyCacheMaxSize",
+     * "resourceValue":10,
+     * "timestamp":"1599257910923",
+     * "nodeIds":{node1},
+     * "nodeIps":{1.1.1.1},
+     * "actionable":1,
+     * "coolOffPeriod": 300000
+     * "muted": 1
+     * "summary": Update [FIELD_DATA_CACHE] capacity from [10000] to [100000] on node [DATA_0]
+     *
+     */
+    private boolean checkPersistedAction(final PersistedAction persistedAction) {
+        Assert.assertEquals(ModifyCacheMaxSizeAction.NAME, persistedAction.getActionName());
+        Assert.assertEquals("{DATA_0}", persistedAction.getNodeIds());
+        Assert.assertEquals("{127.0.0.1}", persistedAction.getNodeIps());
+        Assert.assertEquals(300000, persistedAction.getCoolOffPeriod());
+        Assert.assertTrue(persistedAction.isActionable());
+        Assert.assertFalse(persistedAction.isMuted());
+        return true;
+    }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/validator/FieldDataCacheDeciderValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/validator/FieldDataCacheDeciderValidator.java
@@ -40,7 +40,8 @@ public class FieldDataCacheDeciderValidator implements IValidator {
      * "actionable":1,
      * "coolOffPeriod": 300000
      * "muted": 1
-     * "summary": Update [FIELD_DATA_CACHE] capacity from [10000] to [100000] on node [DATA_0]
+     * "summary": "Id":"DATA_0","Ip":"127.0.0.1","resource":10,"desiredCacheMaxSizeInBytes":100000,
+     *            "currentCacheMaxSizeInBytes":10000,"coolOffPeriodInMillis":300000,"canUpdate":true}
      */
     @Override
     public boolean checkDbObj(Object object) {
@@ -60,7 +61,8 @@ public class FieldDataCacheDeciderValidator implements IValidator {
      * "actionable":1,
      * "coolOffPeriod": 300000
      * "muted": 1
-     * "summary": Update [FIELD_DATA_CACHE] capacity from [10000] to [100000] on node [DATA_0]
+     * "summary": "Id":"DATA_0","Ip":"127.0.0.1","resource":10,"desiredCacheMaxSizeInBytes":100000,
+     *            "currentCacheMaxSizeInBytes":10000,"coolOffPeriodInMillis":300000,"canUpdate":true}
      *
      */
     private boolean checkPersistedAction(final PersistedAction persistedAction) {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/validator/FieldDataCacheDeciderValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/validator/FieldDataCacheDeciderValidator.java
@@ -39,11 +39,11 @@ public class FieldDataCacheDeciderValidator implements IValidator {
      * "summary": Update [FIELD_DATA_CACHE] capacity from [10000] to [100000] on node [DATA_0]
      */
     @Override
-    public <T> boolean check(T response) {
-        if (response == null) {
+    public boolean checkDbObj(Object object) {
+        if (object == null) {
             return false;
         }
-        PersistedAction persistedAction = (PersistedAction) response;
+        PersistedAction persistedAction = (PersistedAction) object;
         return checkPersistedAction(persistedAction);
     }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/validator/FieldDataCacheDeciderValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/validator/FieldDataCacheDeciderValidator.java
@@ -15,15 +15,19 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.validator;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ModifyCacheMaxSizeAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.api.IValidator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
 import org.junit.Assert;
 
 public class FieldDataCacheDeciderValidator implements IValidator {
+    AppContext appContext;
     long startTime;
 
     public FieldDataCacheDeciderValidator() {
+        appContext = new AppContext();
         startTime = System.currentTimeMillis();
     }
 
@@ -60,12 +64,17 @@ public class FieldDataCacheDeciderValidator implements IValidator {
      *
      */
     private boolean checkPersistedAction(final PersistedAction persistedAction) {
+        ModifyCacheMaxSizeAction modifyCacheMaxSizeAction =
+                ModifyCacheMaxSizeAction.fromSummary(persistedAction.getSummary(), appContext);
         Assert.assertEquals(ModifyCacheMaxSizeAction.NAME, persistedAction.getActionName());
         Assert.assertEquals("{DATA_0}", persistedAction.getNodeIds());
         Assert.assertEquals("{127.0.0.1}", persistedAction.getNodeIps());
         Assert.assertEquals(300000, persistedAction.getCoolOffPeriod());
         Assert.assertTrue(persistedAction.isActionable());
         Assert.assertFalse(persistedAction.isMuted());
+        Assert.assertEquals(ResourceEnum.FIELD_DATA_CACHE, modifyCacheMaxSizeAction.getCacheType());
+        Assert.assertEquals(10000, modifyCacheMaxSizeAction.getCurrentCacheMaxSizeInBytes());
+        Assert.assertEquals(100000, modifyCacheMaxSizeAction.getDesiredCacheMaxSizeInBytes());
         return true;
     }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/validator/FieldDataCacheValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/validator/FieldDataCacheValidator.java
@@ -49,7 +49,8 @@ public class FieldDataCacheValidator implements IValidator {
      * ]}
      */
     @Override
-    public boolean check(JsonElement response) {
+    public <T> boolean check(T responseObject) {
+        JsonElement response = (JsonElement) responseObject;
         JsonArray array = response.getAsJsonObject().get("data").getAsJsonArray();
         if (array.size() == 0) {
             return false;
@@ -70,7 +71,7 @@ public class FieldDataCacheValidator implements IValidator {
      *  "HotClusterSummary":[{"number_of_nodes":1,"number_of_unhealthy_nodes":1}]
      * }
      */
-    boolean checkClusterRca(final JsonObject rcaObject) {
+    private boolean checkClusterRca(final JsonObject rcaObject) {
         if (!"unhealthy".equals(rcaObject.get("state").getAsString())) {
             return false;
         }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/validator/FieldDataCacheValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/validator/FieldDataCacheValidator.java
@@ -49,8 +49,7 @@ public class FieldDataCacheValidator implements IValidator {
      * ]}
      */
     @Override
-    public <T> boolean check(T responseObject) {
-        JsonElement response = (JsonElement) responseObject;
+    public boolean checkJsonResp(JsonElement response) {
         JsonArray array = response.getAsJsonObject().get("data").getAsJsonArray();
         if (array.size() == 0) {
             return false;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/validator/ShardRequestCacheDeciderValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/validator/ShardRequestCacheDeciderValidator.java
@@ -39,11 +39,11 @@ public class ShardRequestCacheDeciderValidator implements IValidator {
      * "summary": Update [SHARD_REQUEST_CACHE] capacity from [10000] to [100000] on node [DATA_0]
      */
     @Override
-    public <T> boolean check(T response) {
-        if (response == null) {
+    public boolean checkDbObj(Object object) {
+        if (object == null) {
             return false;
         }
-        PersistedAction persistedAction = (PersistedAction) response;
+        PersistedAction persistedAction = (PersistedAction) object;
         return checkPersistedAction(persistedAction);
     }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/validator/ShardRequestCacheDeciderValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/validator/ShardRequestCacheDeciderValidator.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.validator;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ModifyCacheMaxSizeAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.api.IValidator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
+import org.junit.Assert;
+
+public class ShardRequestCacheDeciderValidator implements IValidator {
+    long startTime;
+
+    public ShardRequestCacheDeciderValidator() {
+        startTime = System.currentTimeMillis();
+    }
+
+    /**
+     * {"actionName":"ModifyCacheMaxSize",
+     * "resourceValue":11,
+     * "timestamp":"1599257910923",
+     * "nodeId":"node1",
+     * "nodeIp":1.1.1.1,
+     * "actionable":1,
+     * "coolOffPeriod": 300000,
+     * "muted": 1,
+     * "summary": Update [SHARD_REQUEST_CACHE] capacity from [10000] to [100000] on node [DATA_0]
+     */
+    @Override
+    public <T> boolean check(T response) {
+        if (response == null) {
+            return false;
+        }
+        PersistedAction persistedAction = (PersistedAction) response;
+        return checkPersistedAction(persistedAction);
+    }
+
+    /**
+     * {"actionName":"ModifyCacheMaxSize",
+     * "resourceValue":11,
+     * "timestamp":"1599257910923",
+     * "nodeId":"node1",
+     * "nodeIp":1.1.1.1,
+     * "actionable":1,
+     * "coolOffPeriod": 300000,
+     * "muted": 1
+     * "summary": Update [SHARD_REQUEST_CACHE] capacity from [10000] to [100000] on node [DATA_0]
+     */
+    private boolean checkPersistedAction(final PersistedAction persistedAction) {
+        Assert.assertEquals(ModifyCacheMaxSizeAction.NAME, persistedAction.getActionName());
+        Assert.assertEquals("{DATA_0}", persistedAction.getNodeIds());
+        Assert.assertEquals("{127.0.0.1}", persistedAction.getNodeIps());
+        Assert.assertEquals(300000, persistedAction.getCoolOffPeriod());
+        Assert.assertTrue(persistedAction.isActionable());
+        Assert.assertFalse(persistedAction.isMuted());
+        return true;
+    }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/validator/ShardRequestCacheValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/validator/ShardRequestCacheValidator.java
@@ -47,7 +47,8 @@ public class ShardRequestCacheValidator implements IValidator {
      * ]}
      */
     @Override
-    public boolean check(JsonElement response) {
+    public <T> boolean check(T responseObject) {
+        JsonElement response = (JsonElement) responseObject;
         JsonArray array = response.getAsJsonObject().get("data").getAsJsonArray();
         if (array.size() == 0) {
             return false;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/validator/ShardRequestCacheValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/validator/ShardRequestCacheValidator.java
@@ -47,8 +47,7 @@ public class ShardRequestCacheValidator implements IValidator {
      * ]}
      */
     @Override
-    public <T> boolean check(T responseObject) {
-        JsonElement response = (JsonElement) responseObject;
+    public boolean checkJsonResp(JsonElement response) {
         JsonArray array = response.getAsJsonObject().get("data").getAsJsonArray();
         if (array.size() == 0) {
             return false;
@@ -70,7 +69,7 @@ public class ShardRequestCacheValidator implements IValidator {
      *  "HotClusterSummary":[{"number_of_nodes":1,"number_of_unhealthy_nodes":1}]
      * }
      */
-    boolean checkClusterRca(final JsonObject rcaObject) {
+    private boolean checkClusterRca(final JsonObject rcaObject) {
         if (!"unhealthy".equals(rcaObject.get("state").getAsString())) {
             return false;
         }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/poc/validator/PocValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/poc/validator/PocValidator.java
@@ -26,7 +26,8 @@ public class PocValidator implements IValidator {
    * ]}
    */
   @Override
-  public boolean check(JsonElement response) {
+  public <T> boolean check(T responseObject) {
+    JsonElement response = (JsonElement) responseObject;
     JsonArray array = response.getAsJsonObject().get("data").getAsJsonArray();
     if (array.size() == 0) {
       return false;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/poc/validator/PocValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/poc/validator/PocValidator.java
@@ -26,8 +26,7 @@ public class PocValidator implements IValidator {
    * ]}
    */
   @Override
-  public <T> boolean check(T responseObject) {
-    JsonElement response = (JsonElement) responseObject;
+  public boolean checkJsonResp(JsonElement response) {
     JsonArray array = response.getAsJsonObject().get("data").getAsJsonArray();
     if (array.size() == 0) {
       return false;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/validator/QueueRejectionValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/validator/QueueRejectionValidator.java
@@ -46,8 +46,7 @@ public class QueueRejectionValidator implements IValidator {
    * ]}
    */
   @Override
-  public <T> boolean check(T responseObject) {
-    JsonElement response = (JsonElement) responseObject;
+  public boolean checkJsonResp(JsonElement response) {
     JsonArray array = response.getAsJsonObject().get("data").getAsJsonArray();
     if (array.size() == 0) {
       return false;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/validator/QueueRejectionValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/validator/QueueRejectionValidator.java
@@ -46,7 +46,8 @@ public class QueueRejectionValidator implements IValidator {
    * ]}
    */
   @Override
-  public boolean check(JsonElement response) {
+  public <T> boolean check(T responseObject) {
+    JsonElement response = (JsonElement) responseObject;
     JsonArray array = response.getAsJsonObject().get("data").getAsJsonArray();
     if (array.size() == 0) {
       return false;


### PR DESCRIPTION
*Fixes #:*

*Description of changes:*
Read from sqlite in IT and add cache decider IT

```
sqlite> .tables
HotClusterSummary   HotResourceSummary  RCA               
HotNodeSummary      PersistedAction   
sqlite> select * from PersistedAction
   ...> ;
PersistedAction_ID  nodeIps      muted       actionName          timestamp      nodeIds     summary                                                                       actionable  coolOffPeriod
------------------  -----------  ----------  ------------------  -------------  ----------  ----------------------------------------------------------------------------  ----------  -------------
1                   {127.0.0.1}  0           ModifyCacheMaxSize  1600883515101  {DATA_0}    Update [FIELD_DATA_CACHE] capacity from [10000] to [100000] on node [DATA_0]  1           300000       
```

```
com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.dedicated_master.FieldDataCacheDeciderDedicatedMasterITest

  Test testFieldDataCacheAction PASSED (5m 5s)

com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.dedicated_master.CacheRcaDedicatedMasterITest

  Test testShardRequestCacheRca PASSED (1m 59s)
  Test testFieldDataCacheRca PASSED (1m 59s)

com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.dedicated_master.ShardRequestCacheDeciderDedicatedMasterITest

  Test testShardRequestCacheAction PASSED (5m 5s)

com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.CacheRcaMultiNodeITest

  Test testShardRequestCacheRca PASSED (1m 59s)
  Test testFieldDataCacheRca PASSED (59.2s)

com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.FieldDataCacheDeciderMultiNodeITest

  Test testFieldDataCacheAction PASSED (5m 5s)

com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.multi_node.ShardRequestCacheDeciderMultiNodeITest

  Test testShardRequestCacheAction PASSED (5m 3s)
```

*Tests:*
IT


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
