### PR TITLE
Add GC_Type metric

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/GCInfoCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/GCInfoCollector.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.jvm.GarbageCollectorInfo;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCInfoDimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsProcessor;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * A collector that collects info about the current garbage collectors for various regions in the
+ * heap.
+ */
+public class GCInfoCollector extends PerformanceAnalyzerMetricsCollector implements
+    MetricsProcessor {
+
+  private static final int SAMPLING_TIME_INTERVAL =
+      MetricsConfiguration.CONFIG_MAP.get(GCInfoCollector.class).samplingInterval;
+  private static final int EXPECTED_KEYS_PATH_LENGTH = 0;
+
+  private final StringBuilder value;
+
+  public GCInfoCollector() {
+    super(SAMPLING_TIME_INTERVAL, "GCInfo");
+    this.value = new StringBuilder();
+  }
+
+  @Override
+  void collectMetrics(long startTime) {
+    // Zero the string builder
+    value.setLength(0);
+
+    // first line is the timestamp
+    value.append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds())
+         .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+
+    for (Map.Entry<String, Supplier<String>> entry :
+        GarbageCollectorInfo.getGcSuppliers().entrySet()) {
+      value.append(new GCInfo(entry.getKey(), entry.getValue().get()).serialize())
+           .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+    }
+
+    saveMetricValues(value.toString(), startTime);
+  }
+
+  @Override
+  public String getMetricsPath(long startTime, String... keysPath) {
+    if (keysPath != null && keysPath.length != EXPECTED_KEYS_PATH_LENGTH) {
+      throw new RuntimeException("keys length should be " + EXPECTED_KEYS_PATH_LENGTH);
+    }
+
+    return PerformanceAnalyzerMetrics.generatePath(startTime,
+        PerformanceAnalyzerMetrics.sGcInfoPath);
+  }
+
+  public static class GCInfo extends MetricStatus {
+
+    private final String memoryPool;
+    private final String collectorName;
+
+    public GCInfo(final String memoryPool, final String collectorName) {
+      this.memoryPool = memoryPool;
+      this.collectorName = collectorName;
+    }
+
+    @JsonProperty(GCInfoDimension.Constants.MEMORY_POOL_VALUE)
+    public String getMemoryPool() {
+      return memoryPool;
+    }
+
+    @JsonProperty(GCInfoDimension.Constants.COLLECTOR_NAME_VALUE)
+    public String getCollectorName() {
+      return collectorName;
+    }
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/jvm/GarbageCollectorInfo.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/jvm/GarbageCollectorInfo.java
@@ -1,0 +1,63 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.jvm;
+
+import com.google.common.collect.ImmutableMap;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class GarbageCollectorInfo {
+
+  private static final Map<String, Supplier<String>> gcSuppliers;
+  private static final ImmutableMap<String, String> memoryPoolMap;
+
+  private static final String SURVIVOR = "Survivor";
+  private static final String EDEN = "Eden";
+  private static final String OLD_GEN = "OldGen";
+  private static final String PERM_GEN = "PermGen";
+
+  static {
+    gcSuppliers = new HashMap<>();
+    memoryPoolMap = ImmutableMap.<String, String>builder()
+        // Perm gen region names as read by different collectors.
+        .put("CMS Perm Gen", PERM_GEN)
+        .put("Perm Gen", PERM_GEN)
+        .put("PS Perm Gen", PERM_GEN)
+        .put("G1 Perm Gen", PERM_GEN)
+        .put("Metaspace", PERM_GEN)
+        // Old gen region names as read by different collectors.
+        .put("CMS Old Gen", OLD_GEN)
+        .put("Tenured Gen", OLD_GEN)
+        .put("PS Old Gen", OLD_GEN)
+        .put("G1 Old Gen", OLD_GEN)
+        // Young gen region names as read by different collectors.
+        .put("Par Eden Space", EDEN)
+        .put("Eden Space", EDEN)
+        .put("PS Eden Space", EDEN)
+        .put("G1 Eden", EDEN)
+        // Survivor space as read by different collectors.
+        .put("Par Survivor Space", SURVIVOR)
+        .put("Survivor Space", SURVIVOR)
+        .put("PS Survivor Space", SURVIVOR)
+        .put("G1 Survivor", SURVIVOR)
+        .build();
+
+    List<GarbageCollectorMXBean> gcBeans = ManagementFactory.getGarbageCollectorMXBeans();
+
+    for (GarbageCollectorMXBean gcBean : gcBeans) {
+      String[] memoryPools = gcBean.getMemoryPoolNames();
+      if (memoryPools != null && memoryPools.length > 0) {
+        for (String memoryPool : memoryPools) {
+          String genericMemoryPool = memoryPoolMap.getOrDefault(memoryPool, memoryPool);
+          gcSuppliers.putIfAbsent(genericMemoryPool, gcBean::getName);
+        }
+      }
+    }
+  }
+
+  public static Map<String, Supplier<String>> getGcSuppliers() {
+    return gcSuppliers;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/AllMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/AllMetrics.java
@@ -319,6 +319,58 @@ public class AllMetrics {
     }
   }
 
+  public enum GCInfoDimension implements MetricDimension, JooqFieldValue {
+
+    MEMORY_POOL(Constants.MEMORY_POOL_VALUE),
+    COLLECTOR_NAME(Constants.COLLECTOR_NAME_VALUE);
+
+    private final String value;
+
+    GCInfoDimension(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String getName() {
+      return value;
+    }
+
+    @Override
+    public Field<String> getField() {
+      return DSL.field(DSL.name(this.value), String.class);
+    }
+
+    @Override
+    public String toString() {
+      return value;
+    }
+
+    public static class Constants {
+      public static final String MEMORY_POOL_VALUE = "MemoryPool";
+      public static final String COLLECTOR_NAME_VALUE = "CollectorName";
+    }
+  }
+
+  public enum GCInfoValue implements MetricValue {
+    GARBAGE_COLLECTOR_TYPE(Constants.GC_TYPE_VALUE);
+
+    private final String value;
+
+    GCInfoValue(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return value;
+    }
+
+    public static class Constants {
+      public static final String GC_TYPE_VALUE = "GC_Type";
+    }
+  }
+
+
   public enum DiskDimension implements MetricDimension {
     DISK_NAME(Constants.NAME_VALUE);
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/MetricsConfiguration.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/MetricsConfiguration.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.DisksCollector;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.GCInfoCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.HeapMetricsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MetricsPurgeActivity;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.NetworkE2ECollector;
@@ -29,7 +30,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.os.OSGlobals;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.os.ThreadCPU;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.os.ThreadDiskIO;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.os.ThreadSched;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -73,5 +73,6 @@ public class MetricsConfiguration {
     CONFIG_MAP.put(StatsCollector.class, new MetricConfig(STATS_ROTATION_INTERVAL, 0, 0));
     CONFIG_MAP.put(DisksCollector.class, cdefault);
     CONFIG_MAP.put(HeapMetricsCollector.class, cdefault);
+    CONFIG_MAP.put(GCInfoCollector.class, cdefault);
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
@@ -51,6 +51,7 @@ public class PerformanceAnalyzerMetrics {
   public static final String sDisksPath = "disk_metrics";
   public static final String sTCPPath = "tcp_metrics";
   public static final String sIPPath = "ip_metrics";
+  public static final String sGcInfoPath = "gc_info";
   public static final String sKeyValueDelimitor = ":";
   public static final String sMetricNewLineDelimitor = System.getProperty("line.separator");
   public static final String START_FILE_NAME = "start";

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/GarbageCollectorInfoProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/GarbageCollectorInfoProcessor.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCInfoDimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.util.JsonConverter;
+import java.sql.Connection;
+import java.util.Map;
+import java.util.NavigableMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jooq.BatchBindStep;
+import org.jooq.Record;
+import org.jooq.Result;
+
+public class GarbageCollectorInfoProcessor implements EventProcessor {
+
+  private static final Logger LOG = LogManager.getLogger(GarbageCollectorInfoProcessor.class);
+
+  private GarbageCollectorInfoSnapshot gcSnap;
+  private BatchBindStep handle;
+  private long startTime;
+  private long endTime;
+
+  private GarbageCollectorInfoProcessor(GarbageCollectorInfoSnapshot gcSnap) {
+    this.gcSnap = gcSnap;
+  }
+
+  static GarbageCollectorInfoProcessor buildGarbageCollectorInfoProcessor(
+      long currWindowStartTime,
+      Connection conn,
+      NavigableMap<Long, GarbageCollectorInfoSnapshot> gcInfoMap) {
+    if (gcInfoMap.get(currWindowStartTime) == null) {
+      GarbageCollectorInfoSnapshot gcSnap = new GarbageCollectorInfoSnapshot(conn, currWindowStartTime);
+      gcInfoMap.put(currWindowStartTime, gcSnap);
+
+      return new GarbageCollectorInfoProcessor(gcSnap);
+    }
+
+    return new GarbageCollectorInfoProcessor(gcInfoMap.get(currWindowStartTime));
+  }
+
+  @Override
+  public void initializeProcessing(long startTime, long endTime) {
+    this.startTime = startTime;
+    this.endTime = endTime;
+    this.handle = gcSnap.startBatchPut();
+  }
+
+  @Override
+  public void finalizeProcessing() {
+    if (handle.size() > 0) {
+      handle.execute();
+
+      Result<Record> records = gcSnap.fetchAll();
+    }
+  }
+
+  @Override
+  public void processEvent(Event event) {
+    handleGarbageCollectorInfoEvent(event);
+    if (handle.size() >= BATCH_LIMIT) {
+      handle.execute();
+      handle = gcSnap.startBatchPut();
+    }
+  }
+
+  private void handleGarbageCollectorInfoEvent(Event event) {
+    String[] lines = event.value.split(System.getProperty("line.separator"));
+    // first line is the timestamp
+    for (int i = 1; i < lines.length; ++i) {
+      parseJsonLine(lines[i]);
+    }
+  }
+
+  private void parseJsonLine(final String jsonString) {
+    Map<String, Object> map = JsonConverter.createMapFrom(jsonString);
+    if (map.isEmpty()) {
+      LOG.warn("Empty line in the event log for gc_info section.");
+      return;
+    }
+
+    GCInfoDimension[] dims = AllMetrics.GCInfoDimension.values();
+
+    Object[] bindVals = new Object[dims.length];
+    int idx = 0;
+    for (GCInfoDimension dimension : dims) {
+      bindVals[idx++] = map.get(dimension.toString());
+    }
+
+    handle.bind(bindVals);
+  }
+
+  @Override
+  public boolean shouldProcessEvent(Event event) {
+    return event.key.contains(PerformanceAnalyzerMetrics.sGcInfoPath);
+  }
+
+  @Override
+  public void commitBatchIfRequired() {
+    if (handle.size() > BATCH_LIMIT) {
+      handle.execute();
+      handle = gcSnap.startBatchPut();
+    }
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/GarbageCollectorInfoProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/GarbageCollectorInfoProcessor.java
@@ -12,6 +12,7 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
@@ -25,8 +26,6 @@ import java.util.NavigableMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jooq.BatchBindStep;
-import org.jooq.Record;
-import org.jooq.Result;
 
 public class GarbageCollectorInfoProcessor implements EventProcessor {
 
@@ -66,18 +65,13 @@ public class GarbageCollectorInfoProcessor implements EventProcessor {
   public void finalizeProcessing() {
     if (handle.size() > 0) {
       handle.execute();
-
-      Result<Record> records = gcSnap.fetchAll();
     }
   }
 
   @Override
   public void processEvent(Event event) {
     handleGarbageCollectorInfoEvent(event);
-    if (handle.size() >= BATCH_LIMIT) {
-      handle.execute();
-      handle = gcSnap.startBatchPut();
-    }
+    commitBatchIfRequired();
   }
 
   private void handleGarbageCollectorInfoEvent(Event event) {
@@ -113,7 +107,7 @@ public class GarbageCollectorInfoProcessor implements EventProcessor {
 
   @Override
   public void commitBatchIfRequired() {
-    if (handle.size() > BATCH_LIMIT) {
+    if (handle.size() >= BATCH_LIMIT) {
       handle.execute();
       handle = gcSnap.startBatchPut();
     }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/GarbageCollectorInfoSnapshot.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/GarbageCollectorInfoSnapshot.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCInfoDimension;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jooq.BatchBindStep;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+
+public class GarbageCollectorInfoSnapshot implements Removable {
+
+  private static final Logger LOG = LogManager.getLogger(GarbageCollectorInfoSnapshot.class);
+
+  private final DSLContext create;
+  private final Long windowStartTime;
+  private final String tableName;
+  private List<Field<?>> columns;
+
+
+  public enum Fields {
+    MEMORY_POOL(GCInfoDimension.MEMORY_POOL.toString()),
+    COLLECTOR_NAME(GCInfoDimension.COLLECTOR_NAME.toString());
+
+    private final String fieldValue;
+
+    Fields(String fieldValue) {
+      this.fieldValue = fieldValue;
+    }
+
+
+    @Override
+    public String toString() {
+      return fieldValue;
+    }
+  }
+
+  public GarbageCollectorInfoSnapshot(Connection conn, Long windowStartTime) {
+    this.create = DSL.using(conn, SQLDialect.SQLITE);
+    this.windowStartTime = windowStartTime;
+    this.tableName = "gc_info_" + windowStartTime;
+    this.columns = new ArrayList<Field<?>>() {
+      {
+        this.add(DSL.field(DSL.name(Fields.MEMORY_POOL.toString()), String.class));
+        this.add(DSL.field(DSL.name(Fields.COLLECTOR_NAME.toString()), String.class));
+      }
+    };
+
+    create.createTable(tableName).columns(columns).execute();
+  }
+
+  public BatchBindStep startBatchPut() {
+    List<Object> dummyValues = new ArrayList<>();
+    for (int i = 0; i < columns.size(); i++) {
+      dummyValues.add("");
+    }
+    return create.batch(create.insertInto(DSL.table(this.tableName)).values(dummyValues));
+  }
+
+  public Result<Record> fetchAll() {
+    return create.select().from(DSL.table(tableName)).fetch();
+  }
+
+  @Override
+  public void remove() throws Exception {
+    create.dropTable(DSL.table(tableName)).execute();
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MetricsEmitter.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MetricsEmitter.java
@@ -626,8 +626,8 @@ public class MetricsEmitter {
 
     metricsDB.createMetric(new Metric<>(GCInfoValue.GARBAGE_COLLECTOR_TYPE.toString(), 0d), dims);
     BatchBindStep handle =
-        metricsDB.startBatchPut(new Metric<>(GCInfoValue.GARBAGE_COLLECTOR_TYPE.toString(), 0d)
-            , dims);
+        metricsDB.startBatchPut(new Metric<>(GCInfoValue.GARBAGE_COLLECTOR_TYPE.toString(), 0d),
+            dims);
     for (Record record : gcTypeRecords) {
       Optional<Object> memPoolObj =
           Optional.ofNullable(record.get(GCInfoDimension.MEMORY_POOL.toString()));

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/GarbageCollectorInfoProcessorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/GarbageCollectorInfoProcessorTest.java
@@ -1,0 +1,69 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.GCInfoCollector.GCInfo;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.GarbageCollectorInfoSnapshot.Fields;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.junit.Before;
+import org.junit.Test;
+
+public class GarbageCollectorInfoProcessorTest {
+
+  private static final String DB_URL = "jdbc:sqlite:";
+  private static final String TEST_MEM_POOL = "testMemPool";
+  private static final String COLLECTOR_NAME = "testCollectorName";
+  private static final String GC_INFO_KEY = "gc_info";
+  private GarbageCollectorInfoProcessor gcProcessor;
+  private long currTimestamp;
+  private NavigableMap<Long, GarbageCollectorInfoSnapshot> snapMap;
+  Connection conn;
+
+  @Before
+  public void setup() throws Exception {
+    Class.forName("org.sqlite.JDBC");
+    System.setProperty("java.io.tmpdir", "/tmp");
+    conn = DriverManager.getConnection(DB_URL);
+    this.currTimestamp = System.currentTimeMillis();
+    this.snapMap = new TreeMap<>();
+    this.gcProcessor = GarbageCollectorInfoProcessor
+        .buildGarbageCollectorInfoProcessor(currTimestamp, conn, snapMap);
+  }
+
+  @Test
+  public void testHandleEvent() throws Exception {
+    Event testEvent = buildTestGcInfoEvent();
+
+    gcProcessor.initializeProcessing(currTimestamp, System.currentTimeMillis());
+
+    assertTrue(gcProcessor.shouldProcessEvent(testEvent));
+
+    gcProcessor.processEvent(testEvent);
+    gcProcessor.finalizeProcessing();
+
+    GarbageCollectorInfoSnapshot snap = snapMap.get(currTimestamp);
+    Result<Record> result = snap.fetchAll();
+    assertEquals(1, result.size());
+    assertEquals(TEST_MEM_POOL, result.get(0).get(Fields.MEMORY_POOL.toString()));
+    assertEquals(COLLECTOR_NAME, result.get(0).get(Fields.COLLECTOR_NAME.toString()));
+  }
+
+  private Event buildTestGcInfoEvent() {
+    StringBuilder val = new StringBuilder();
+    val.append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds())
+       .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+
+    val.append(new GCInfo(TEST_MEM_POOL, COLLECTOR_NAME).serialize())
+       .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+    return new Event(GC_INFO_KEY, val.toString(), System.currentTimeMillis());
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/GarbageCollectorInfoProcessorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/GarbageCollectorInfoProcessorTest.java
@@ -1,5 +1,19 @@
-package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/GarbageCollectorInfoSnapshotTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/GarbageCollectorInfoSnapshotTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/GarbageCollectorInfoSnapshotTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/GarbageCollectorInfoSnapshotTest.java
@@ -1,0 +1,54 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
+
+import static org.junit.Assert.assertEquals;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.GarbageCollectorInfoSnapshot.Fields;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import org.jooq.BatchBindStep;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class GarbageCollectorInfoSnapshotTest {
+
+  private static final String DB_URL = "jdbc:sqlite:";
+  private static final String TEST_MEM_POOL = "OldGen";
+  private static final String COLLECTOR_NAME = "G1";
+  private Connection conn;
+  GarbageCollectorInfoSnapshot snapshot;
+
+  @Before
+  public void setup() throws Exception {
+    Class.forName("org.sqlite.JDBC");
+    System.setProperty("java.io.tmpdir", "/tmp");
+    conn = DriverManager.getConnection(DB_URL);
+    snapshot = new GarbageCollectorInfoSnapshot(conn, System.currentTimeMillis());
+  }
+
+  @Test
+  public void testReadGcSnapshot() throws Exception {
+    final BatchBindStep handle = snapshot.startBatchPut();
+    insertIntoTable(handle, TEST_MEM_POOL, COLLECTOR_NAME);
+
+    final Result<Record> result = snapshot.fetchAll();
+
+    assertEquals(1, result.size());
+    assertEquals(TEST_MEM_POOL, result.get(0).get(Fields.MEMORY_POOL.toString()));
+    assertEquals(COLLECTOR_NAME, result.get(0).get(Fields.COLLECTOR_NAME.toString()));
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    conn.close();
+  }
+
+  private void insertIntoTable(BatchBindStep handle, String memPool, String collectorName) {
+    Object[] bindVals = new Object[2];
+    bindVals[0] = memPool;
+    bindVals[1] = collectorName;
+    handle.bind(bindVals).execute();
+  }
+}


### PR DESCRIPTION
*Fixes #:*
#437 
*Description of changes:*
Adds a new `GC_Type` metric to the metricsdb.

This change adds a new collector: `GCInfoCollector` which fetches the names of the collectors assigned to garbage collect specific memory pools(eden, old gen, survivor, etc).

This event is then processed by the `GarbageCollectorInfoProcessor` to convert the events to a metric table: `GC_Type` in the metricsdb.

*Tests:*
Tested on docker. The content of the table in metricsdb is pasted below.

```
sqlite> select * from GC_Type;
Survivor|ParNew||||
OldGen|ConcurrentMarkSweep||||
Eden|ParNew||||
```
*If new tests are added, how long do the new ones take to complete*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
