### PR TITLE
Modify NodeConfigCollector to include more heap stats

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/ResourceUtil.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/ResourceUtil.java
@@ -31,7 +31,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum
  * such as TOTAL_THROUGHPUT and SYS_CALL_RATE
  */
 public class ResourceUtil {
-  // JVM resource
+  // JVM resources
   public static final Resource HEAP_MAX_SIZE = Resource.newBuilder()
           .setResourceEnum(ResourceEnum.HEAP)
           .setMetricEnum(MetricEnum.HEAP_MAX).build();
@@ -41,6 +41,18 @@ public class ResourceUtil {
   public static final Resource YOUNG_GEN_PROMOTION_RATE = Resource.newBuilder()
       .setResourceEnum(ResourceEnum.YOUNG_GEN)
       .setMetricEnum(MetricEnum.PROMOTION_RATE).build();
+  public static final Resource FULL_GC_PAUSE_TIME = Resource.newBuilder()
+      .setResourceEnum(ResourceEnum.OLD_GEN)
+      .setMetricEnum(MetricEnum.FULL_GC).build();
+  public static final Resource OLD_GEN_MAX_SIZE = Resource.newBuilder()
+      .setResourceEnum(ResourceEnum.OLD_GEN)
+      .setMetricEnum(MetricEnum.HEAP_MAX).build();
+  public static final Resource YOUNG_GEN_MAX_SIZE = Resource.newBuilder()
+      .setResourceEnum(ResourceEnum.YOUNG_GEN)
+      .setMetricEnum(MetricEnum.HEAP_MAX).build();
+  public static final Resource MINOR_GC_PAUSE_TIME = Resource.newBuilder()
+      .setResourceEnum(ResourceEnum.YOUNG_GEN)
+      .setMetricEnum(MetricEnum.MINOR_GC).build();
 
   // hardware resource
   public static final Resource CPU_USAGE = Resource.newBuilder()

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/collector/NodeConfigCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/collector/NodeConfigCollector.java
@@ -22,6 +22,7 @@ import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.Al
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.Resource;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CacheType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCType;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolType;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.EsConfigNode;
@@ -83,10 +84,21 @@ public class NodeConfigCollector extends EsConfigNode {
     collectAndPublishMetric(ResourceUtil.SHARD_REQUEST_CACHE_MAX_SIZE, shardRequestCacheMaxSize);
   }
 
-  private void collectHeapMaxSize(MetricFlowUnit heapMax) {
+  private void collectHeapStats(MetricFlowUnit heapMax) {
+    // total maximum heap size
     final double heapMaxSize = SQLParsingUtil.readDataFromSqlResult(heapMax.getData(),
             MEM_TYPE.getField(), AllMetrics.GCType.HEAP.toString(), MetricsDB.MAX);
     collectAndPublishMetric(ResourceUtil.HEAP_MAX_SIZE, heapMaxSize);
+    // maximum old generation heap size
+    final double oldGenMaxSize = SQLParsingUtil.readDataFromSqlResult(heapMax.getData(),
+        MEM_TYPE.getField(), GCType.OLD_GEN.toString(), MetricsDB.MAX);
+    collectAndPublishMetric(ResourceUtil.OLD_GEN_MAX_SIZE, oldGenMaxSize);
+    // maximum young generation heap size
+    final double edenMaxSize = SQLParsingUtil.readDataFromSqlResult(heapMax.getData(),
+        MEM_TYPE.getField(), GCType.EDEN.toString(), MetricsDB.MAX);
+    final double survivorMaxSize = SQLParsingUtil.readDataFromSqlResult(heapMax.getData(),
+        MEM_TYPE.getField(), GCType.SURVIVOR.toString(), MetricsDB.MAX);
+    collectAndPublishMetric(ResourceUtil.YOUNG_GEN_MAX_SIZE, edenMaxSize + (2 * survivorMaxSize));
   }
 
   private void collectAndPublishMetric(final Resource resource, final double metricValue) {
@@ -126,7 +138,7 @@ public class NodeConfigCollector extends EsConfigNode {
       if (flowUnit.isEmpty()) {
         continue;
       }
-      collectHeapMaxSize(flowUnit);
+      collectHeapStats(flowUnit);
     }
 
     if (counter == rcaPeriod) {

--- a/src/main/proto/inter_node_rpc_service.proto
+++ b/src/main/proto/inter_node_rpc_service.proto
@@ -83,7 +83,7 @@ enum MetricEnum {
   // JVM
   HEAP_USAGE = 0 [(additional_fields).name = "heap usage", (additional_fields).description = "memory usage in percentage"];
   PROMOTION_RATE = 1 [(additional_fields).name = "promotion rate", (additional_fields).description = "mb/s"];
-  MINOR_GC = 2 [(additional_fields).name = "minor gc", (additional_fields).description = "time in percentage"];
+  MINOR_GC = 2 [(additional_fields).name = "minor gc", (additional_fields).description = "minor gc pause time in ms"];
 
   // hardware
   CPU_USAGE = 3 [(additional_fields).name = "cpu usage", (additional_fields).description = "num of cores"];
@@ -101,6 +101,9 @@ enum MetricEnum {
 
   // Heap
   HEAP_MAX = 16 [(additional_fields).name = "heap max", (additional_fields).description = "max heap size in bytes"];
+
+  // GC
+  FULL_GC = 32 [(additional_fields).name = "full gc", (additional_fields).description = "full gc pause time in ms"];
 }
 
 /*


### PR DESCRIPTION
Modify NodeConfigCollector to include more heap stats

*Fixes #:* N/A

*Description of changes:*
- NodeConfigCollector now reports the maximum amount of memory avaiable
in the old generation and the young generation in bytes

*Tests:* 
- NodeConfigCollectorTest

*If new tests are added, how long do the new ones take to complete*
Negligible effect on overall test time

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
