### PR TITLE
Add the PersistableSlidingWindow class

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/PersistableSlidingWindow.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/PersistableSlidingWindow.java
@@ -50,8 +50,7 @@ public class PersistableSlidingWindow extends SlidingWindow<SlidingWindowData> {
         load(pathToFile);
       }
     } catch (IOException e) {
-      LOG.error("Couldn't create file {} to perform young generation tuning", pathToFile, e);
-      throw new IllegalArgumentException("Couldn't create or read a file at " + filePath);
+      LOG.error("Couldn't load SlidingWindow data from {}", pathToFile, e);
     }
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/PersistableSlidingWindow.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/PersistableSlidingWindow.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.aggregators;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.FileRotate;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.LineIterator;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * PersistableSlidingWindow is a SlidingWindow which can have its data written to and read from disk
+ */
+public class PersistableSlidingWindow extends SlidingWindow<SlidingWindowData> {
+  private static final Logger LOG = LogManager.getLogger(PersistableSlidingWindow.class);
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  private Path pathToFile;
+
+  public PersistableSlidingWindow(int slidingWindowSize,
+                                  TimeUnit timeUnit,
+                                  Path filePath) {
+    super(slidingWindowSize, timeUnit);
+    this.pathToFile = filePath;
+    try {
+      if (Files.exists(pathToFile)) {
+        load(pathToFile);
+      }
+    } catch (IOException e) {
+      LOG.error("Couldn't create file {} to perform young generation tuning", pathToFile, e);
+      throw new IllegalArgumentException("Couldn't create or read a file at " + filePath);
+    }
+  }
+
+  /**
+   * Loads the SlidingWindowData contained in the given path into this PersistableSlidingWindow
+   * @param path The path to the file containing the SlidingWindow data
+   * @throws IOException If there is an error reading the file
+   */
+  protected synchronized void load(Path path) throws IOException {
+    LineIterator it = FileUtils.lineIterator(path.toFile(), "UTF-8");
+    try {
+      while (it.hasNext()) {
+        String line = it.nextLine();
+        SlidingWindowData data = objectMapper.readValue(line, SlidingWindowData.class);
+        next(data);
+      }
+    } finally {
+      LineIterator.closeQuietly(it);
+    }
+  }
+
+  /**
+   * Writes the contents of this SlidingWindow into the path provided during construction
+   *
+   * <p>This write occurs in 2 stages, it writes to a temporary file, then replaces the actual data
+   * file with the contents of the temporary file
+   *
+   * @throws IOException If there is a CRUD error with the files involved
+   */
+  protected synchronized void write() throws IOException {
+    String tmpFile = pathToFile.toString() + RandomStringUtils.randomAlphanumeric(32);
+    Path tmpPath = Paths.get(tmpFile);
+    Files.createFile(Paths.get(tmpFile));
+    BufferedWriter writer = new BufferedWriter(new FileWriter(tmpFile, false));
+    Iterator<SlidingWindowData> it = windowDeque.descendingIterator();
+    while (it.hasNext()) {
+      writer.write(objectMapper.writeValueAsString(it.next()));
+      writer.write(System.lineSeparator());
+    }
+    // write to temporary file
+    writer.flush();
+    // atomic rotate
+    FileRotate.rotateFile(tmpPath, pathToFile);
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/SlidingWindow.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/SlidingWindow.java
@@ -28,11 +28,13 @@ public class SlidingWindow<E extends SlidingWindowData> {
   protected final Deque<E> windowDeque;
   protected final long SLIDING_WINDOW_SIZE;
   protected double sum;
+  protected TimeUnit timeUnit;
 
   public SlidingWindow(int SLIDING_WINDOW_SIZE_IN_TIMESTAMP, TimeUnit timeUnit) {
     this.windowDeque = new LinkedList<>();
     this.SLIDING_WINDOW_SIZE = timeUnit.toSeconds(SLIDING_WINDOW_SIZE_IN_TIMESTAMP);
     this.sum = 0.0;
+    this.timeUnit = timeUnit;
   }
 
   /**
@@ -92,5 +94,9 @@ public class SlidingWindow<E extends SlidingWindowData> {
    */
   public double readSum() {
     return this.sum;
+  }
+
+  public int size() {
+    return windowDeque.size();
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/SlidingWindowData.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/SlidingWindowData.java
@@ -1,8 +1,32 @@
+/*
+ *  Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.aggregators;
 
+/**
+ * SlidingWindowData holds a timestamp in ms and a double value. It is the basic datatype used by a
+ * {@link SlidingWindow}
+ */
 public class SlidingWindowData {
   protected long timeStamp;
   protected double value;
+
+  public SlidingWindowData() {
+    this.timeStamp = -1;
+    this.value = -1;
+  }
 
   public SlidingWindowData(long timeStamp, double value) {
     this.timeStamp = timeStamp;
@@ -13,8 +37,16 @@ public class SlidingWindowData {
     return this.timeStamp;
   }
 
+  public void setTimeStamp(long timeStamp) {
+    this.timeStamp = timeStamp;
+  }
+
   public double getValue() {
     return this.value;
+  }
+
+  public void setValue(double value) {
+    this.value = value;
   }
 }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/PersistableSlidingWindowTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/PersistableSlidingWindowTest.java
@@ -1,0 +1,98 @@
+/*
+ *  Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.aggregators;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PersistableSlidingWindowTest {
+  private static final Logger LOG = LogManager.getLogger(PersistableSlidingWindowTest.class);
+
+  private static Path testLocation;
+  private static Path persistFile;
+
+  @Before
+  public void init() throws IOException {
+    String cwd = System.getProperty("user.dir");
+    testLocation = Paths.get(cwd, "src", "test", "resources", "tmp", "PersistableSlidingWindowTest");
+    Files.createDirectories(testLocation);
+    FileUtils.cleanDirectory(testLocation.toFile());
+    persistFile = Paths.get(testLocation.toString(), "PersistableSlidingWindowTest.test");
+    Files.deleteIfExists(persistFile);
+  }
+
+  @Test
+  public void testNext() throws Exception {
+    PersistableSlidingWindow slidingWindow = new PersistableSlidingWindow(5, TimeUnit.SECONDS, persistFile);
+    long curTimestamp = Instant.now().toEpochMilli();
+    // Load data into the window
+    slidingWindow.next(new SlidingWindowData(curTimestamp, 10));
+    slidingWindow.next(new SlidingWindowData(curTimestamp, 2));
+    slidingWindow.next(new SlidingWindowData(curTimestamp, 12));
+    slidingWindow.next(new SlidingWindowData(curTimestamp, 18));
+    // NOTE even though 5900ms is 5.9s, SlidingWindowData timestamps are truncated, so this point
+    // will NOT kick out the other datapoints
+    slidingWindow.next(new SlidingWindowData(curTimestamp + 5900, 19));
+    Assert.assertEquals(5, slidingWindow.size());
+    // Now the older datapoints will get kicked out
+    slidingWindow.next(new SlidingWindowData(curTimestamp + 6100, 66));
+    slidingWindow.next(new SlidingWindowData(curTimestamp + 6700, 1));
+    Assert.assertEquals(3, slidingWindow.size());
+    // Test that we can read our writes
+    slidingWindow.write();
+    PersistableSlidingWindow slidingWindow2 = new PersistableSlidingWindow(5, TimeUnit.SECONDS, persistFile);
+    Assert.assertTrue(SlidingWindowTestUtil.equals(slidingWindow, slidingWindow2));
+    Assert.assertTrue(SlidingWindowTestUtil.equals_MUTATE(slidingWindow, slidingWindow2));
+  }
+
+  @Test
+  public void testDifferentTimeUnits() throws Exception {
+    PersistableSlidingWindow slidingWindow = new PersistableSlidingWindow(5000000, TimeUnit.MICROSECONDS, persistFile);
+    long curTimestamp = Instant.now().toEpochMilli();
+    // Load data into the window
+    slidingWindow.next(new SlidingWindowData(curTimestamp, 10));
+    slidingWindow.next(new SlidingWindowData(curTimestamp, 2));
+    slidingWindow.next(new SlidingWindowData(curTimestamp, 12));
+    slidingWindow.next(new SlidingWindowData(curTimestamp, 18));
+    Assert.assertEquals(4, slidingWindow.size());
+    // Test that bucket writes occur properly
+    slidingWindow.next(new SlidingWindowData(curTimestamp + 6100, 66));
+    Assert.assertEquals(1, slidingWindow.size());
+  }
+
+
+
+  @AfterClass
+  public static void tearDown() {
+    try {
+      Files.deleteIfExists(persistFile);
+      Files.deleteIfExists(testLocation);
+    } catch (IOException e) {
+      LOG.error("Couldn't delete file {}", persistFile, e);
+    }
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/SlidingWindowTestUtil.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/SlidingWindowTestUtil.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.aggregators;
+
+import java.util.Iterator;
+import java.util.Objects;
+
+public class SlidingWindowTestUtil {
+  public static boolean equals(SlidingWindow<SlidingWindowData> a, SlidingWindow<SlidingWindowData> b) {
+    Objects.requireNonNull(a);
+    Objects.requireNonNull(b);
+    if (a.size() != b.size()) {
+      return false;
+    }
+    Iterator<SlidingWindowData> aIt = a.windowDeque.descendingIterator();
+    Iterator<SlidingWindowData> bIt = b.windowDeque.descendingIterator();
+    while (aIt.hasNext()) {
+      SlidingWindowData aData = aIt.next();
+      SlidingWindowData bData = bIt.next();
+      if (aData.getValue() != bData.getValue() || aData.getTimeStamp() != bData.getTimeStamp()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  public static boolean equals_MUTATE(SlidingWindow<SlidingWindowData> a, SlidingWindow<SlidingWindowData> b) {
+    Objects.requireNonNull(a);
+    Objects.requireNonNull(b);
+    if (a.size() != b.size()) {
+      return false;
+    }
+    while (a.size() > 0) {
+      if (a.windowDeque.getLast().getValue() != b.windowDeque.getLast().getValue()) {
+        return false;
+      }
+      a.windowDeque.removeLast();
+      b.windowDeque.removeLast();
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
Add the PersistableSlidingWindow class

*Fixes #:* N/A

*Description of changes:*
- A PersistableSlidingWindow is a sliding window that aggregates data
into buckets and can be written to and read from the disk. This makes it
suitable for retaining data over large spans of time requiring too much
memory or being susceptible to node loss.

*Tests:*
- PersistableSlidingWindowTest

*If new tests are added, how long do the new ones take to complete*
- Test time is negligible

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
