### PR TITLE
Bucketized Sliding Window with Alarm Monitors

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/AlarmMonitor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/AlarmMonitor.java
@@ -27,9 +27,9 @@ public interface AlarmMonitor {
    * @param timeStamp Issue timestamp in millis
    * @param value Issues can be recorded with an intensity value
    */
-  public void recordIssue(long timeStamp, double value);
+  void recordIssue(long timeStamp, double value);
 
-  public default void recordIssue() {
+  default void recordIssue() {
     recordIssue(System.currentTimeMillis(), 1);
   }
 
@@ -37,6 +37,6 @@ public interface AlarmMonitor {
    * State of the alarm
    * @return true if alarm is in healthy state, false otherwise
    */
-  public boolean isHealthy();
+  boolean isHealthy();
 
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/AlarmMonitor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/AlarmMonitor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders;
+
+/**
+ * AlarmMonitor evaluates and maintains the state of an alarm.
+ *
+ * <p>An alarm can either be healthy or unhealthy.
+ */
+public interface AlarmMonitor {
+
+  /**
+   * Invoked whenever an issue needs to be recorded with the monitor
+   * @param timeStamp Issue timestamp in millis
+   * @param value Issues can be recorded with an intensity value
+   */
+  public void recordIssue(long timeStamp, double value);
+
+  public default void recordIssue() {
+    recordIssue(System.currentTimeMillis(), 1);
+  }
+
+  /**
+   * State of the alarm
+   * @return true if alarm is in healthy state, false otherwise
+   */
+  public boolean isHealthy();
+
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmActionsAlarmMonitor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmActionsAlarmMonitor.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.jvm;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.AlarmMonitor;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.aggregators.BucketizedSlidingWindow;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.aggregators.SlidingWindowData;
+import java.util.concurrent.TimeUnit;
+
+public class JvmActionsAlarmMonitor implements AlarmMonitor {
+
+  public static final int DAY_BREACH_THRESHOLD = 5;
+  public static final int WEEK_BREACH_THRESHOLD = 2;
+
+  private BucketizedSlidingWindow dayMonitor;
+  private BucketizedSlidingWindow weekMonitor;
+  private boolean alarmHealthy = true;
+
+  public JvmActionsAlarmMonitor() {
+    dayMonitor = new BucketizedSlidingWindow((int) TimeUnit.DAYS.toMinutes(1), 30, TimeUnit.MINUTES);
+    weekMonitor = new BucketizedSlidingWindow(4, 1, TimeUnit.DAYS);
+  }
+
+  @Override
+  public void recordIssue(long timeStamp, double value) {
+    SlidingWindowData dataPoint = new SlidingWindowData(timeStamp, value);
+    dayMonitor.next(dataPoint);
+    // If we've breached the day threshold, record it as a bad day this week.
+    if (dayMonitor.size() >= DAY_BREACH_THRESHOLD) {
+      weekMonitor.next(dataPoint);
+    }
+  }
+
+  private void evaluateAlarm() {
+    if (alarmHealthy) {
+      if (weekMonitor.size() >= WEEK_BREACH_THRESHOLD) {
+        alarmHealthy = false;
+      }
+    } else {
+      if (dayMonitor.size() == 0 && weekMonitor.size() == 0) {
+        alarmHealthy = true;
+      }
+    }
+  }
+
+  @Override
+  public boolean isHealthy() {
+    evaluateAlarm();
+    return alarmHealthy;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmActionsAlarmMonitor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmActionsAlarmMonitor.java
@@ -18,6 +18,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.de
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.AlarmMonitor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.aggregators.BucketizedSlidingWindow;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.aggregators.SlidingWindowData;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.TimeUnit;
 
 public class JvmActionsAlarmMonitor implements AlarmMonitor {
@@ -40,7 +41,7 @@ public class JvmActionsAlarmMonitor implements AlarmMonitor {
     dayMonitor.next(dataPoint);
     // If we've breached the day threshold, record it as a bad day this week.
     if (dayMonitor.size() >= DAY_BREACH_THRESHOLD) {
-      weekMonitor.next(dataPoint);
+      weekMonitor.next(new SlidingWindowData(dataPoint.getTimeStamp(), dataPoint.getValue()));
     }
   }
 
@@ -60,5 +61,20 @@ public class JvmActionsAlarmMonitor implements AlarmMonitor {
   public boolean isHealthy() {
     evaluateAlarm();
     return alarmHealthy;
+  }
+
+  @VisibleForTesting
+  BucketizedSlidingWindow getDayMonitor() {
+    return dayMonitor;
+  }
+
+  @VisibleForTesting
+  BucketizedSlidingWindow getWeekMonitor() {
+    return weekMonitor;
+  }
+
+  @VisibleForTesting
+  void setAlarmHealth(boolean isHealthy) {
+    this.alarmHealthy = isHealthy;
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/BucketizedSlidingWindow.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/BucketizedSlidingWindow.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.aggregators;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The BucketizedSlidingWindow provides a SlidingWindow implementation that can aggregate all
+ * inserts within a configured time range, {@link BUCKET_WINDOW_SIZE}, into a single data point.
+ *
+ * <p> All data within a single bucket window time range is summed by default.
+ */
+public class BucketizedSlidingWindow extends SlidingWindow<SlidingWindowData> {
+
+  private final long BUCKET_WINDOW_SIZE;
+
+  public BucketizedSlidingWindow(int SLIDING_WINDOW_SIZE, int BUCKET_WINDOW_SIZE, TimeUnit timeUnit) {
+    super(SLIDING_WINDOW_SIZE, timeUnit);
+    assert BUCKET_WINDOW_SIZE < SLIDING_WINDOW_SIZE : "BucketWindow size should be less than SlidingWindow size";
+    this.BUCKET_WINDOW_SIZE = timeUnit.toSeconds(BUCKET_WINDOW_SIZE);
+  }
+
+  @Override
+  public void next(SlidingWindowData e) {
+    if (!windowDeque.isEmpty()) {
+      SlidingWindowData firstElement = windowDeque.getFirst();
+      if (TimeUnit.MILLISECONDS.toSeconds(e.getTimeStamp() - firstElement.getTimeStamp()) <= BUCKET_WINDOW_SIZE) {
+        firstElement.value += e.getValue();
+        firstElement.timeStamp = e.getTimeStamp();
+        add(e);
+        pruneExpiredEntries(e.getTimeStamp());
+        return;
+      }
+    }
+    super.next(e);
+  }
+
+  public int size() {
+    pruneExpiredEntries(System.currentTimeMillis());
+    return windowDeque.size();
+  }
+
+  @Override
+  public double readAvg() {
+    pruneExpiredEntries(System.currentTimeMillis());
+    return super.readAvg();
+  }
+
+  @Override
+  public double readAvg(TimeUnit timeUnit) {
+    pruneExpiredEntries(System.currentTimeMillis());
+    return super.readAvg(timeUnit);
+  }
+
+  @Override
+  public double readSum() {
+    pruneExpiredEntries(System.currentTimeMillis());
+    return super.readSum();
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/BucketizedSlidingWindow.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/BucketizedSlidingWindow.java
@@ -30,14 +30,14 @@ public class BucketizedSlidingWindow extends SlidingWindow<SlidingWindowData> {
   public BucketizedSlidingWindow(int SLIDING_WINDOW_SIZE, int BUCKET_WINDOW_SIZE, TimeUnit timeUnit) {
     super(SLIDING_WINDOW_SIZE, timeUnit);
     assert BUCKET_WINDOW_SIZE < SLIDING_WINDOW_SIZE : "BucketWindow size should be less than SlidingWindow size";
-    this.BUCKET_WINDOW_SIZE = timeUnit.toSeconds(BUCKET_WINDOW_SIZE);
+    this.BUCKET_WINDOW_SIZE = timeUnit.toMillis(BUCKET_WINDOW_SIZE);
   }
 
   @Override
   public void next(SlidingWindowData e) {
     if (!windowDeque.isEmpty()) {
       SlidingWindowData firstElement = windowDeque.getFirst();
-      if (TimeUnit.MILLISECONDS.toSeconds(e.getTimeStamp() - firstElement.getTimeStamp()) < BUCKET_WINDOW_SIZE) {
+      if ((e.getTimeStamp() - firstElement.getTimeStamp()) < BUCKET_WINDOW_SIZE) {
         firstElement.value += e.getValue();
         add(e);
         pruneExpiredEntries(e.getTimeStamp());

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/BucketizedSlidingWindow.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/BucketizedSlidingWindow.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
  * The BucketizedSlidingWindow provides a SlidingWindow implementation that can aggregate all
  * inserts within a configured time range, BUCKET_WINDOW_SIZE, into a single data point.
  *
- * <p> All data within a single bucket window time range is summed by default.
+ * <p>All data within a single bucket window time range is summed by default.
  */
 public class BucketizedSlidingWindow extends SlidingWindow<SlidingWindowData> {
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/BucketizedSlidingWindow.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/BucketizedSlidingWindow.java
@@ -37,7 +37,7 @@ public class BucketizedSlidingWindow extends SlidingWindow<SlidingWindowData> {
   public void next(SlidingWindowData e) {
     if (!windowDeque.isEmpty()) {
       SlidingWindowData firstElement = windowDeque.getFirst();
-      if (TimeUnit.MILLISECONDS.toSeconds(e.getTimeStamp() - firstElement.getTimeStamp()) <= BUCKET_WINDOW_SIZE) {
+      if (TimeUnit.MILLISECONDS.toSeconds(e.getTimeStamp() - firstElement.getTimeStamp()) < BUCKET_WINDOW_SIZE) {
         firstElement.value += e.getValue();
         add(e);
         pruneExpiredEntries(e.getTimeStamp());

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/BucketizedSlidingWindow.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/BucketizedSlidingWindow.java
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * The BucketizedSlidingWindow provides a SlidingWindow implementation that can aggregate all
- * inserts within a configured time range, {@link BUCKET_WINDOW_SIZE}, into a single data point.
+ * inserts within a configured time range, BUCKET_WINDOW_SIZE, into a single data point.
  *
  * <p> All data within a single bucket window time range is summed by default.
  */
@@ -39,7 +39,6 @@ public class BucketizedSlidingWindow extends SlidingWindow<SlidingWindowData> {
       SlidingWindowData firstElement = windowDeque.getFirst();
       if (TimeUnit.MILLISECONDS.toSeconds(e.getTimeStamp() - firstElement.getTimeStamp()) <= BUCKET_WINDOW_SIZE) {
         firstElement.value += e.getValue();
-        firstElement.timeStamp = e.getTimeStamp();
         add(e);
         pruneExpiredEntries(e.getTimeStamp());
         return;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/SlidingWindow.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/SlidingWindow.java
@@ -51,16 +51,20 @@ public class SlidingWindow<E extends SlidingWindowData> {
     sum -= e.getValue();
   }
 
-  /**
-   * insert data into the sliding window
-   */
-  public void next(E e) {
+  protected void pruneExpiredEntries(long endTimeStamp) {
     while (!windowDeque.isEmpty()
-        && TimeUnit.MILLISECONDS.toSeconds(e.getTimeStamp() - windowDeque.peekLast().getTimeStamp())
+        && TimeUnit.MILLISECONDS.toSeconds(endTimeStamp - windowDeque.peekLast().getTimeStamp())
         > SLIDING_WINDOW_SIZE) {
       E lastData = windowDeque.pollLast();
       remove(lastData);
     }
+  }
+
+  /**
+   * insert data into the sliding window
+   */
+  public void next(E e) {
+    pruneExpiredEntries(e.getTimeStamp());
     add(e);
     windowDeque.addFirst(e);
   }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/SlidingWindow.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/SlidingWindow.java
@@ -53,8 +53,7 @@ public class SlidingWindow<E extends SlidingWindowData> {
 
   protected void pruneExpiredEntries(long endTimeStamp) {
     while (!windowDeque.isEmpty()
-        && TimeUnit.MILLISECONDS.toSeconds(endTimeStamp - windowDeque.peekLast().getTimeStamp())
-        > SLIDING_WINDOW_SIZE) {
+        && TimeUnit.MILLISECONDS.toSeconds(endTimeStamp - windowDeque.peekLast().getTimeStamp()) > SLIDING_WINDOW_SIZE) {
       E lastData = windowDeque.pollLast();
       remove(lastData);
     }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmActionsAlarmMonitorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmActionsAlarmMonitorTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.jvm;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.AlarmMonitor;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.aggregators.SlidingWindowData;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+
+public class JvmActionsAlarmMonitorTest {
+
+  @Test
+  public void testInit() {
+    AlarmMonitor monitor = new JvmActionsAlarmMonitor();
+    assertTrue(monitor.isHealthy());
+  }
+
+  @Test
+  public void testFlipToUnhealthy() {
+    AlarmMonitor monitor = new JvmActionsAlarmMonitor();
+    JvmActionsAlarmMonitor jvmMonitor = (JvmActionsAlarmMonitor) monitor;
+    long startTimeInMins = TimeUnit.MILLISECONDS.toMinutes(System.currentTimeMillis());
+
+    // Record issues and breach day threshold
+    // (31 issues per bucket as we include boundary data points)
+    long currTime;
+    long thresholdBreachTS = startTimeInMins + 31 * jvmMonitor.DAY_BREACH_THRESHOLD;
+    for (currTime = startTimeInMins; currTime < thresholdBreachTS; currTime++) {
+      monitor.recordIssue(TimeUnit.MINUTES.toMillis(currTime), 1);
+    }
+    assertEquals(5, jvmMonitor.getDayMonitor().size());
+    assertEquals(1, jvmMonitor.getWeekMonitor().size());
+    assertTrue(monitor.isHealthy());
+
+    // More issues within the same day do not add to week monitor
+    for (currTime = thresholdBreachTS; currTime < thresholdBreachTS + 120; currTime++) {
+      monitor.recordIssue(TimeUnit.MINUTES.toMillis(currTime), 1);
+    }
+    assertEquals(1, jvmMonitor.getWeekMonitor().size());
+    assertTrue(jvmMonitor.getDayMonitor().size() > 5);
+    assertTrue(monitor.isHealthy());
+
+    // Add issues after 2 days
+    currTime += TimeUnit.DAYS.toMinutes(2);
+    for (int i = 0; i < jvmMonitor.DAY_BREACH_THRESHOLD; i++) {
+      currTime += 31;
+      monitor.recordIssue(TimeUnit.MINUTES.toMillis(currTime), 1);
+    }
+    assertEquals(jvmMonitor.DAY_BREACH_THRESHOLD, jvmMonitor.getDayMonitor().size());
+    assertEquals(2, jvmMonitor.getWeekMonitor().size());
+    assertFalse(monitor.isHealthy());
+  }
+
+  @Test
+  public void testFlipToHealthy() {
+    AlarmMonitor monitor = new JvmActionsAlarmMonitor();
+    JvmActionsAlarmMonitor jvmMonitor = (JvmActionsAlarmMonitor) monitor;
+    jvmMonitor.setAlarmHealth(false);
+
+    // Since both monitors are empty, the alarm evaluates to healthy
+    assertTrue(monitor.isHealthy());
+
+    // Only day issues present
+    jvmMonitor.setAlarmHealth(false);
+    long currTime = TimeUnit.MILLISECONDS.toMinutes(System.currentTimeMillis());
+    monitor.recordIssue(TimeUnit.MINUTES.toMillis(currTime), 1);
+    assertEquals(1, jvmMonitor.getDayMonitor().size());
+    assertEquals(0, jvmMonitor.getWeekMonitor().size());
+    assertFalse(monitor.isHealthy());
+  }
+
+  @Test
+  public void testFlipToHealthyWithWeekMonitorFlagged() {
+    AlarmMonitor monitor = new JvmActionsAlarmMonitor();
+    JvmActionsAlarmMonitor jvmMonitor = (JvmActionsAlarmMonitor) monitor;
+    jvmMonitor.setAlarmHealth(false);
+
+    jvmMonitor.getWeekMonitor().next(new SlidingWindowData(System.currentTimeMillis(), 1));
+    assertEquals(0, jvmMonitor.getDayMonitor().size());
+    assertEquals(1, jvmMonitor.getWeekMonitor().size());
+    assertFalse(monitor.isHealthy());
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmActionsAlarmMonitorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmActionsAlarmMonitorTest.java
@@ -39,13 +39,12 @@ public class JvmActionsAlarmMonitorTest {
     long startTimeInMins = TimeUnit.MILLISECONDS.toMinutes(System.currentTimeMillis());
 
     // Record issues and breach day threshold
-    // (31 issues per bucket as we include boundary data points)
     long currTime;
-    long thresholdBreachTS = startTimeInMins + 31 * jvmMonitor.DAY_BREACH_THRESHOLD;
+    long thresholdBreachTS = startTimeInMins + 30 * jvmMonitor.DAY_BREACH_THRESHOLD;
     for (currTime = startTimeInMins; currTime < thresholdBreachTS; currTime++) {
       monitor.recordIssue(TimeUnit.MINUTES.toMillis(currTime), 1);
     }
-    assertEquals(5, jvmMonitor.getDayMonitor().size());
+    assertEquals(jvmMonitor.DAY_BREACH_THRESHOLD, jvmMonitor.getDayMonitor().size());
     assertEquals(1, jvmMonitor.getWeekMonitor().size());
     assertTrue(monitor.isHealthy());
 
@@ -60,7 +59,7 @@ public class JvmActionsAlarmMonitorTest {
     // Add issues after 2 days
     currTime += TimeUnit.DAYS.toMinutes(2);
     for (int i = 0; i < jvmMonitor.DAY_BREACH_THRESHOLD; i++) {
-      currTime += 31;
+      currTime += 30;
       monitor.recordIssue(TimeUnit.MINUTES.toMillis(currTime), 1);
     }
     assertEquals(jvmMonitor.DAY_BREACH_THRESHOLD, jvmMonitor.getDayMonitor().size());

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmActionsAlarmMonitorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmActionsAlarmMonitorTest.java
@@ -40,11 +40,11 @@ public class JvmActionsAlarmMonitorTest {
 
     // Record issues and breach day threshold
     long currTime;
-    long thresholdBreachTS = startTimeInMins + 30 * jvmMonitor.DAY_BREACH_THRESHOLD;
+    long thresholdBreachTS = startTimeInMins + 30 * jvmMonitor.getDayBreachThreshold();
     for (currTime = startTimeInMins; currTime < thresholdBreachTS; currTime++) {
       monitor.recordIssue(TimeUnit.MINUTES.toMillis(currTime), 1);
     }
-    assertEquals(jvmMonitor.DAY_BREACH_THRESHOLD, jvmMonitor.getDayMonitor().size());
+    assertEquals(jvmMonitor.getDayBreachThreshold(), jvmMonitor.getDayMonitor().size());
     assertEquals(1, jvmMonitor.getWeekMonitor().size());
     assertTrue(monitor.isHealthy());
 
@@ -58,11 +58,11 @@ public class JvmActionsAlarmMonitorTest {
 
     // Add issues after 2 days
     currTime += TimeUnit.DAYS.toMinutes(2);
-    for (int i = 0; i < jvmMonitor.DAY_BREACH_THRESHOLD; i++) {
+    for (int i = 0; i < jvmMonitor.getDayBreachThreshold(); i++) {
       currTime += 30;
       monitor.recordIssue(TimeUnit.MINUTES.toMillis(currTime), 1);
     }
-    assertEquals(jvmMonitor.DAY_BREACH_THRESHOLD, jvmMonitor.getDayMonitor().size());
+    assertEquals(jvmMonitor.getDayBreachThreshold(), jvmMonitor.getDayMonitor().size());
     assertEquals(2, jvmMonitor.getWeekMonitor().size());
     assertFalse(monitor.isHealthy());
   }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/BucketizedSlidingWindowTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/BucketizedSlidingWindowTest.java
@@ -61,6 +61,21 @@ public class BucketizedSlidingWindowTest {
     assertEquals(6, slidingWindow.readSum(), 0.00000001);
   }
 
+  /**
+   * When events are added frequently, with time between consecutive events being
+   * less than the bucket window size, we should still see aggregated buckets across
+   * the full sliding window timeline.
+   */
+  @Test
+  public void testFrequentEvents() {
+    BucketizedSlidingWindow slidingWindow = new BucketizedSlidingWindow(10, 2, TimeUnit.SECONDS);
+    long currTimeInSecs = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    for (long t = currTimeInSecs; t < currTimeInSecs + 4; t++) {
+      slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(t), 1));
+    }
+    assertEquals(2, slidingWindow.size());
+  }
+
   @Test
   public void testReadAvgWithPartialPruning() {
     BucketizedSlidingWindow slidingWindow = new BucketizedSlidingWindow(10, 1, TimeUnit.SECONDS);
@@ -142,4 +157,8 @@ public class BucketizedSlidingWindowTest {
     assertEquals(0, slidingWindow.size());
   }
 
+  @Test(expected = AssertionError.class)
+  public void testInit() {
+    BucketizedSlidingWindow slidingWindow = new BucketizedSlidingWindow(10, 10, TimeUnit.SECONDS);
+  }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/BucketizedSlidingWindowTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/BucketizedSlidingWindowTest.java
@@ -84,7 +84,7 @@ public class BucketizedSlidingWindowTest {
     slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs - 9), 9));
     slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs - 7), 7));
     assertEquals(3, slidingWindow.windowDeque.size());  // we cannot call slidingWindow.size() as it also prunes expired elements
-    assertEquals((double)(9 + 7)/(double)2, slidingWindow.readAvg(), 0.00000001);
+    assertEquals((double)(9 + 7) / (double)2, slidingWindow.readAvg(), 0.00000001);
     assertEquals(2, slidingWindow.size());
   }
 
@@ -105,7 +105,7 @@ public class BucketizedSlidingWindowTest {
     slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs - 9), 9));
     slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs - 7), 5));
     assertEquals(3, slidingWindow.windowDeque.size());  // we cannot call slidingWindow.size() as it also prunes expired elements
-    assertEquals((double)(9 + 5)/(double)2, slidingWindow.readAvg(TimeUnit.SECONDS), 0.00000001);
+    assertEquals((double)(9 + 5) / (double)2, slidingWindow.readAvg(TimeUnit.SECONDS), 0.00000001);
     assertEquals(2, slidingWindow.size());
   }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/BucketizedSlidingWindowTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/BucketizedSlidingWindowTest.java
@@ -38,7 +38,7 @@ public class BucketizedSlidingWindowTest {
     currTimeInSecs += 3;
 
     // Add data within bucket window size
-    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs + 2), 3));
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs + 1), 3));
     assertEquals(2, slidingWindow.size());
     assertEquals(1 + (2 + 3), slidingWindow.readSum(), 0.00000001);
     currTimeInSecs += 2;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/BucketizedSlidingWindowTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/BucketizedSlidingWindowTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.aggregators;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+
+public class BucketizedSlidingWindowTest {
+
+  @Test
+  public void testBucketization() {
+    BucketizedSlidingWindow slidingWindow = new BucketizedSlidingWindow(10, 2, TimeUnit.SECONDS);
+    long currTimeInSecs = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs), 1));
+    assertEquals(1, slidingWindow.size());
+    assertEquals(1, slidingWindow.readSum(), 0.00000001);
+
+    // Add data after bucket window size
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs + 3), 2));
+    assertEquals(2, slidingWindow.size());
+    assertEquals(1 + 2, slidingWindow.readSum(), 0.00000001);
+    currTimeInSecs += 3;
+
+    // Add data within bucket window size
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs + 2), 3));
+    assertEquals(2, slidingWindow.size());
+    assertEquals(1 + (2 + 3), slidingWindow.readSum(), 0.00000001);
+    currTimeInSecs += 2;
+
+    // Add data outside sliding window size
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs + 6), 4));
+    assertEquals(2, slidingWindow.size());
+    assertEquals((2 + 3) + 4, slidingWindow.readSum(), 0.00000001);
+    currTimeInSecs += 6;
+
+    // Add data at sliding window size boundary
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs + 10), 5));
+    assertEquals(2, slidingWindow.size());
+    assertEquals(4 + 5, slidingWindow.readSum(), 0.00000001);
+    currTimeInSecs += 10;
+
+    // Add data outside sliding window
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs + 11), 6));
+    assertEquals(1, slidingWindow.size());
+    assertEquals(6, slidingWindow.readSum(), 0.00000001);
+  }
+
+  @Test
+  public void testReadAvgWithPartialPruning() {
+    BucketizedSlidingWindow slidingWindow = new BucketizedSlidingWindow(10, 1, TimeUnit.SECONDS);
+    long currTimeInSecs = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs - 11), 11));
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs - 9), 9));
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs - 7), 7));
+    assertEquals(3, slidingWindow.windowDeque.size());  // we cannot call slidingWindow.size() as it also prunes expired elements
+    assertEquals((double)(9 + 7)/(double)2, slidingWindow.readAvg(), 0.00000001);
+    assertEquals(2, slidingWindow.size());
+  }
+
+  @Test
+  public void testReadAvgWithFullPruning() {
+    BucketizedSlidingWindow slidingWindow = new BucketizedSlidingWindow(10, 1, TimeUnit.SECONDS);
+    long currTimeInSecs = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs - 11), 11));
+    assertTrue(Double.isNaN(slidingWindow.readAvg()));
+    assertEquals(0, slidingWindow.size());
+  }
+
+  @Test
+  public void testReadTimeAvgWithPartialPruning() {
+    BucketizedSlidingWindow slidingWindow = new BucketizedSlidingWindow(10, 1, TimeUnit.SECONDS);
+    long currTimeInSecs = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs - 11), 11));
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs - 9), 9));
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs - 7), 5));
+    assertEquals(3, slidingWindow.windowDeque.size());  // we cannot call slidingWindow.size() as it also prunes expired elements
+    assertEquals((double)(9 + 5)/(double)2, slidingWindow.readAvg(TimeUnit.SECONDS), 0.00000001);
+    assertEquals(2, slidingWindow.size());
+  }
+
+  @Test
+  public void testReadTimeAvgWithFullPruning() {
+    BucketizedSlidingWindow slidingWindow = new BucketizedSlidingWindow(10, 1, TimeUnit.SECONDS);
+    long currTimeInSecs = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs - 11), 11));
+    assertTrue(Double.isNaN(slidingWindow.readAvg(TimeUnit.SECONDS)));
+    assertEquals(0, slidingWindow.size());
+  }
+
+  @Test
+  public void testReadSumWithPartialPruning() {
+    BucketizedSlidingWindow slidingWindow = new BucketizedSlidingWindow(10, 1, TimeUnit.SECONDS);
+    long currTimeInSecs = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs - 11), 11));
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs - 9), 9));
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs - 7), 5));
+    assertEquals(3, slidingWindow.windowDeque.size());  // we cannot call slidingWindow.size() as it also prunes expired elements
+    assertEquals((double)(9 + 5), slidingWindow.readSum(), 0.00000001);
+    assertEquals(2, slidingWindow.size());
+  }
+
+  @Test
+  public void testReadSumWithFullPruning() {
+    BucketizedSlidingWindow slidingWindow = new BucketizedSlidingWindow(10, 1, TimeUnit.SECONDS);
+    long currTimeInSecs = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs - 11), 11));
+    assertEquals(0, slidingWindow.readSum(), 0.000001);
+    assertEquals(0, slidingWindow.size());
+  }
+
+  @Test
+  public void testSizeWithPartialPruning() {
+    BucketizedSlidingWindow slidingWindow = new BucketizedSlidingWindow(10, 1, TimeUnit.SECONDS);
+    long currTimeInSecs = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs - 11), 11));
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs - 9), 9));
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs - 7), 5));
+    assertEquals(2, slidingWindow.size());
+  }
+
+  @Test
+  public void testSizeWithFullPruning() {
+    BucketizedSlidingWindow slidingWindow = new BucketizedSlidingWindow(10, 1, TimeUnit.SECONDS);
+    long currTimeInSecs = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    slidingWindow.next(new SlidingWindowData(TimeUnit.SECONDS.toMillis(currTimeInSecs - 11), 11));
+    assertEquals(0, slidingWindow.size());
+  }
+
+}


### PR DESCRIPTION
This change adds a bucketized sliding window implementation.
The `BucketizedSlidingWindow` provides a `SlidingWindow` that can aggregate all inserts within a configured time range, (BUCKET_WINDOW_SIZE), into a single data point.

Further, the bucketized sliding windows are used to create an alarm monitor for jvm actions.

**Tests:** Added unit tests

*If new tests are added, how long do the new ones take to complete*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
