### PR TITLE
Add disk usage metrics

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerApp.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerApp.java
@@ -52,6 +52,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.threads.exception
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.sun.net.httpserver.HttpServer;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -126,6 +127,11 @@ public class PerformanceAnalyzerApp {
       startGrpcServerThread(clientServers.getNetServer(), THREAD_PROVIDER);
       startWebServerThread(clientServers.getHttpServer(), THREAD_PROVIDER);
       startRcaTopLevelThread(clientServers, connectionManager, appContext, THREAD_PROVIDER);
+
+      long start = System.currentTimeMillis();
+
+      LOG.error("kak main: total size = {}. Took: {}", new File(Util.DATA_DIR).getTotalSpace(),
+          System.currentTimeMillis() - start);
     } else {
       LOG.error("Performance analyzer app stopped due to invalid config status.");
       StatsCollector.instance().logException(StatExceptionCode.READER_THREAD_STOPPED);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerApp.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerApp.java
@@ -52,7 +52,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.threads.exception
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.sun.net.httpserver.HttpServer;
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -127,11 +126,6 @@ public class PerformanceAnalyzerApp {
       startGrpcServerThread(clientServers.getNetServer(), THREAD_PROVIDER);
       startWebServerThread(clientServers.getHttpServer(), THREAD_PROVIDER);
       startRcaTopLevelThread(clientServers, connectionManager, appContext, THREAD_PROVIDER);
-
-      long start = System.currentTimeMillis();
-
-      LOG.error("kak main: total size = {}. Took: {}", new File(Util.DATA_DIR).getTotalSpace(),
-          System.currentTimeMillis() - start);
     } else {
       LOG.error("Performance analyzer app stopped due to invalid config status.");
       StatsCollector.instance().logException(StatExceptionCode.READER_THREAD_STOPPED);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MountedPartitionMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MountedPartitionMetrics.java
@@ -1,0 +1,47 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.DevicePartitionDimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.DevicePartitionValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MountedPartitionMetrics extends MetricStatus {
+  private final String mountPoint;
+  private final String devicePartition;
+  private final long totalSpace;
+  private final long freeSpace;
+  private final long usableFreeSpace;
+
+  public MountedPartitionMetrics(String devicePartition, String mountPoint, long totalSpace,
+      long freeSpace, long usableFreeSpace) {
+    this.devicePartition = devicePartition;
+    this.mountPoint = mountPoint;
+    this.totalSpace = totalSpace;
+    this.freeSpace = freeSpace;
+    this.usableFreeSpace = usableFreeSpace;
+  }
+
+  @JsonProperty(DevicePartitionDimension.Constants.MOUNT_POINT_VALUE)
+  public String getMountPoint() {
+    return mountPoint;
+  }
+
+  @JsonProperty(DevicePartitionDimension.Constants.DEVICE_PARTITION_VALUE)
+  public String getDevicePartition() {
+    return devicePartition;
+  }
+
+  @JsonProperty(DevicePartitionValue.Constants.TOTAL_SPACE_VALUE)
+  public long getTotalSpace() {
+    return totalSpace;
+  }
+
+  @JsonProperty(DevicePartitionValue.Constants.FREE_SPACE_VALUE)
+  public long getFreeSpace() {
+    return freeSpace;
+  }
+
+  @JsonProperty(DevicePartitionValue.Constants.USABLE_FREE_SPACE_VALUE)
+  public long getUsableFreeSpace() {
+    return usableFreeSpace;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MountedPartitionMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MountedPartitionMetricsCollector.java
@@ -1,0 +1,65 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.OSMetricsGeneratorFactory;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsProcessor;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics_generator.MountedPartitionMetricsGenerator;
+import java.util.Set;
+
+public class MountedPartitionMetricsCollector extends PerformanceAnalyzerMetricsCollector implements
+    MetricsProcessor {
+
+  private static final int SAMPLING_TIME_INTERVAL =
+      MetricsConfiguration.CONFIG_MAP.get(MountedPartitionMetricsCollector.class).samplingInterval;
+  private static final int EXPECTED_KEYS_PATH_LENGTH = 0;
+  private final StringBuilder value;
+
+  public MountedPartitionMetricsCollector() {
+    super(SAMPLING_TIME_INTERVAL, "MountedPartition");
+    this.value = new StringBuilder();
+  }
+
+  @Override
+  void collectMetrics(long startTime) {
+    MountedPartitionMetricsGenerator mountedPartitionMetricsGenerator =
+        OSMetricsGeneratorFactory.getInstance().getMountedPartitionMetricsGenerator();
+
+    mountedPartitionMetricsGenerator.addSample();
+
+    saveMetricValues(getMetrics(mountedPartitionMetricsGenerator), startTime);
+  }
+
+  @Override
+  public String getMetricsPath(long startTime, String... keysPath) {
+    if (keysPath != null && keysPath.length != EXPECTED_KEYS_PATH_LENGTH) {
+      throw new RuntimeException("keys length should be " + EXPECTED_KEYS_PATH_LENGTH);
+    }
+
+    return PerformanceAnalyzerMetrics.generatePath(startTime,
+        PerformanceAnalyzerMetrics.sMountedPartitionMetricsPath);
+  }
+
+  private String getMetrics(
+      final MountedPartitionMetricsGenerator mountedPartitionMetricsGenerator) {
+    // zero the string builder
+    value.setLength(0);
+
+    // first line is the timestamp
+    value.append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds())
+         .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+
+    Set<String> mountPoints = mountedPartitionMetricsGenerator.getAllMountPoints();
+    for (String mountPoint : mountPoints) {
+      value.append(
+          new MountedPartitionMetrics(
+              mountedPartitionMetricsGenerator.getDevicePartition(mountPoint),
+              mountPoint,
+              mountedPartitionMetricsGenerator.getTotalSpace(mountPoint),
+              mountedPartitionMetricsGenerator.getFreeSpace(mountPoint),
+              mountedPartitionMetricsGenerator.getUsableFreeSpace(mountPoint)).serialize())
+           .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+    }
+    return value.toString();
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/PerformanceAnalyzerMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/PerformanceAnalyzerMetricsCollector.java
@@ -59,7 +59,7 @@ public abstract class PerformanceAnalyzerMetricsCollector implements Runnable {
       // - should not be any...but in case, absorbing here
       // - logging...we shouldn't be doing as it will slow down; as well as fill up the log. Need to
       // find a way to catch these
-      LOG.debug(
+      LOG.error(
           "Error In Collect Metrics: {} with ExceptionCode: {}",
           () -> ex.toString(),
           () -> StatExceptionCode.OTHER_COLLECTION_ERROR.toString());

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/hwnet/MountedPartitions.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/hwnet/MountedPartitions.java
@@ -1,0 +1,86 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.hwnet;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MountedPartitionMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics_generator.MountedPartitionMetricsGenerator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics_generator.linux.LinuxMountedPartitionMetricsGenerator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.os.SchemaFileParser;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.os.SchemaFileParser.FieldTypes;
+import com.google.common.collect.ImmutableSet;
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class MountedPartitions {
+
+  private static final String CGROUP = "cgroup";
+  private static final String PROC = "proc";
+  private static final String SYSFS = "sysfs";
+  private static final String DEV_PTS = "devpts";
+  private static final String DEV_TMPFS = "devtmpfs";
+  private static final String PATH_SYS = "/sys/";
+  private static final String PATH_ETC = "/etc/";
+  private static final String KEY_DEVICE_PARTITION = "devicePartition";
+  private static final String KEY_MOUNT_POINT = "mountPoint";
+  private static final String KEY_FILE_SYSTEM_TYPE = "fileSystemType";
+  private static final String KEY_MOUNT_OPTIONS = "mountOptions";
+  private static final String KEY_DUMP = "dump";
+  private static final String KEY_PASS = "pass";
+  private static final String NONE = "none";
+  private static final LinuxMountedPartitionMetricsGenerator linuxMountedPartitionMetricsGenerator;
+  private static final Map<String, File> mountPointFileMap;
+  private static final Set<String> virtualSysPartitionSet;
+  private static final Set<String> ignoredMountPoints;
+  private static final String[] schemaKeys = {
+      KEY_DEVICE_PARTITION,
+      KEY_MOUNT_POINT,
+      KEY_FILE_SYSTEM_TYPE,
+      KEY_MOUNT_OPTIONS,
+      KEY_DUMP,
+      KEY_PASS
+  };
+  private static final FieldTypes[] schemaKeyTypes = {
+      FieldTypes.STRING,  // devicePartition
+      FieldTypes.STRING,  // mountPoint
+      FieldTypes.STRING,  // fileSystemType
+      FieldTypes.STRING,  // mountOptions
+      FieldTypes.INT,     // dump
+      FieldTypes.INT      // pass
+  };
+
+  static {
+    linuxMountedPartitionMetricsGenerator = new LinuxMountedPartitionMetricsGenerator();
+    mountPointFileMap = new HashMap<>();
+    virtualSysPartitionSet = ImmutableSet.of(CGROUP, PROC, SYSFS, DEV_PTS, DEV_TMPFS, NONE);
+    ignoredMountPoints = ImmutableSet.of(PATH_SYS, PATH_ETC);
+  }
+
+  public static void addSample() {
+    SchemaFileParser parser = new SchemaFileParser("/proc/mounts", schemaKeys, schemaKeyTypes);
+    List<Map<String, Object>> parsedMaps = parser.parseMultiple().stream().filter(map -> {
+      String devicePartition = (String) map.get(KEY_DEVICE_PARTITION);
+      String mountPoint = (String) map.get(KEY_MOUNT_POINT);
+
+      return !(virtualSysPartitionSet.contains(devicePartition) || !devicePartition.startsWith(
+          "/dev/") || ignoredMountPoints.contains(mountPoint));
+    }).collect(Collectors.toList());
+    for (Map<String, Object> mountInfo : parsedMaps) {
+      String devicePartition = (String) mountInfo.get(KEY_DEVICE_PARTITION);
+      String mountPoint = (String) mountInfo.get(KEY_MOUNT_POINT);
+
+      long totalSpace = mountPointFileMap.computeIfAbsent(mountPoint, File::new).getTotalSpace();
+      long freeSpace = mountPointFileMap.get(mountPoint).getFreeSpace();
+      long usableFreeSpace = mountPointFileMap.get(mountPoint).getUsableSpace();
+      MountedPartitionMetrics metrics = new MountedPartitionMetrics(devicePartition, mountPoint,
+          totalSpace, freeSpace, usableFreeSpace);
+
+      linuxMountedPartitionMetricsGenerator.addSupplier(mountPoint, metrics);
+    }
+  }
+
+  public static MountedPartitionMetricsGenerator getLinuxMountedPartitionMetricsGenerator() {
+    return linuxMountedPartitionMetricsGenerator;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/AllMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/AllMetrics.java
@@ -40,7 +40,8 @@ public class AllMetrics {
     IP_METRICS,
     THREAD_POOL,
     SHARD_STATS,
-    MASTER_PENDING
+    MASTER_PENDING,
+    MOUNTED_PARTITION_METRICS
   }
 
   // we don't store node details as a metric on reader side database.  We
@@ -370,7 +371,6 @@ public class AllMetrics {
     }
   }
 
-
   public enum DiskDimension implements MetricDimension {
     DISK_NAME(Constants.NAME_VALUE);
 
@@ -412,6 +412,52 @@ public class AllMetrics {
       public static final String WAIT_VALUE = "Disk_WaitTime";
 
       public static final String SRATE_VALUE = "Disk_ServiceRate";
+    }
+  }
+
+  public enum DevicePartitionDimension implements MetricDimension {
+    MOUNT_POINT(Constants.MOUNT_POINT_VALUE),
+    DEVICE_PARTITION(Constants.DEVICE_PARTITION_VALUE);
+
+    private final String value;
+
+    DevicePartitionDimension(final String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return this.value;
+    }
+
+    public static class Constants {
+
+      public static final String MOUNT_POINT_VALUE = "MountPoint";
+      public static final String DEVICE_PARTITION_VALUE = "DevicePartition";
+    }
+  }
+
+  public enum DevicePartitionValue implements MetricValue {
+    TOTAL_SPACE(Constants.TOTAL_SPACE_VALUE),
+    FREE_SPACE(Constants.FREE_SPACE_VALUE),
+    USABLE_FREE_SPACE(Constants.USABLE_FREE_SPACE_VALUE);
+
+    private final String value;
+
+    DevicePartitionValue(final String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return this.value;
+    }
+
+    public static class Constants {
+
+      public static final String TOTAL_SPACE_VALUE = "Partition_TotalSpace";
+      public static final String FREE_SPACE_VALUE = "Partition_FreeSpace";
+      public static final String USABLE_FREE_SPACE_VALUE = "Partition_UsableFreeSpace";
     }
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/MetricsConfiguration.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/MetricsConfiguration.java
@@ -19,9 +19,9 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.DisksC
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.GCInfoCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.HeapMetricsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MetricsPurgeActivity;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MountedPartitionMetricsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.NetworkE2ECollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.NetworkInterfaceCollector;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MountedPartitionMetricsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.jvm.GCMetrics;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/MetricsConfiguration.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/MetricsConfiguration.java
@@ -21,6 +21,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.HeapMe
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MetricsPurgeActivity;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.NetworkE2ECollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.NetworkInterfaceCollector;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MountedPartitionMetricsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.jvm.GCMetrics;
@@ -74,5 +75,6 @@ public class MetricsConfiguration {
     CONFIG_MAP.put(DisksCollector.class, cdefault);
     CONFIG_MAP.put(HeapMetricsCollector.class, cdefault);
     CONFIG_MAP.put(GCInfoCollector.class, cdefault);
+    CONFIG_MAP.put(MountedPartitionMetricsCollector.class, cdefault);
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
@@ -52,6 +52,7 @@ public class PerformanceAnalyzerMetrics {
   public static final String sTCPPath = "tcp_metrics";
   public static final String sIPPath = "ip_metrics";
   public static final String sGcInfoPath = "gc_info";
+  public static final String sMountedPartitionMetricsPath = "mounted_part_space";
   public static final String sKeyValueDelimitor = ":";
   public static final String sMetricNewLineDelimitor = System.getProperty("line.separator");
   public static final String START_FILE_NAME = "start";

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics_generator/MountedPartitionMetricsGenerator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics_generator/MountedPartitionMetricsGenerator.java
@@ -1,0 +1,17 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics_generator;
+
+import java.util.Set;
+
+public interface MountedPartitionMetricsGenerator {
+  void addSample();
+
+  Set<String> getAllMountPoints();
+
+  String getDevicePartition(String mountPoint);
+
+  long getTotalSpace(String mountPoint);
+
+  long getFreeSpace(String mountPoint);
+
+  long getUsableFreeSpace(String mountPoint);
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics_generator/OSMetricsGenerator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics_generator/OSMetricsGenerator.java
@@ -34,4 +34,6 @@ public interface OSMetricsGenerator {
   IPMetricsGenerator getIPMetricsGenerator();
 
   DiskMetricsGenerator getDiskMetricsGenerator();
+
+  MountedPartitionMetricsGenerator getMountedPartitionMetricsGenerator();
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics_generator/linux/LinuxMountedPartitionMetricsGenerator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics_generator/linux/LinuxMountedPartitionMetricsGenerator.java
@@ -1,0 +1,48 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics_generator.linux;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MountedPartitionMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.hwnet.MountedPartitions;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics_generator.MountedPartitionMetricsGenerator;
+import com.google.common.collect.ImmutableSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class LinuxMountedPartitionMetricsGenerator implements MountedPartitionMetricsGenerator {
+  private static final Map<String, MountedPartitionMetrics> suppliers = new HashMap<>();
+
+  @Override
+  public void addSample() {
+    MountedPartitions.addSample();
+  }
+
+  @Override
+  public Set<String> getAllMountPoints() {
+    return ImmutableSet.copyOf(suppliers.keySet());
+  }
+
+  public void addSupplier(final String mountPoint,
+      final MountedPartitionMetrics supplier) {
+    suppliers.put(mountPoint, supplier);
+  }
+
+  @Override
+  public String getDevicePartition(final String mountPoint) {
+    return suppliers.get(mountPoint).getDevicePartition();
+  }
+
+  @Override
+  public long getTotalSpace(final String mountPoint) {
+    return suppliers.get(mountPoint).getTotalSpace();
+  }
+
+  @Override
+  public long getFreeSpace(final String mountPoint) {
+    return suppliers.get(mountPoint).getFreeSpace();
+  }
+
+  @Override
+  public long getUsableFreeSpace(final String mountPoint) {
+    return suppliers.get(mountPoint).getUsableFreeSpace();
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics_generator/linux/LinuxOSMetricsGenerator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics_generator/linux/LinuxOSMetricsGenerator.java
@@ -16,12 +16,14 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics_generator.linux;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.hwnet.Disks;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.hwnet.MountedPartitions;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.hwnet.NetworkE2E;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.hwnet.NetworkInterface;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics_generator.CPUPagingActivityGenerator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics_generator.DiskIOMetricsGenerator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics_generator.DiskMetricsGenerator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics_generator.IPMetricsGenerator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics_generator.MountedPartitionMetricsGenerator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics_generator.OSMetricsGenerator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics_generator.SchedMetricsGenerator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics_generator.TCPMetricsGenerator;
@@ -89,5 +91,10 @@ public class LinuxOSMetricsGenerator implements OSMetricsGenerator {
   public DiskMetricsGenerator getDiskMetricsGenerator() {
 
     return Disks.getDiskMetricsHandler();
+  }
+
+  @Override
+  public MountedPartitionMetricsGenerator getMountedPartitionMetricsGenerator() {
+    return MountedPartitions.getLinuxMountedPartitionMetricsGenerator();
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MetricPropertiesConfig.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MetricPropertiesConfig.java
@@ -20,6 +20,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetric
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CacheConfigValue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CircuitBreakerDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CircuitBreakerValue;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.DevicePartitionDimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.DevicePartitionValue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.DiskDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.DiskValue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.HeapDimension;
@@ -164,6 +166,8 @@ public final class MetricPropertiesConfig {
     metricPathMap.put(MetricName.THREAD_POOL, PerformanceAnalyzerMetrics.sThreadPoolPath);
     metricPathMap.put(MetricName.SHARD_STATS, PerformanceAnalyzerMetrics.sIndicesPath);
     metricPathMap.put(MetricName.MASTER_PENDING, PerformanceAnalyzerMetrics.sPendingTasksPath);
+    metricPathMap.put(MetricName.MOUNTED_PARTITION_METRICS,
+        PerformanceAnalyzerMetrics.sMountedPartitionMetricsPath);
 
     eventKeyToMetricNameMap = new HashMap<>();
     eventKeyToMetricNameMap.put(PerformanceAnalyzerMetrics.sCacheConfigPath, MetricName.CACHE_CONFIG);
@@ -177,6 +181,8 @@ public final class MetricPropertiesConfig {
     eventKeyToMetricNameMap.put(PerformanceAnalyzerMetrics.sIndicesPath, MetricName.SHARD_STATS);
     eventKeyToMetricNameMap.put(
         PerformanceAnalyzerMetrics.sPendingTasksPath, MetricName.MASTER_PENDING);
+    eventKeyToMetricNameMap.put(PerformanceAnalyzerMetrics.sMountedPartitionMetricsPath,
+        MetricName.MOUNTED_PARTITION_METRICS);
 
     metricName2Property = new HashMap<>();
 
@@ -238,6 +244,12 @@ public final class MetricPropertiesConfig {
                 metricPathMap.get(MetricName.MASTER_PENDING),
                 PerformanceAnalyzerMetrics.MASTER_CURRENT,
                 PerformanceAnalyzerMetrics.MASTER_META_DATA)));
+    metricName2Property.put(MetricName.MOUNTED_PARTITION_METRICS,
+        new MetricProperties(
+            DevicePartitionDimension.values(),
+            DevicePartitionValue.values(),
+            createFileHandler(metricPathMap.get(MetricName.MOUNTED_PARTITION_METRICS))
+        ));
   }
 
   public static MetricPropertiesConfig getInstance() {


### PR DESCRIPTION
*Fixes #:*

*Description of changes:*
This change adds disk space metrics.
Our current disk utilization metric only tracks the utilization rate(reads/s + writes/s) in the last 5 seconds.

In order for the under utilization RCA to detect under utilization of disks we need both low service rate and low usage of disk space.

Since the concept of a disk applies to the operating system more than to Java(which interfaces through file systems which abstract out the physical disk device construct), we measure the space available on a mounted partition. This change adds the following metrics: `Partition_TotalSpace`, `Partition_FreeSpace`, and `Partition_UsableFreeSpace` metrics to the metricsDB.

The metrics parses the output of `/proc/mounts` and ignores virtual devices and system related mountpoints.

*Tests:*
Tested on docker.
```
sqlite> select * from Partition_TotalSpace;
/usr/share/elasticsearch/data|/dev/vda1|62725623808.0|62725623808.0|62725623808.0|62725623808.0

sqlite> select * from Partition_FreeSpace;
/usr/share/elasticsearch/data|/dev/vda1|28551467008.0|28551467008.0|28551467008.0|28551467008.0
```

UTs incoming.

*If new tests are added, how long do the new ones take to complete*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
