### PR TITLE
Adding the Support of Retrieving Actions Persisted via an API

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,48 @@ The sample response from above api
 
 ```
 {
-    "LastSuggestedActionSet": "[{\"nodeIps\":\"{1.1.1.1,2.2.2.2}\",\"muted\":false,\"actionName\":\"M1\",\"timestamp\":1602190468123,\"nodeIds\":\"{1,2}\",\"summary\":\"MockSummary\",\"actionable\":false,\"coolOffPeriod\":0},
-                                {\"nodeIps\":\"{1.1.1.1,2.2.2.2}\",\"muted\":false,\"actionName\":\"M2\",\"timestamp\":1602190468123,\"nodeIds\":\"{1,2}\",\"summary\":\"MockSummary\",\"actionable\":false,\"coolOffPeriod\":0}]"
+    "LastSuggestedActionSet": [
+        {
+            "actionName": "MockAction1",
+            "actionable": false,
+            "coolOffPeriod": 10,
+            "muted": false,
+            "nodeIds": "1,11",
+            "nodeIps": "1.1.1.1,11.11.11.11",
+            "summary": "MockSummary",
+            "timestamp": 1602538860025
+        },
+        {
+            "actionName": "MockAction2",
+            "actionable": false,
+            "coolOffPeriod": 20,
+            "muted": false,
+            "nodeIds": "2,22",
+            "nodeIps": "2.2.2.2,22.22.22.22",
+            "summary": "MockSummary",
+            "timestamp": 1602538860025
+        },
+        {
+            "actionName": "MockAction1",
+            "actionable": false,
+            "coolOffPeriod": 30,
+            "muted": false,
+            "nodeIds": "1,11",
+            "nodeIps": "1.1.1.1,11.11.11.11",
+            "summary": "MockSummary",
+            "timestamp": 1602538860025
+        },
+        {
+            "actionName": "MockAction2",
+            "actionable": false,
+            "coolOffPeriod": 40,
+            "muted": false,
+            "nodeIds": "2,22",
+            "nodeIps": "2.2.2.2,22.22.22.22",
+            "summary": "MockSummary",
+            "timestamp": 1602538860025
+        }
+    ]
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -124,6 +124,25 @@ In order to get the temperature of a particular node, we can use:
 
 `curl "localhost:9600/_opendistro/_performanceanalyzer/rca?name=AllTemperatureDimensions&local=true"`
 
+## Actions API
+This API provides the last suggested action set via the Decision Maker framework. All the suggested action sets are persisted in the SQL tables. This API provides the action set which was published with the latest timestamp.
+
+
+### SAMPLE REQUEST
+
+GET `_opendistro/_performanceanalyzer/actions`
+
+The sample response from above api
+
+```
+{
+    "LastSuggestedActionSet": "[{\"nodeIps\":\"{1.1.1.1,2.2.2.2}\",\"muted\":false,\"actionName\":\"M1\",\"timestamp\":1602190468123,\"nodeIds\":\"{1,2}\",\"summary\":\"MockSummary\",\"actionable\":false,\"coolOffPeriod\":0},
+                                {\"nodeIps\":\"{1.1.1.1,2.2.2.2}\",\"muted\":false,\"actionName\":\"M2\",\"timestamp\":1602190468123,\"nodeIds\":\"{1,2}\",\"summary\":\"MockSummary\",\"actionable\":false,\"coolOffPeriod\":0}]"
+}
+
+```
+
+
 ## Building, Deploying, and Running the RCA Framework
 Please refer to the [Install Guide](./INSTALL.md) for detailed information on building, installing and running the RCA framework.
 

--- a/README.md
+++ b/README.md
@@ -124,65 +124,6 @@ In order to get the temperature of a particular node, we can use:
 
 `curl "localhost:9600/_opendistro/_performanceanalyzer/rca?name=AllTemperatureDimensions&local=true"`
 
-## Actions API
-This API provides the last suggested action set via the Decision Maker framework. All the suggested action sets are persisted in the SQL tables. This API provides the action set which was published with the latest timestamp.
-
-
-### SAMPLE REQUEST
-
-GET `_opendistro/_performanceanalyzer/actions`
-
-The sample response from above api
-
-```
-{
-    "LastSuggestedActionSet": [
-        {
-            "actionName": "MockAction1",
-            "actionable": false,
-            "coolOffPeriod": 10,
-            "muted": false,
-            "nodeIds": "1,11",
-            "nodeIps": "1.1.1.1,11.11.11.11",
-            "summary": "MockSummary",
-            "timestamp": 1602538860025
-        },
-        {
-            "actionName": "MockAction2",
-            "actionable": false,
-            "coolOffPeriod": 20,
-            "muted": false,
-            "nodeIds": "2,22",
-            "nodeIps": "2.2.2.2,22.22.22.22",
-            "summary": "MockSummary",
-            "timestamp": 1602538860025
-        },
-        {
-            "actionName": "MockAction1",
-            "actionable": false,
-            "coolOffPeriod": 30,
-            "muted": false,
-            "nodeIds": "1,11",
-            "nodeIps": "1.1.1.1,11.11.11.11",
-            "summary": "MockSummary",
-            "timestamp": 1602538860025
-        },
-        {
-            "actionName": "MockAction2",
-            "actionable": false,
-            "coolOffPeriod": 40,
-            "muted": false,
-            "nodeIds": "2,22",
-            "nodeIps": "2.2.2.2,22.22.22.22",
-            "summary": "MockSummary",
-            "timestamp": 1602538860025
-        }
-    ]
-}
-
-```
-
-
 ## Building, Deploying, and Running the RCA Framework
 Please refer to the [Install Guide](./INSTALL.md) for detailed information on building, installing and running the RCA framework.
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/core/Util.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/core/Util.java
@@ -27,6 +27,7 @@ public class Util {
   private static final Logger LOG = LogManager.getLogger(Util.class);
   public static final String METRICS_QUERY_URL = "/_opendistro/_performanceanalyzer/metrics";
   public static final String RCA_QUERY_URL = "/_opendistro/_performanceanalyzer/rca";
+  public static final String ACTIONS_QUERY_URL = "/_opendistro/_performanceanalyzer/actions";
   public static final String ES_HOME = System.getProperty("es.path.home");
   // TODO: Make this configurable.
   public static final int RPC_PORT = 9650;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/Publisher.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/Publisher.java
@@ -61,6 +61,7 @@ public class Publisher extends NonLeafNode<EmptyFlowUnit> {
    */
   public void compute(FlowUnitOperationArgWrapper args) {
     // TODO: Need to add dampening, avoidance etc.
+    List <Action> actionsPublished = new ArrayList<>();
     if (!collator.getFlowUnits().isEmpty()) {
       Decision decision = collator.getFlowUnits().get(0);
       for (Action action : decision.getActions()) {
@@ -69,12 +70,13 @@ public class Publisher extends NonLeafNode<EmptyFlowUnit> {
           for (ActionListener listener : actionListeners) {
             listener.actionPublished(action);
           }
-          // Persist actions to sqlite
-          PublisherEventsPersistor persistor = new PublisherEventsPersistor(args.getPersistable());
-          persistor.persistAction(action);
+          actionsPublished.add(action);
         }
       }
     }
+    // Persist actions to sqlite
+    PublisherEventsPersistor persistor = new PublisherEventsPersistor(args.getPersistable());
+    persistor.persistAction(actionsPublished);
   }
 
   @Override

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/Publisher.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/Publisher.java
@@ -76,7 +76,7 @@ public class Publisher extends NonLeafNode<EmptyFlowUnit> {
     }
     // Persist actions to sqlite
     PublisherEventsPersistor persistor = new PublisherEventsPersistor(args.getPersistable());
-    persistor.persistAction(actionsPublished);
+    persistor.persistAction(actionsPublished, Instant.now().toEpochMilli());
   }
 
   @Override

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/Publisher.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/Publisher.java
@@ -61,7 +61,7 @@ public class Publisher extends NonLeafNode<EmptyFlowUnit> {
    */
   public void compute(FlowUnitOperationArgWrapper args) {
     // TODO: Need to add dampening, avoidance etc.
-    List <Action> actionsPublished = new ArrayList<>();
+    List<Action> actionsPublished = new ArrayList<>();
     if (!collator.getFlowUnits().isEmpty()) {
       Decision decision = collator.getFlowUnits().get(0);
       for (Action action : decision.getActions()) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/SQLiteQueryUtils.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/SQLiteQueryUtils.java
@@ -17,8 +17,6 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.ut
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit.ResourceFlowUnitFieldValue;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.ClusterDimensionalSummary;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.temperature.ClusterTemperatureSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HighHeapUsageClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HotNodeClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.FieldDataCacheClusterRca;
@@ -32,10 +30,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.tem
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.temperature.dimension.ShardSizeDimensionTemperatureRca;
 import com.google.common.collect.ImmutableList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import org.jooq.DSLContext;
 import org.jooq.Field;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
@@ -73,7 +73,8 @@ public interface Persistable {
    * This API reads all the rows from the table corresponding to the maximum value in the field Object.
    * @param clz The Class whose Object is desired.
    * @param <T> The generic type of the class.
-   * @param field DSL field for which the maximum value is desired.
+   * @param fieldName DSL field for which the maximum value is desired.
+   * @param fieldClz Class Type of the field for which the maximum value is desired.
    * @return A List of instantiated Objects of the class with the fields populated with the data from the corresponding rows in the table.
    * @throws NoSuchMethodException If the expected setter does not exist.
    * @throws IllegalAccessException If the setter is not Public
@@ -81,7 +82,7 @@ public interface Persistable {
    * @throws InstantiationException Creating an Object of the class failed for some reason.
    * @throws DataAccessException Thrown by the DB layer.
    */
-  <T, E> @Nullable List<T> readAllForMaxField(Class<T> clz, Field<E> field)
+  <T, E> @Nullable List<T> readAllForMaxField(Class<T> clz, String fieldName, Class<E> fieldClz)
           throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException, DataAccessException;
 
   /**

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
@@ -70,11 +70,11 @@ public interface Persistable {
 
 
   /**
-   * This API reads all the rows from the table for the latest timestamp corresponding to the Object.
+   * This API reads all the rows from the table corresponding to the maximum value in the field Object.
    * @param clz The Class whose Object is desired.
-   * @param <T> The generic type of the class
-   * @return An instantiated Object of the class with the fields populated with the data from the latest row in the table and other
-   *     referenced tables or null if the table does not exist yet.
+   * @param <T> The generic type of the class.
+   * @param field DSL field for which the maximum value is desired.
+   * @return An instantiated Object of the class with the fields populated with the data from the corresponding rows in the table.
    * @throws NoSuchMethodException If the expected setter does not exist.
    * @throws IllegalAccessException If the setter is not Public
    * @throws InvocationTargetException If invoking the setter by reflection threw an exception.

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
@@ -80,7 +80,7 @@ public interface Persistable {
    * @throws InstantiationException Creating an Object of the class failed for some reason.
    * @throws DataAccessException Thrown by the DB layer.
    */
-  <T> @Nullable List<T> readLatestGroup(Class<T> clz)
+  <T> @Nullable List<T> readAllForMaxTimeStamp(Class<T> clz)
           throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException, DataAccessException;
 
   /**

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jooq.Field;
 import org.jooq.Record;
 import org.jooq.Result;
 import org.jooq.exception.DataAccessException;
@@ -80,7 +81,7 @@ public interface Persistable {
    * @throws InstantiationException Creating an Object of the class failed for some reason.
    * @throws DataAccessException Thrown by the DB layer.
    */
-  <T> @Nullable List<T> readAllForMaxTimeStamp(Class<T> clz)
+  <T, E> @Nullable List<T> readAllForMaxField(Class<T> clz, Field<E> field)
           throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException, DataAccessException;
 
   /**

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
@@ -80,7 +80,7 @@ public interface Persistable {
    * @throws InstantiationException Creating an Object of the class failed for some reason.
    * @throws DataAccessException Thrown by the DB layer.
    */
-  <T> @Nullable List<T> readForTimestamp(Class<T> clz)
+  <T> @Nullable List<T> readLatestGroup(Class<T> clz)
           throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException, DataAccessException;
 
   /**

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
@@ -67,6 +67,22 @@ public interface Persistable {
   <T> @Nullable T read(Class<T> clz)
       throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException, DataAccessException;
 
+
+  /**
+   * This API reads all the rows from the table for the latest timestamp corresponding to the Object.
+   * @param clz The Class whose Object is desired.
+   * @param <T> The generic type of the class
+   * @return An instantiated Object of the class with the fields populated with the data from the latest row in the table and other
+   *     referenced tables or null if the table does not exist yet.
+   * @throws NoSuchMethodException If the expected setter does not exist.
+   * @throws IllegalAccessException If the setter is not Public
+   * @throws InvocationTargetException If invoking the setter by reflection threw an exception.
+   * @throws InstantiationException Creating an Object of the class failed for some reason.
+   * @throws DataAccessException Thrown by the DB layer.
+   */
+  <T> @Nullable List<T> readForTimestamp(Class<T> clz)
+          throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException, DataAccessException;
+
   /**
    * Write data to the database.
    *

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/Persistable.java
@@ -74,7 +74,7 @@ public interface Persistable {
    * @param clz The Class whose Object is desired.
    * @param <T> The generic type of the class.
    * @param field DSL field for which the maximum value is desired.
-   * @return An instantiated Object of the class with the fields populated with the data from the corresponding rows in the table.
+   * @return A List of instantiated Objects of the class with the fields populated with the data from the corresponding rows in the table.
    * @throws NoSuchMethodException If the expected setter does not exist.
    * @throws IllegalAccessException If the setter is not Public
    * @throws InvocationTargetException If invoking the setter by reflection threw an exception.

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistor.java
@@ -49,10 +49,10 @@ public class PublisherEventsPersistor {
             if (action.impactedNodes() != null) {
                 final String nodeIds = action.impactedNodes().stream()
                         .map(n -> n.getNodeId().toString())
-                        .collect(Collectors.joining(","));
+                        .collect(Collectors.joining(",", "{", "}"));
                 final String nodeIps = action.impactedNodes().stream()
                         .map(n -> n.getHostAddress().toString())
-                        .collect(Collectors.joining(","));
+                        .collect(Collectors.joining(",", "{", "}"));
                 final PersistedAction actionsSummary = new PersistedAction();
                 actionsSummary.setActionName(action.name());
                 actionsSummary.setNodeIds(nodeIds);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistor.java
@@ -20,7 +20,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.act
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaRuntimeMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
-import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistor.java
@@ -21,6 +21,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.met
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaRuntimeMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
 import java.time.Instant;
+import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -41,33 +42,35 @@ public class PublisherEventsPersistor {
         this.persistable = persistable;
     }
 
-    public void persistAction(final Action action) {
+    public void persistAction(final List<Action> actionsPublished) {
         long timestamp = Instant.now().toEpochMilli();
-        LOG.debug("Action: [{}] published to persistor publisher.", action.name());
-        PerformanceAnalyzerApp.RCA_RUNTIME_METRICS_AGGREGATOR.updateStat(
-                RcaRuntimeMetrics.ACTIONS_PUBLISHED, action.name(), 1);
-        if (action.impactedNodes() != null) {
-            final String nodeIds = action.impactedNodes().stream()
-                                           .map(n -> n.getNodeId().toString())
-                                           .collect(Collectors.joining(",", "{", "}"));
-            final String nodeIps = action.impactedNodes().stream()
-                                           .map(n -> n.getHostAddress().toString())
-                                           .collect(Collectors.joining(",", "{", "}"));
-            final PersistedAction actionsSummary = new PersistedAction();
-            actionsSummary.setActionName(action.name());
-            actionsSummary.setNodeIds(nodeIds);
-            actionsSummary.setNodeIps(nodeIps);
-            actionsSummary.setActionable(action.isActionable());
-            actionsSummary.setCoolOffPeriod(action.coolOffPeriodInMillis());
-            actionsSummary.setMuted(action.isMuted());
-            actionsSummary.setSummary(action.summary());
-            actionsSummary.setTimestamp(timestamp);
-            try {
-                persistable.write(actionsSummary);
-            } catch (Exception e) {
-                LOG.error("Unable to write publisher events to sqlite", e);
-                PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
-                        ExceptionsAndErrors.EXCEPTION_IN_PERSIST, action.name(), 1);
+        for (Action action : actionsPublished) {
+            LOG.debug("Action: [{}] published to persistor publisher.", action.name());
+            PerformanceAnalyzerApp.RCA_RUNTIME_METRICS_AGGREGATOR.updateStat(
+                    RcaRuntimeMetrics.ACTIONS_PUBLISHED, action.name(), 1);
+            if (action.impactedNodes() != null) {
+                final String nodeIds = action.impactedNodes().stream()
+                        .map(n -> n.getNodeId().toString())
+                        .collect(Collectors.joining(",", "{", "}"));
+                final String nodeIps = action.impactedNodes().stream()
+                        .map(n -> n.getHostAddress().toString())
+                        .collect(Collectors.joining(",", "{", "}"));
+                final PersistedAction actionsSummary = new PersistedAction();
+                actionsSummary.setActionName(action.name());
+                actionsSummary.setNodeIds(nodeIds);
+                actionsSummary.setNodeIps(nodeIps);
+                actionsSummary.setActionable(action.isActionable());
+                actionsSummary.setCoolOffPeriod(action.coolOffPeriodInMillis());
+                actionsSummary.setMuted(action.isMuted());
+                actionsSummary.setSummary(action.summary());
+                actionsSummary.setTimestamp(timestamp);
+                try {
+                    persistable.write(actionsSummary);
+                } catch (Exception e) {
+                    LOG.error("Unable to write publisher events to sqlite", e);
+                    PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+                            ExceptionsAndErrors.EXCEPTION_IN_PERSIST, action.name(), 1);
+                }
             }
         }
     }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistor.java
@@ -42,8 +42,7 @@ public class PublisherEventsPersistor {
         this.persistable = persistable;
     }
 
-    public void persistAction(final List<Action> actionsPublished) {
-        long timestamp = Instant.now().toEpochMilli();
+    public void persistAction(final List<Action> actionsPublished, long timestamp) {
         for (Action action : actionsPublished) {
             LOG.debug("Action: [{}] published to persistor publisher.", action.name());
             PerformanceAnalyzerApp.RCA_RUNTIME_METRICS_AGGREGATOR.updateStat(
@@ -51,10 +50,10 @@ public class PublisherEventsPersistor {
             if (action.impactedNodes() != null) {
                 final String nodeIds = action.impactedNodes().stream()
                         .map(n -> n.getNodeId().toString())
-                        .collect(Collectors.joining(",", "{", "}"));
+                        .collect(Collectors.joining(","));
                 final String nodeIps = action.impactedNodes().stream()
                         .map(n -> n.getHostAddress().toString())
-                        .collect(Collectors.joining(",", "{", "}"));
+                        .collect(Collectors.joining(","));
                 final PersistedAction actionsSummary = new PersistedAction();
                 actionsSummary.setActionName(action.name());
                 actionsSummary.setNodeIds(nodeIds);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
@@ -265,10 +265,11 @@ class SQLitePersistor extends PersistorBase {
   }
 
   @Override
-  public synchronized <T, E> @org.checkerframework.checker.nullness.qual.Nullable List<T> readAllForMaxField(Class<T> clz, Field<E> field)
+  public synchronized <T, E> @org.checkerframework.checker.nullness.qual.Nullable List<T> readAllForMaxField(Class<T> clz, String fieldName, Class <E> fieldClz)
           throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException, DataAccessException {
     String tableName = getTableNameFromClassName(clz);
     List<Record> recordsWithMaxFieldValue;
+    Field<E> field = DSL.field(fieldName, fieldClz);
 
     try {
       // Fetch the latest rows with the last timestamp.

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
@@ -265,7 +265,9 @@ class SQLitePersistor extends PersistorBase {
   }
 
   @Override
-  public synchronized <T, E> @org.checkerframework.checker.nullness.qual.Nullable List<T> readAllForMaxField(Class<T> clz, String fieldName, Class <E> fieldClz)
+  public synchronized <T, E> @org.checkerframework.checker.nullness.qual.Nullable List<T> readAllForMaxField(Class<T> clz,
+                                                                                                             String fieldName,
+                                                                                                             Class<E> fieldClz)
           throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException, DataAccessException {
     String tableName = getTableNameFromClassName(clz);
     List<Record> recordsWithMaxFieldValue;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
@@ -263,7 +263,7 @@ class SQLitePersistor extends PersistorBase {
   }
 
   @Override
-  public synchronized <T> @org.checkerframework.checker.nullness.qual.Nullable List<T> readForTimestamp(Class<T> clz)
+  public synchronized <T> @org.checkerframework.checker.nullness.qual.Nullable List<T> readLatestGroup(Class<T> clz)
           throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException, DataAccessException {
     String tableName = getTableNameFromClassName(clz);
     Field<String> actionName = DSL.field(PersistedAction.SQL_SCHEMA_CONSTANTS.ACTION_COL_NAME, String.class);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
@@ -15,8 +15,6 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence;
 
-import static org.jooq.impl.DSL.max;
-
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Resources.State;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit.ResourceFlowUnitFieldValue;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
@@ -268,11 +268,11 @@ class SQLitePersistor extends PersistorBase {
   public synchronized <T, E> @org.checkerframework.checker.nullness.qual.Nullable List<T> readAllForMaxField(Class<T> clz, Field<E> field)
           throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException, DataAccessException {
     String tableName = getTableNameFromClassName(clz);
-    List<Record> maxTimeStampRecordList;
+    List<Record> recordsWithMaxFieldValue;
 
     try {
       // Fetch the latest rows with the last timestamp.
-      maxTimeStampRecordList = create.select().from(tableName).where(DSL.field(field)
+      recordsWithMaxFieldValue = create.select().from(tableName).where(DSL.field(field)
               .eq(create.select(max(field)).from(tableName))).fetch();
     } catch (DataAccessException dex) {
       LOG.error("Error querying table {}", tableName, dex);
@@ -281,8 +281,8 @@ class SQLitePersistor extends PersistorBase {
 
     List<T> objList = new ArrayList<>();
 
-    LOG.debug("Record List {}", maxTimeStampRecordList);
-    for (Record record : maxTimeStampRecordList) {
+    LOG.debug("Record List {}", recordsWithMaxFieldValue);
+    for (Record record : recordsWithMaxFieldValue) {
       objList.add(readFields(clz, record, tableName));
     }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
@@ -54,7 +54,16 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jooq.*;
+import org.jooq.CreateTableConstraintStep;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.InsertValuesStepN;
+import org.jooq.JSONFormat;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.jooq.SQLDialect;
+import org.jooq.SelectJoinStep;
+import org.jooq.Table;
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
 
@@ -256,14 +265,15 @@ class SQLitePersistor extends PersistorBase {
   }
 
   @Override
-  public synchronized <T> @org.checkerframework.checker.nullness.qual.Nullable List<T> readForTimestamp(Class<T> clz) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException, DataAccessException {
+  public synchronized <T> @org.checkerframework.checker.nullness.qual.Nullable List<T> readForTimestamp(Class<T> clz)
+          throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException, DataAccessException {
     String tableName = getTableNameFromClassName(clz);
     Field<String> actionName = DSL.field(PersistedAction.SQL_SCHEMA_CONSTANTS.ACTION_COL_NAME, String.class);
     List<Record> maxTimeStampRecordList;
 
     try {
       // Fetch the latest rows with the last timestamp.
-      maxTimeStampRecordList = create.select().from(tableName).groupBy(actionName).fetch() ;
+      maxTimeStampRecordList = create.select().from(tableName).groupBy(actionName).fetch();
     } catch (DataAccessException dex) {
       LOG.error("Error querying table {}", tableName, dex);
       return null;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
@@ -265,16 +265,15 @@ class SQLitePersistor extends PersistorBase {
   }
 
   @Override
-  public synchronized <T> @org.checkerframework.checker.nullness.qual.Nullable List<T> readAllForMaxTimeStamp(Class<T> clz)
+  public synchronized <T, E> @org.checkerframework.checker.nullness.qual.Nullable List<T> readAllForMaxField(Class<T> clz, Field<E> field)
           throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException, DataAccessException {
     String tableName = getTableNameFromClassName(clz);
-    Field<String> timestamp = DSL.field(PersistedAction.SQL_SCHEMA_CONSTANTS.TIMESTAMP_COL_NAME, String.class);
     List<Record> maxTimeStampRecordList;
 
     try {
       // Fetch the latest rows with the last timestamp.
-      maxTimeStampRecordList = create.select().from(tableName).where(DSL.field(timestamp)
-              .eq(create.select(max(timestamp)).from(tableName))).fetch();
+      maxTimeStampRecordList = create.select().from(tableName).where(DSL.field(field)
+              .eq(create.select(max(field)).from(tableName))).fetch();
     } catch (DataAccessException dex) {
       LOG.error("Error querying table {}", tableName, dex);
       return null;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/actions/PersistedAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/actions/PersistedAction.java
@@ -2,6 +2,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.ValueColumn;
 
+import com.google.gson.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -90,5 +91,31 @@ public class PersistedAction {
 
     public void setTimestamp(long timestamp) {
         this.timestamp = timestamp;
+    }
+
+    public static class SQL_SCHEMA_CONSTANTS {
+
+        public static final String TIMESTAMP_COL_NAME = "timestamp";
+        public static final String ACTION_COL_NAME = "actionName";
+        public static final String NODE_IDS_NAME = "nodeIds";
+        public static final String NODE_IPS_NAME = "nodeIps";
+        public static final String MUTED_NAME = "muted";
+        public static final String SUMMARY_NAME = "summary";
+        public static final String ACTIONABLE_NAME = "actionable";
+        public static final String COOLOFFPERIOD_NAME = "coolOffPeriod";
+
+    }
+
+    public JsonObject toJson() {
+        JsonObject summaryObj = new JsonObject();
+        summaryObj.addProperty(SQL_SCHEMA_CONSTANTS.NODE_IPS_NAME, this.nodeIps);
+        summaryObj.addProperty(SQL_SCHEMA_CONSTANTS.MUTED_NAME, this.muted);
+        summaryObj.addProperty(SQL_SCHEMA_CONSTANTS.ACTION_COL_NAME, this.actionName);
+        summaryObj.addProperty(SQL_SCHEMA_CONSTANTS.TIMESTAMP_COL_NAME, this.timestamp);
+        summaryObj.addProperty(SQL_SCHEMA_CONSTANTS.NODE_IDS_NAME, this.nodeIds);
+        summaryObj.addProperty(SQL_SCHEMA_CONSTANTS.SUMMARY_NAME, this.summary);
+        summaryObj.addProperty(SQL_SCHEMA_CONSTANTS.ACTIONABLE_NAME, this.actionable);
+        summaryObj.addProperty(SQL_SCHEMA_CONSTANTS.COOLOFFPERIOD_NAME, this.coolOffPeriod);
+        return summaryObj;
     }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/actions/PersistedAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/actions/PersistedAction.java
@@ -2,6 +2,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.ValueColumn;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -106,7 +107,7 @@ public class PersistedAction {
 
     }
 
-    public JsonObject toJson() {
+    public JsonElement toJson() {
         JsonObject summaryObj = new JsonObject();
         summaryObj.addProperty(SQL_SCHEMA_CONSTANTS.NODE_IPS_NAME, this.nodeIps);
         summaryObj.addProperty(SQL_SCHEMA_CONSTANTS.MUTED_NAME, this.muted);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryActionRequestHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryActionRequestHandler.java
@@ -106,8 +106,7 @@ public class QueryActionRequestHandler extends MetricsHandler implements HttpHan
         JsonObject result = new JsonObject();
         if (persistable != null) {
             try {
-                // TODO: Read Last suggested Action Set
-                List<PersistedAction> actionSet = persistable.readLatestGroup(PersistedAction.class);
+                List<PersistedAction> actionSet = persistable.readAllForMaxTimeStamp(PersistedAction.class);
                 JsonArray response = new JsonArray();
                 if (actionSet != null) {
                     for (PersistedAction action : actionSet) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryActionRequestHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryActionRequestHandler.java
@@ -39,7 +39,7 @@ import org.jooq.impl.DSL;
 
 /**
  * Request Handler that supports querying the latest action set
- *TODO: Update with actual Action Values.
+ *TODO: Update with actual Action Values here and in the README.
  *
  * <p>To get the response for the latest action set suggested via DM Framework
  * curl --url "localhost:9600/_opendistro/_performanceanalyzer/actions" -XGET

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryActionRequestHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryActionRequestHandler.java
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.util.Supplier;
+import org.jooq.impl.DSL;
 
 public class QueryActionRequestHandler extends MetricsHandler implements HttpHandler {
 
@@ -106,7 +107,8 @@ public class QueryActionRequestHandler extends MetricsHandler implements HttpHan
         JsonObject result = new JsonObject();
         if (persistable != null) {
             try {
-                List<PersistedAction> actionSet = persistable.readAllForMaxTimeStamp(PersistedAction.class);
+                List<PersistedAction> actionSet = persistable.readAllForMaxField(PersistedAction.class,
+                        DSL.field(PersistedAction.SQL_SCHEMA_CONSTANTS.TIMESTAMP_COL_NAME, String.class));
                 JsonArray response = new JsonArray();
                 if (actionSet != null) {
                     for (PersistedAction action : actionSet) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryActionRequestHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryActionRequestHandler.java
@@ -40,7 +40,7 @@ import org.jooq.impl.DSL;
 /**
  * Request Handler that supports querying the latest action set
  *
- * <p> To get the response for the latest action set suggested via DM Framework
+ * <p>To get the response for the latest action set suggested via DM Framework
  * curl --url "localhost:9600/_opendistro/_performanceanalyzer/actions" -XGET
  * @<code>
  *     {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryActionRequestHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryActionRequestHandler.java
@@ -105,20 +105,23 @@ public class QueryActionRequestHandler extends MetricsHandler implements HttpHan
             try {
                 // TODO: Read Last suggested Action Set
                 PersistedAction response = persistable.read(PersistedAction.class);
-                result.addProperty("LastSuggestedAction", response.toJson().toString());
+                if (response != null) {
+                    result.addProperty("LastSuggestedAction", response.toJson().toString());
+                } else {
+                    result.addProperty("LastSuggestedAction", "Nil");
+                }
             } catch (Exception e) {
                 result.addProperty("error", e.getMessage());
             }
         }
-        LOG.info("Here is the result {}", result.toString());
         return result;
     }
 
     public void sendResponse(HttpExchange exchange, String response, int status) throws IOException {
-        try (OutputStream os = exchange.getResponseBody()) {
+        try {
+            OutputStream os = exchange.getResponseBody();
             exchange.sendResponseHeaders(status, response.length());
             os.write(response.getBytes());
-            LOG.info("Response Sent AYAy {} status {}", response, status);
         } catch (Exception e) {
             response = e.toString();
             exchange.sendResponseHeaders(HttpURLConnection.HTTP_INTERNAL_ERROR, response.length());

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryActionRequestHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryActionRequestHandler.java
@@ -107,7 +107,7 @@ public class QueryActionRequestHandler extends MetricsHandler implements HttpHan
         if (persistable != null) {
             try {
                 // TODO: Read Last suggested Action Set
-                List<PersistedAction> actionSet = persistable.readForTimestamp(PersistedAction.class);
+                List<PersistedAction> actionSet = persistable.readLatestGroup(PersistedAction.class);
                 JsonArray response = new JsonArray();
                 if (actionSet != null) {
                     for (PersistedAction action : actionSet) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryActionRequestHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryActionRequestHandler.java
@@ -39,6 +39,7 @@ import org.jooq.impl.DSL;
 
 /**
  * Request Handler that supports querying the latest action set
+ *TODO: Update with actual Action Values.
  *
  * <p>To get the response for the latest action set suggested via DM Framework
  * curl --url "localhost:9600/_opendistro/_performanceanalyzer/actions" -XGET

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryActionRequestHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryActionRequestHandler.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rest;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatExceptionCode;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.Persistable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
+import com.google.gson.JsonObject;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.security.InvalidParameterException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.logging.log4j.util.Supplier;
+
+public class QueryActionRequestHandler extends MetricsHandler implements HttpHandler {
+
+    private static final Logger LOG = LogManager.getLogger(QueryActionRequestHandler.class);
+    private Persistable persistable;
+    private AppContext appContext;
+
+    public QueryActionRequestHandler(final AppContext appContext) {
+        this.appContext = appContext;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        String requestMethod = exchange.getRequestMethod();
+
+        if (requestMethod.equalsIgnoreCase("GET")) {
+            LOG.debug("Action Query handler called.");
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+
+            try {
+                synchronized (this) {
+                    String query = exchange.getRequestURI().getQuery();
+                    handleActionRequest(exchange);
+                }
+            } catch (InvalidParameterException e) {
+                LOG.error(
+                        (Supplier<?>)
+                                () ->
+                                        new ParameterizedMessage(
+                                                "QueryException {} ExceptionCode: {}.",
+                                                e.toString(),
+                                                StatExceptionCode.REQUEST_ERROR.toString()),
+                        e);
+                String response = "{\"error\":\"" + e.getMessage() + "\"}";
+                sendResponse(exchange, response, HttpURLConnection.HTTP_BAD_REQUEST);
+            } catch (Exception e) {
+                LOG.error(
+                        (Supplier<?>)
+                                () ->
+                                        new ParameterizedMessage(
+                                                "QueryException {} ExceptionCode: {}.",
+                                                e.toString(),
+                                                StatExceptionCode.REQUEST_ERROR.toString()),
+                        e);
+                String response = "{\"error\":\"" + e.toString() + "\"}";
+                sendResponse(exchange, response, HttpURLConnection.HTTP_INTERNAL_ERROR);
+            }
+        } else {
+            exchange.sendResponseHeaders(HttpURLConnection.HTTP_NOT_FOUND, -1);
+            exchange.close();
+        }
+    }
+
+    private void handleActionRequest(HttpExchange exchange)
+            throws IOException {
+        //check if we are querying from elected master
+        if (!validNodeRole()) {
+            JsonObject errResponse = new JsonObject();
+            errResponse.addProperty("error", "Node being queried is not elected master.");
+            sendResponse(exchange, errResponse.toString(),
+                    HttpURLConnection.HTTP_BAD_REQUEST);
+            return;
+        }
+
+        String response = getActionData(persistable).toString();
+        sendResponse(exchange, response, HttpURLConnection.HTTP_OK);
+    }
+
+    private JsonObject getActionData(Persistable persistable) {
+        LOG.debug("Action: in getActionData");
+        JsonObject result = new JsonObject();
+        if (persistable != null) {
+            try {
+                // TODO: Read Last suggested Action Set
+                PersistedAction response = persistable.read(PersistedAction.class);
+                result.addProperty("LastSuggestedAction", response.toJson().toString());
+            } catch (Exception e) {
+                result.addProperty("error", e.getMessage());
+            }
+        }
+        LOG.info("Here is the result {}", result.toString());
+        return result;
+    }
+
+    public void sendResponse(HttpExchange exchange, String response, int status) throws IOException {
+        try (OutputStream os = exchange.getResponseBody()) {
+            exchange.sendResponseHeaders(status, response.length());
+            os.write(response.getBytes());
+            LOG.info("Response Sent AYAy {} status {}", response, status);
+        } catch (Exception e) {
+            response = e.toString();
+            exchange.sendResponseHeaders(HttpURLConnection.HTTP_INTERNAL_ERROR, response.length());
+        }
+    }
+
+    public synchronized void setPersistable(Persistable persistable) {
+        this.persistable = persistable;
+    }
+
+    // check if we are querying from elected master
+    private boolean validNodeRole() {
+        return appContext.getMyInstanceDetails().getIsMaster();
+    }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryActionRequestHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryActionRequestHandler.java
@@ -35,7 +35,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.util.Supplier;
-import org.jooq.impl.DSL;
 
 /**
  * Request Handler that supports querying the latest action set
@@ -166,7 +165,7 @@ public class QueryActionRequestHandler extends MetricsHandler implements HttpHan
         if (persistable != null) {
             try {
                 List<PersistedAction> actionSet = persistable.readAllForMaxField(PersistedAction.class,
-                        DSL.field(PersistedAction.SQL_SCHEMA_CONSTANTS.TIMESTAMP_COL_NAME, String.class));
+                        PersistedAction.SQL_SCHEMA_CONSTANTS.TIMESTAMP_COL_NAME, Long.class);
                 JsonArray response = new JsonArray();
                 if (actionSet != null) {
                     for (PersistedAction action : actionSet) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryRcaRequestHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryRcaRequestHandler.java
@@ -156,8 +156,8 @@ public class QueryRcaRequestHandler extends MetricsHandler implements HttpHandle
       }
     } else {
       exchange.sendResponseHeaders(HttpURLConnection.HTTP_NOT_FOUND, -1);
-      exchange.close();
     }
+    exchange.close();
   }
 
   private void handleClusterRcaRequest(Map<String, String> params, HttpExchange exchange)

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
@@ -65,8 +65,8 @@ public class PublisherEventsPersistorTest {
             Assert.assertEquals(action.getActionName(), "MockAction" + index);
             String IP1 = (index + ".").repeat(4);
             String IP2 = (Integer.toString(index) + index + ".").repeat(4);
-            Assert.assertEquals(action.getNodeIps(), IP1.substring(0, IP1.length() - 1) + ","
-                                                         + IP2.substring(0, IP2.length() - 1));
+            Assert.assertEquals(action.getNodeIps(), "{" + IP1.substring(0, IP1.length() - 1) + ","
+                                                         + IP2.substring(0, IP2.length() - 1)  + "}");
             Assert.assertEquals(action.isActionable(), false);
             Assert.assertEquals(action.isMuted(), false);
             Assert.assertEquals(action.getSummary(), "MockSummary");
@@ -93,8 +93,8 @@ public class PublisherEventsPersistorTest {
             Assert.assertEquals(action.getActionName(), "MockAction" + index);
             String IP1 = (index + ".").repeat(4);
             String IP2 = (Integer.toString(index) + index + ".").repeat(4);
-            Assert.assertEquals(action.getNodeIps(), IP1.substring(0, IP1.length() - 1) + ","
-                    + IP2.substring(0, IP2.length() - 1));
+            Assert.assertEquals(action.getNodeIps(),"{" + IP1.substring(0, IP1.length() - 1) + ","
+                    + IP2.substring(0, IP2.length() - 1) + "}");
             Assert.assertEquals(action.isActionable(), false);
             Assert.assertEquals(action.isMuted(), false);
             Assert.assertEquals(action.getSummary(), "MockSummary");

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
@@ -48,8 +48,8 @@ public class PublisherEventsPersistorTest {
 
     @Test
     public void actionPublished() throws Exception {
-        final MockAction mockAction1 = new MockAction("MockAction1");
-        final MockAction mockAction2 = new MockAction("MockAction2");
+        final MockAction mockAction1 = new MockAction("MockAction1", new ArrayList<String>(){{ add("1"); add("11"); }});
+        final MockAction mockAction2 = new MockAction("MockAction2", new ArrayList<String>(){{ add("2"); add("33"); }});
 
         List<Action> mockActions = new ArrayList<>();
         mockActions.add(mockAction1);
@@ -58,8 +58,8 @@ public class PublisherEventsPersistorTest {
 
         publisherEventsPersistor.persistAction(mockActions);
 
-        final MockAction mockAction3 = new MockAction("MockAction3");
-        final MockAction mockAction4 = new MockAction("MockAction4");
+        final MockAction mockAction3 = new MockAction("MockAction3",new ArrayList<String>(){{ add("3"); add("33"); }});
+        final MockAction mockAction4 = new MockAction("MockAction4",new ArrayList<String>(){{ add("4"); add("44"); }});
         mockActions.add(mockAction3);
         mockActions.add(mockAction4);
 
@@ -72,23 +72,27 @@ public class PublisherEventsPersistorTest {
         Assert.assertEquals(actionsSummary.size(), 2);
         int index = 3;
         for (PersistedAction action : actionsSummary) {
-            System.out.println("Action  " +  action.actionName);
-            Assert.assertEquals(action.getActionName(), "MockAction" + index++);
-            Assert.assertEquals(action.getNodeIds(), "{1,2}");
-            Assert.assertEquals(action.getNodeIps(), "{1.1.1.1,2.2.2.2}");
+            Assert.assertEquals(action.getActionName(), "MockAction" + index);
+            String IP1 = (index + "." ).repeat(4);
+            String IP2 = (Integer.toString(index) + index + ".").repeat(4);
+            Assert.assertEquals(action.getNodeIps(), "{" + IP1.substring(0, IP1.length() - 1) + ","
+                                                         + IP2.substring(0, IP2.length() - 1) +  "}");
             Assert.assertEquals(action.isActionable(), mockAction3.isActionable());
             Assert.assertEquals(action.getCoolOffPeriod(), mockAction3.coolOffPeriodInMillis());
             Assert.assertEquals(action.isMuted(), mockAction3.isMuted());
             Assert.assertEquals(action.getSummary(), mockAction3.summary());
+            index++;
         }
 
     }
 
     public class MockAction implements Action {
         private String name;
+        private List<String> nodeIps;
 
-        public MockAction(String name) {
+        public MockAction(String name, List<String> nodeIps) {
             this.name = name;
+            this.nodeIps = nodeIps;
         }
 
         @Override
@@ -104,8 +108,10 @@ public class PublisherEventsPersistorTest {
         @Override
         public List<NodeKey> impactedNodes() {
             List<NodeKey> nodeKeys = new ArrayList<>();
-            nodeKeys.add(new NodeKey(new InstanceDetails.Id("1"), new InstanceDetails.Ip("1.1.1.1")));
-            nodeKeys.add(new NodeKey(new InstanceDetails.Id("2"), new InstanceDetails.Ip("2.2.2.2")));
+            String IP1 = (nodeIps.get(0) + ".").repeat(4);
+            String IP2 = (nodeIps.get(1) + ".").repeat(4);
+            nodeKeys.add(new NodeKey(new InstanceDetails.Id(nodeIps.get(0)), new InstanceDetails.Ip(IP1.substring(0, IP1.length() - 1))));
+            nodeKeys.add(new NodeKey(new InstanceDetails.Id(nodeIps.get(1)), new InstanceDetails.Ip(IP2.substring(0, IP2.length() - 1))));
             return nodeKeys;
         }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
@@ -58,7 +58,7 @@ public class PublisherEventsPersistorTest {
 
         publisherEventsPersistor.persistAction(mockActions);
 
-        List<PersistedAction> actionsSummary = persistable.readForTimestamp(PersistedAction.class);
+        List<PersistedAction> actionsSummary = persistable.readLatestGroup(PersistedAction.class);
         Assert.assertNotNull(actionsSummary);
         Assert.assertEquals(actionsSummary.size(), 2);
         int index = 1;
@@ -81,7 +81,7 @@ public class PublisherEventsPersistorTest {
         mockActions.add(mockAction4);
         publisherEventsPersistor.persistAction(mockActions);
 
-        actionsSummary = persistable.readForTimestamp(PersistedAction.class);
+        actionsSummary = persistable.readLatestGroup(PersistedAction.class);
         Assert.assertNotNull(actionsSummary);
         Assert.assertEquals(actionsSummary.size(), 2);
         index = 3;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
@@ -80,7 +80,7 @@ public class PublisherEventsPersistorTest {
 
         addActions();
         WaitFor.waitFor(() -> persistable.readAllForMaxField(PersistedAction.class,
-                DSL.field(PersistedAction.SQL_SCHEMA_CONSTANTS.TIMESTAMP_COL_NAME, String.class)
+                DSL.field(PersistedAction.SQL_SCHEMA_CONSTANTS.COOLOFFPERIOD_NAME, String.class)
                 ).size() == 2, 5,
                 TimeUnit.SECONDS);
         List<PersistedAction> actionsSummary = persistable.readAllForMaxField(PersistedAction.class,
@@ -139,7 +139,7 @@ public class PublisherEventsPersistorTest {
             {
                 add("5");
                 add("55");
-            }}, 50);
+            }}, 60);
         final MockAction mockAction6 = new MockAction("MockAction6",new ArrayList<String>() {
             {
                 add("6");

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
-import org.jooq.impl.DSL;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -52,11 +51,10 @@ public class PublisherEventsPersistorTest {
 
         addActions();
         WaitFor.waitFor(() -> persistable.readAllForMaxField(PersistedAction.class,
-                DSL.field(PersistedAction.SQL_SCHEMA_CONSTANTS.TIMESTAMP_COL_NAME, String.class)
-                ).size() == 2, 5,
+                PersistedAction.SQL_SCHEMA_CONSTANTS.TIMESTAMP_COL_NAME, Long.class).size() == 2, 5,
                 TimeUnit.SECONDS);
         List<PersistedAction> actionsSummary = persistable.readAllForMaxField(PersistedAction.class,
-                DSL.field(PersistedAction.SQL_SCHEMA_CONSTANTS.TIMESTAMP_COL_NAME, String.class));
+                PersistedAction.SQL_SCHEMA_CONSTANTS.TIMESTAMP_COL_NAME, Long.class);
         Assert.assertNotNull(actionsSummary);
         Assert.assertEquals(actionsSummary.size(), 2);
         // MockAction3 and MockAction4 should be returned as those have the highed Timestamps.
@@ -80,11 +78,11 @@ public class PublisherEventsPersistorTest {
 
         addActions();
         WaitFor.waitFor(() -> persistable.readAllForMaxField(PersistedAction.class,
-                DSL.field(PersistedAction.SQL_SCHEMA_CONSTANTS.COOLOFFPERIOD_NAME, String.class)
+                PersistedAction.SQL_SCHEMA_CONSTANTS.COOLOFFPERIOD_NAME, Long.class
                 ).size() == 2, 5,
                 TimeUnit.SECONDS);
         List<PersistedAction> actionsSummary = persistable.readAllForMaxField(PersistedAction.class,
-                DSL.field(PersistedAction.SQL_SCHEMA_CONSTANTS.COOLOFFPERIOD_NAME, String.class));
+                PersistedAction.SQL_SCHEMA_CONSTANTS.COOLOFFPERIOD_NAME, Long.class);
         Assert.assertNotNull(actionsSummary);
         Assert.assertEquals(actionsSummary.size(), 2);
         // MockAction5 and MockAction6 should be returned as those have the highed CooloffPeriods.

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
@@ -48,9 +48,16 @@ public class PublisherEventsPersistorTest {
 
     @Test
     public void actionPublished() throws Exception {
-        final MockAction mockAction1 = new MockAction("MockAction1", new ArrayList<String>(){{ add("1"); add("11"); }});
-        final MockAction mockAction2 = new MockAction("MockAction2", new ArrayList<String>(){{ add("2"); add("33"); }});
-
+        final MockAction mockAction1 = new MockAction("MockAction1", new ArrayList<String>() {
+            {
+                add("1");
+                add("11");
+            }});
+        final MockAction mockAction2 = new MockAction("MockAction2", new ArrayList<String>() {
+            {
+                add("2");
+                add("33");
+            }});
         List<Action> mockActions = new ArrayList<>();
         mockActions.add(mockAction1);
         mockActions.add(mockAction2);
@@ -58,8 +65,16 @@ public class PublisherEventsPersistorTest {
 
         publisherEventsPersistor.persistAction(mockActions);
 
-        final MockAction mockAction3 = new MockAction("MockAction3",new ArrayList<String>(){{ add("3"); add("33"); }});
-        final MockAction mockAction4 = new MockAction("MockAction4",new ArrayList<String>(){{ add("4"); add("44"); }});
+        final MockAction mockAction3 = new MockAction("MockAction3",new ArrayList<String>() {
+            {
+                add("3");
+                add("33");
+            }});
+        final MockAction mockAction4 = new MockAction("MockAction4",new ArrayList<String>() {
+            {
+                add("4");
+                add("44");
+            }});
         mockActions.add(mockAction3);
         mockActions.add(mockAction4);
 
@@ -73,7 +88,7 @@ public class PublisherEventsPersistorTest {
         int index = 3;
         for (PersistedAction action : actionsSummary) {
             Assert.assertEquals(action.getActionName(), "MockAction" + index);
-            String IP1 = (index + "." ).repeat(4);
+            String IP1 = (index + ".").repeat(4);
             String IP2 = (Integer.toString(index) + index + ".").repeat(4);
             Assert.assertEquals(action.getNodeIps(), "{" + IP1.substring(0, IP1.length() - 1) + ","
                                                          + IP2.substring(0, IP2.length() - 1) +  "}");

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
@@ -47,11 +47,12 @@ public class PublisherEventsPersistorTest {
     }
 
     @Test
-    public void actionPublished() throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException, InterruptedException {
+    public void actionPublished()
+            throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException, InterruptedException {
         final MockAction mockAction1 = new MockAction("MockAction1");
         final MockAction mockAction2 = new MockAction("MockAction2");
 
-        List <Action> mockActions = new ArrayList<>();
+        List<Action> mockActions = new ArrayList<>();
         mockActions.add(mockAction1);
         mockActions.add(mockAction2);
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
@@ -54,6 +54,14 @@ public class PublisherEventsPersistorTest {
         List<Action> mockActions = new ArrayList<>();
         mockActions.add(mockAction1);
         mockActions.add(mockAction2);
+        mockActions.clear();
+
+        publisherEventsPersistor.persistAction(mockActions);
+
+        final MockAction mockAction3 = new MockAction("MockAction3");
+        final MockAction mockAction4 = new MockAction("MockAction4");
+        mockActions.add(mockAction3);
+        mockActions.add(mockAction4);
 
         publisherEventsPersistor.persistAction(mockActions);
 
@@ -62,32 +70,9 @@ public class PublisherEventsPersistorTest {
         List<PersistedAction> actionsSummary = persistable.readLatestGroup(PersistedAction.class);
         Assert.assertNotNull(actionsSummary);
         Assert.assertEquals(actionsSummary.size(), 2);
-        int index = 1;
+        int index = 3;
         for (PersistedAction action : actionsSummary) {
-            Assert.assertEquals(action.getActionName(), "MockAction" + index++);
-            Assert.assertEquals(action.getNodeIds(), "{1,2}");
-            Assert.assertEquals(action.getNodeIps(), "{1.1.1.1,2.2.2.2}");
-            Assert.assertEquals(action.isActionable(), mockAction2.isActionable());
-            Assert.assertEquals(action.getCoolOffPeriod(), mockAction2.coolOffPeriodInMillis());
-            Assert.assertEquals(action.isMuted(), mockAction2.isMuted());
-            Assert.assertEquals(action.getSummary(), mockAction2.summary());
-        }
-
-        final MockAction mockAction3 = new MockAction("MockAction3");
-        final MockAction mockAction4 = new MockAction("MockAction4");
-        mockActions.clear();
-        mockActions.add(mockAction3);
-        mockActions.add(mockAction4);
-
-        publisherEventsPersistor.persistAction(mockActions);
-
-        WaitFor.waitFor(() -> persistable.readLatestGroup(PersistedAction.class).size() == 2, 5,
-                TimeUnit.SECONDS);
-        actionsSummary = persistable.readLatestGroup(PersistedAction.class);
-        Assert.assertNotNull(actionsSummary);
-        Assert.assertEquals(actionsSummary.size(), 2);
-        index = 3;
-        for (PersistedAction action : actionsSummary) {
+            System.out.println("Action  " +  action.actionName);
             Assert.assertEquals(action.getActionName(), "MockAction" + index++);
             Assert.assertEquals(action.getNodeIds(), "{1,2}");
             Assert.assertEquals(action.getNodeIps(), "{1.1.1.1,2.2.2.2}");

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
@@ -56,15 +56,14 @@ public class PublisherEventsPersistorTest {
         final MockAction mockAction2 = new MockAction("MockAction2", new ArrayList<String>() {
             {
                 add("2");
-                add("33");
+                add("22");
             }});
         List<Action> mockActions = new ArrayList<>();
         mockActions.add(mockAction1);
         mockActions.add(mockAction2);
+        publisherEventsPersistor.persistAction(mockActions,123456789);
+
         mockActions.clear();
-
-        publisherEventsPersistor.persistAction(mockActions);
-
         final MockAction mockAction3 = new MockAction("MockAction3",new ArrayList<String>() {
             {
                 add("3");
@@ -78,11 +77,11 @@ public class PublisherEventsPersistorTest {
         mockActions.add(mockAction3);
         mockActions.add(mockAction4);
 
-        publisherEventsPersistor.persistAction(mockActions);
+        publisherEventsPersistor.persistAction(mockActions, 987654321);
 
-        WaitFor.waitFor(() -> persistable.readLatestGroup(PersistedAction.class).size() == 2, 5,
+        WaitFor.waitFor(() -> persistable.readAllForMaxTimeStamp(PersistedAction.class).size() == 2, 5,
                 TimeUnit.SECONDS);
-        List<PersistedAction> actionsSummary = persistable.readLatestGroup(PersistedAction.class);
+        List<PersistedAction> actionsSummary = persistable.readAllForMaxTimeStamp(PersistedAction.class);
         Assert.assertNotNull(actionsSummary);
         Assert.assertEquals(actionsSummary.size(), 2);
         int index = 3;
@@ -90,8 +89,8 @@ public class PublisherEventsPersistorTest {
             Assert.assertEquals(action.getActionName(), "MockAction" + index);
             String IP1 = (index + ".").repeat(4);
             String IP2 = (Integer.toString(index) + index + ".").repeat(4);
-            Assert.assertEquals(action.getNodeIps(), "{" + IP1.substring(0, IP1.length() - 1) + ","
-                                                         + IP2.substring(0, IP2.length() - 1) +  "}");
+            Assert.assertEquals(action.getNodeIps(), IP1.substring(0, IP1.length() - 1) + ","
+                                                         + IP2.substring(0, IP2.length() - 1));
             Assert.assertEquals(action.isActionable(), mockAction3.isActionable());
             Assert.assertEquals(action.getCoolOffPeriod(), mockAction3.coolOffPeriodInMillis());
             Assert.assertEquals(action.isMuted(), mockAction3.isMuted());

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
+import org.jooq.impl.DSL;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -79,9 +80,12 @@ public class PublisherEventsPersistorTest {
 
         publisherEventsPersistor.persistAction(mockActions, 987654321);
 
-        WaitFor.waitFor(() -> persistable.readAllForMaxTimeStamp(PersistedAction.class).size() == 2, 5,
+        WaitFor.waitFor(() -> persistable.readAllForMaxField(PersistedAction.class,
+                DSL.field(PersistedAction.SQL_SCHEMA_CONSTANTS.TIMESTAMP_COL_NAME, String.class)
+                ).size() == 2, 5,
                 TimeUnit.SECONDS);
-        List<PersistedAction> actionsSummary = persistable.readAllForMaxTimeStamp(PersistedAction.class);
+        List<PersistedAction> actionsSummary = persistable.readAllForMaxField(PersistedAction.class,
+                DSL.field(PersistedAction.SQL_SCHEMA_CONSTANTS.TIMESTAMP_COL_NAME, String.class));
         Assert.assertNotNull(actionsSummary);
         Assert.assertEquals(actionsSummary.size(), 2);
         int index = 3;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
@@ -48,17 +48,72 @@ public class PublisherEventsPersistorTest {
     }
 
     @Test
-    public void actionPublished() throws Exception {
+    public void testActionPublishedIncreasingTimestamp() throws Exception {
+
+        addActions();
+        WaitFor.waitFor(() -> persistable.readAllForMaxField(PersistedAction.class,
+                DSL.field(PersistedAction.SQL_SCHEMA_CONSTANTS.TIMESTAMP_COL_NAME, String.class)
+                ).size() == 2, 5,
+                TimeUnit.SECONDS);
+        List<PersistedAction> actionsSummary = persistable.readAllForMaxField(PersistedAction.class,
+                DSL.field(PersistedAction.SQL_SCHEMA_CONSTANTS.TIMESTAMP_COL_NAME, String.class));
+        Assert.assertNotNull(actionsSummary);
+        Assert.assertEquals(actionsSummary.size(), 2);
+        // MockAction3 and MockAction4 should be returned as those have the highed Timestamps.
+        int index = 3;
+        for (PersistedAction action : actionsSummary) {
+            Assert.assertEquals(action.getActionName(), "MockAction" + index);
+            String IP1 = (index + ".").repeat(4);
+            String IP2 = (Integer.toString(index) + index + ".").repeat(4);
+            Assert.assertEquals(action.getNodeIps(), IP1.substring(0, IP1.length() - 1) + ","
+                                                         + IP2.substring(0, IP2.length() - 1));
+            Assert.assertEquals(action.isActionable(), false);
+            Assert.assertEquals(action.isMuted(), false);
+            Assert.assertEquals(action.getSummary(), "MockSummary");
+            index++;
+        }
+
+    }
+
+    @Test
+    public void testActionPublishedIncreasingCoolOffPeriod() throws Exception {
+
+        addActions();
+        WaitFor.waitFor(() -> persistable.readAllForMaxField(PersistedAction.class,
+                DSL.field(PersistedAction.SQL_SCHEMA_CONSTANTS.TIMESTAMP_COL_NAME, String.class)
+                ).size() == 2, 5,
+                TimeUnit.SECONDS);
+        List<PersistedAction> actionsSummary = persistable.readAllForMaxField(PersistedAction.class,
+                DSL.field(PersistedAction.SQL_SCHEMA_CONSTANTS.COOLOFFPERIOD_NAME, String.class));
+        Assert.assertNotNull(actionsSummary);
+        Assert.assertEquals(actionsSummary.size(), 2);
+        // MockAction5 and MockAction6 should be returned as those have the highed CooloffPeriods.
+        int index = 5;
+        for (PersistedAction action : actionsSummary) {
+            Assert.assertEquals(action.getActionName(), "MockAction" + index);
+            String IP1 = (index + ".").repeat(4);
+            String IP2 = (Integer.toString(index) + index + ".").repeat(4);
+            Assert.assertEquals(action.getNodeIps(), IP1.substring(0, IP1.length() - 1) + ","
+                    + IP2.substring(0, IP2.length() - 1));
+            Assert.assertEquals(action.isActionable(), false);
+            Assert.assertEquals(action.isMuted(), false);
+            Assert.assertEquals(action.getSummary(), "MockSummary");
+            index++;
+        }
+
+    }
+
+    public void addActions() {
         final MockAction mockAction1 = new MockAction("MockAction1", new ArrayList<String>() {
             {
                 add("1");
                 add("11");
-            }});
+            }}, 10);
         final MockAction mockAction2 = new MockAction("MockAction2", new ArrayList<String>() {
             {
                 add("2");
                 add("22");
-            }});
+            }}, 20);
         List<Action> mockActions = new ArrayList<>();
         mockActions.add(mockAction1);
         mockActions.add(mockAction2);
@@ -69,48 +124,41 @@ public class PublisherEventsPersistorTest {
             {
                 add("3");
                 add("33");
-            }});
+            }}, 30);
         final MockAction mockAction4 = new MockAction("MockAction4",new ArrayList<String>() {
             {
                 add("4");
                 add("44");
-            }});
+            }}, 40);
         mockActions.add(mockAction3);
         mockActions.add(mockAction4);
-
         publisherEventsPersistor.persistAction(mockActions, 987654321);
 
-        WaitFor.waitFor(() -> persistable.readAllForMaxField(PersistedAction.class,
-                DSL.field(PersistedAction.SQL_SCHEMA_CONSTANTS.TIMESTAMP_COL_NAME, String.class)
-                ).size() == 2, 5,
-                TimeUnit.SECONDS);
-        List<PersistedAction> actionsSummary = persistable.readAllForMaxField(PersistedAction.class,
-                DSL.field(PersistedAction.SQL_SCHEMA_CONSTANTS.TIMESTAMP_COL_NAME, String.class));
-        Assert.assertNotNull(actionsSummary);
-        Assert.assertEquals(actionsSummary.size(), 2);
-        int index = 3;
-        for (PersistedAction action : actionsSummary) {
-            Assert.assertEquals(action.getActionName(), "MockAction" + index);
-            String IP1 = (index + ".").repeat(4);
-            String IP2 = (Integer.toString(index) + index + ".").repeat(4);
-            Assert.assertEquals(action.getNodeIps(), IP1.substring(0, IP1.length() - 1) + ","
-                                                         + IP2.substring(0, IP2.length() - 1));
-            Assert.assertEquals(action.isActionable(), mockAction3.isActionable());
-            Assert.assertEquals(action.getCoolOffPeriod(), mockAction3.coolOffPeriodInMillis());
-            Assert.assertEquals(action.isMuted(), mockAction3.isMuted());
-            Assert.assertEquals(action.getSummary(), mockAction3.summary());
-            index++;
-        }
-
+        mockActions.clear();
+        final MockAction mockAction5 = new MockAction("MockAction5",new ArrayList<String>() {
+            {
+                add("5");
+                add("55");
+            }}, 50);
+        final MockAction mockAction6 = new MockAction("MockAction6",new ArrayList<String>() {
+            {
+                add("6");
+                add("66");
+            }}, 60);
+        mockActions.add(mockAction5);
+        mockActions.add(mockAction6);
+        publisherEventsPersistor.persistAction(mockActions, 987651);
     }
 
     public class MockAction implements Action {
         private String name;
         private List<String> nodeIps;
+        private long coolOffPeriodInMillis;
 
-        public MockAction(String name, List<String> nodeIps) {
+        public MockAction(String name, List<String> nodeIps, long coolOffPeriod) {
             this.name = name;
             this.nodeIps = nodeIps;
+            this.coolOffPeriodInMillis = coolOffPeriod;
         }
 
         @Override
@@ -120,7 +168,7 @@ public class PublisherEventsPersistorTest {
 
         @Override
         public long coolOffPeriodInMillis() {
-            return 0;
+            return this.coolOffPeriodInMillis;
         }
 
         @Override

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/PublisherEventsPersistorTest.java
@@ -5,6 +5,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.act
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.util.WaitFor;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -15,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.util.WaitFor;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Assert;


### PR DESCRIPTION
*Fixes #:* Adding the Support of Retrieving Actions Persisted via an API #469 

*Description of changes:* Return the last persisted action set in the SQL table via an API which would be used by monitoring to detect the actions triggered on a cluster. 


*Tests:*  Testing done on Docker 

*API Behavior when there is are actions published:*

**Last Few Entries in the SQL table:**

```
46|18.18.18.18,123.123.123.123|0|MockAction2|1602305937764|18,123|MockSummary|0|0
47|168.168.168.168,31.31.31.31|0|MockAction3|1602305937778|168,31|MockSummary|0|0
48|12.12.12.12,143.143.143.143|0|MockAction2|1602305937778|12,143|MockSummary|0|0
49|133.133.133.133,114.114.114.114|0|MockAction1|1602305942275|133,114|MockSummary|0|0
50|11.11.11.11,125.125.125.125|0|MockAction2|1602305942275|11,125|MockSummary|0|0
51|162.162.162.162,31.31.31.31|0|MockAction3|1602305942284|162,31|MockSummary|0|0
52|18.18.18.18,148.148.148.148|0|MockAction2|1602305942284|18,148|MockSummary|0|0sqlite> 
```

**Response of the API (gives just the entries with the max timestamp):**

```
[root@bebd00b62f74 elasticsearch]# curl --url "localhost:9600/_opendistro/_performanceanalyzer/actions" -XGET
{
    "LastSuggestedActionSet": [
        {
            "actionName": "MockAction1",
            "actionable": false,
            "coolOffPeriod": 10,
            "muted": false,
            "nodeIds": "1,11",
            "nodeIps": "1.1.1.1,11.11.11.11",
            "summary": "MockSummary",
            "timestamp": 1602538860025
        },
        {
            "actionName": "MockAction2",
            "actionable": false,
            "coolOffPeriod": 20,
            "muted": false,
            "nodeIds": "2,22",
            "nodeIps": "2.2.2.2,22.22.22.22",
            "summary": "MockSummary",
            "timestamp": 1602538860025
        },
        {
            "actionName": "MockAction1",
            "actionable": false,
            "coolOffPeriod": 30,
            "muted": false,
            "nodeIds": "1,11",
            "nodeIps": "1.1.1.1,11.11.11.11",
            "summary": "MockSummary",
            "timestamp": 1602538860025
        },
        {
            "actionName": "MockAction2",
            "actionable": false,
            "coolOffPeriod": 40,
            "muted": false,
            "nodeIds": "2,22",
            "nodeIps": "2.2.2.2,22.22.22.22",
            "summary": "MockSummary",
            "timestamp": 1602538860025
        }
    ]
}
[root@bebd00b62f74 elasticsearch]# 
```

*API Behavior when there is are no actions published:*

```
sqlite> .tables
RCA
```

```
[root@357cbfdc6872 elasticsearch]# curl --url "localhost:9600/_opendistro/_performanceanalyzer/actions" -XGET | python -m json.tool 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    29  100    29    0     0   3722      0 --:--:-- --:--:-- --:--:--  4142
{
    "LastSuggestedActionSet": []
}
```

*Build:* 
```
> Task :spotbugsMain
Warning at xsl:variable on line 348 column 57 of default.xsl:
  SXWN9001: A variable with no following sibling instructions has no effect
Warning at xsl:variable on line 351 column 57 of default.xsl:
  SXWN9001: A variable with no following sibling instructions has no effect

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.5/userguide/command_line_interface.html#sec:command_line_warnings

**BUILD SUCCESSFUL in 31m 0s**
19 actionable tasks: 19 executed

aditjind@3c22fbd31611 performance-analyzer-rca % **./gradlew spotBugsMain**

> Configure project :
pa in dir: (../performance-analyzer) will be built.
PA repo located at '../performance-analyzer' will be used.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.5/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 1s
6 actionable tasks: 6 up-to-date
aditjind@3c22fbd31611 performance-analyzer-rca % **./gradlew checkStyleMain**

> Configure project :
pa in dir: (../performance-analyzer) will be built.
PA repo located at '../performance-analyzer' will be used.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.5/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 828ms


```




*If new tests are added, how long do the new ones take to complete*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
