### PR TITLE
Queue decider IT

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyCacheMaxSizeAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyCacheMaxSizeAction.java
@@ -29,6 +29,8 @@ import com.google.gson.JsonParser;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -197,7 +199,7 @@ public class ModifyCacheMaxSizeAction extends SuppressibleAction {
       double upperBoundThreshold = cacheActionConfig.getThresholdConfig(cacheType).upperBound();
       double lowerBoundThreshold = cacheActionConfig.getThresholdConfig(cacheType).lowerBound();
       this.stepSizeInPercent = cacheActionConfig.getStepSize(cacheType);
-      this.coolOffPeriodInMillis = cacheActionConfig.getCoolOffPeriodInSeconds() * 1_000;
+      this.coolOffPeriodInMillis = TimeUnit.SECONDS.toMillis(cacheActionConfig.getCoolOffPeriodInSeconds());
       if (heapMaxSizeInBytes != null) {
         this.upperBoundInBytes = getThresholdInBytes(upperBoundThreshold, heapMaxSizeInBytes);
         this.lowerBoundInBytes = getThresholdInBytes(lowerBoundThreshold, heapMaxSizeInBytes);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyQueueCapacityAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/ModifyQueueCapacityAction.java
@@ -31,6 +31,8 @@ import com.google.gson.JsonParser;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -171,7 +173,7 @@ public class ModifyQueueCapacityAction extends SuppressibleAction {
       this.upperBound = queueActionConfig.getThresholdConfig(threadPool).upperBound();
       this.lowerBound = queueActionConfig.getThresholdConfig(threadPool).lowerBound();
       this.stepSize = queueActionConfig.getStepSize(threadPool);
-      this.coolOffPeriodInMillis = queueActionConfig.getCoolOffPeriodInSeconds() * 1_000;
+      this.coolOffPeriodInMillis = TimeUnit.SECONDS.toMillis(queueActionConfig.getCoolOffPeriodInSeconds());
     }
 
     public Builder coolOffPeriod(long coolOffPeriodInMillis) {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/RcaConfTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/RcaConfTest.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.configs.CacheActionConfig;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.configs.CachePriorityOrderConfig;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.configs.DeciderConfig;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.configs.WorkLoadTypeConfig;
@@ -27,6 +28,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.configs.Shard
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Map;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -85,6 +88,11 @@ public class RcaConfTest {
 
   @Test
   public void testValidateRcaConfig() {
+    Integer defaultValue1 = rcaConf.readRcaConfig(FieldDataCacheRcaConfig.CONFIG_NAME,
+            FieldDataCacheRcaConfig.RCA_CONF_KEY_CONSTANTS.FIELD_DATA_COLLECTOR_TIME_PERIOD_IN_SEC,
+            0, s -> s < 1, Integer.class);
+    Assert.assertNotNull(defaultValue1);
+    Assert.assertEquals(0, defaultValue1.intValue());
     Integer defaultValue = rcaConf.readRcaConfig(ShardRequestCacheRcaConfig.CONFIG_NAME,
             ShardRequestCacheRcaConfig.RCA_CONF_KEY_CONSTANTS.SHARD_REQUEST_COLLECTOR_TIME_PERIOD_IN_SEC,
             0, s -> s < 1, Integer.class);
@@ -103,5 +111,14 @@ public class RcaConfTest {
     WorkLoadTypeConfig workLoadTypeConfig = configObj.getWorkLoadTypeConfig();
     Assert.assertFalse(workLoadTypeConfig.preferSearch());
     Assert.assertTrue(workLoadTypeConfig.preferIngest());
+  }
+
+  @Test
+  public void testReadActionConfig() {
+    Map<String, Object> actionConfig = rcaConf.getActionConfigSettings();
+    NestedConfig cacheSettingsConfig = new NestedConfig("cache-settings", actionConfig);
+    Config<Integer> coolOffPeriodInSeconds = new Config<Integer>("cool-off-period-in-seconds", cacheSettingsConfig.getValue(),
+            300, (s) -> (s > 0), Integer.class);
+    Assert.assertEquals(10, coolOffPeriodInSeconds.getValue().intValue());
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/RcaConfTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/core/RcaConfTest.java
@@ -77,13 +77,13 @@ public class RcaConfTest {
             FieldDataCacheRcaConfig.RCA_CONF_KEY_CONSTANTS.FIELD_DATA_COLLECTOR_TIME_PERIOD_IN_SEC,
             FieldDataCacheRcaConfig.DEFAULT_FIELD_DATA_COLLECTOR_TIME_PERIOD_IN_SEC, Integer.class);
     Assert.assertNotNull(fieldDataTimePeriod);
-    Assert.assertEquals(FieldDataCacheRcaConfig.DEFAULT_FIELD_DATA_COLLECTOR_TIME_PERIOD_IN_SEC, fieldDataTimePeriod.intValue());
+    Assert.assertEquals(10, fieldDataTimePeriod.intValue());
 
     Integer shardRequestTimePeriod = rcaConf.readRcaConfig(ShardRequestCacheRcaConfig.CONFIG_NAME,
             ShardRequestCacheRcaConfig.RCA_CONF_KEY_CONSTANTS.SHARD_REQUEST_COLLECTOR_TIME_PERIOD_IN_SEC,
             ShardRequestCacheRcaConfig.DEFAULT_SHARD_REQUEST_COLLECTOR_TIME_PERIOD_IN_SEC, Integer.class);
     Assert.assertNotNull(shardRequestTimePeriod);
-    Assert.assertEquals(ShardRequestCacheRcaConfig.DEFAULT_SHARD_REQUEST_COLLECTOR_TIME_PERIOD_IN_SEC, shardRequestTimePeriod.intValue());
+    Assert.assertEquals(10, shardRequestTimePeriod.intValue());
   }
 
   @Test
@@ -118,7 +118,7 @@ public class RcaConfTest {
     Map<String, Object> actionConfig = rcaConf.getActionConfigSettings();
     NestedConfig cacheSettingsConfig = new NestedConfig("cache-settings", actionConfig);
     Config<Integer> coolOffPeriodInSeconds = new Config<Integer>("cool-off-period-in-seconds", cacheSettingsConfig.getValue(),
-            300, (s) -> (s > 0), Integer.class);
+            CacheActionConfig.DEFAULT_COOL_OFF_PERIOD_IN_SECONDS, (s) -> (s > 0), Integer.class);
     Assert.assertEquals(10, coolOffPeriodInSeconds.getValue().intValue());
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/resource/rca.conf
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/resource/rca.conf
@@ -73,17 +73,16 @@
     }
   },
 
+  "muted-rcas": [],
+  "muted-deciders": [],
+  "muted-actions": [],
+
+  "decider-config-settings": {},
+
   // Action Configurations
   "action-config-settings": {
     "cache-settings": {
       "cool-off-period-in-seconds" : 10
-    },
-    "queue-settings": {
-      "cool-off-period-in-seconds" : 10
     }
-  },
-
-  "muted-rcas": [],
-  "muted-deciders": [],
-  "muted-actions": []
+  }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/validator/FieldDataCacheDeciderValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/validator/FieldDataCacheDeciderValidator.java
@@ -71,7 +71,7 @@ public class FieldDataCacheDeciderValidator implements IValidator {
         Assert.assertEquals(ModifyCacheMaxSizeAction.NAME, persistedAction.getActionName());
         Assert.assertEquals("{DATA_0}", persistedAction.getNodeIds());
         Assert.assertEquals("{127.0.0.1}", persistedAction.getNodeIps());
-        Assert.assertEquals(300000, persistedAction.getCoolOffPeriod());
+        Assert.assertEquals(10000, persistedAction.getCoolOffPeriod());
         Assert.assertTrue(persistedAction.isActionable());
         Assert.assertFalse(persistedAction.isMuted());
         Assert.assertEquals(ResourceEnum.FIELD_DATA_CACHE, modifyCacheMaxSizeAction.getCacheType());

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/Constants.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/Constants.java
@@ -1,0 +1,7 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.Consts;
+
+public class Constants {
+    public static final String QUEUE_TUNING_RESOURCES_DIR = Consts.INTEG_TESTS_SRC_DIR + "./tests/queue_tuning/resource/";
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/dedicated_master/QueueDeciderDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/dedicated_master/QueueDeciderDedicatedMasterITest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.dedicated_master;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.Constants.QUEUE_TUNING_RESOURCES_DIR;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolDimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_QueueCapacity;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_RejectedReqs;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AErrorPatternIgnored;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AExpect;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AMetric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaGraph;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.Consts;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.validator.QueueDeciderValidator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.ElasticSearchAnalysisGraph;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(RcaItNotEncryptedRunner.class)
+
+@Category(RcaItMarker.class)
+@AClusterType(ClusterType.MULTI_NODE_DEDICATED_MASTER)
+@ARcaGraph(ElasticSearchAnalysisGraph.class)
+//specify a custom rca.conf to set the rejection-time-period-in-seconds to 5s to reduce runtime
+@ARcaConf(dataNode = QUEUE_TUNING_RESOURCES_DIR + "rca.conf")
+@AMetric(name = ThreadPool_RejectedReqs.class,
+    dimensionNames = {ThreadPoolDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = HostTag.DATA_0,
+            tuple = {
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.WRITE_NAME},
+                    sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.SEARCH_NAME},
+                    sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
+            }
+        )
+    }
+)
+
+@AMetric(name = ThreadPool_QueueCapacity.class,
+    dimensionNames = {ThreadPoolDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = HostTag.DATA_0,
+            tuple = {
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.WRITE_NAME},
+                    sum = 500, avg = 500, min = 500, max = 500),
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.SEARCH_NAME},
+                    sum = 1500, avg = 1500, min = 1500, max = 1500)
+            }
+        )
+    }
+)
+public class QueueDeciderDedicatedMasterITest {
+  // This integ test is built to test Decision Maker framework and queue remediation actions
+  // This test injects queue rejection metrics on one of the data node and queries the
+  // sqlite table on master to check whether queue remediation actions has been published.
+  @Test
+  @AExpect(
+      what = AExpect.Type.DB_QUERY,
+      on = HostTag.ELECTED_MASTER,
+      validator = QueueDeciderValidator.class,
+      forRca = PersistedAction.class,
+      timeoutSeconds = 1000)
+  @AErrorPatternIgnored(pattern = "CacheUtil:getCacheMaxSize()",
+      reason = "Cache related configs are expected to be missing in this integ test")
+  @AErrorPatternIgnored(pattern = "AggregateMetric:gather()",
+      reason = "Cache metrics are expected to be missing in this integ test")
+  @AErrorPatternIgnored(pattern = "SubscribeResponseHandler:onError()",
+      reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+  public void testQueueCapacityDecider() {
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/dedicated_master/QueueRcaDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/dedicated_master/QueueRcaDedicatedMasterITest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.dedicated_master;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.Constants.QUEUE_TUNING_RESOURCES_DIR;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolDimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_QueueCapacity;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_RejectedReqs;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AErrorPatternIgnored;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AExpect;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AMetric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaGraph;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.Consts;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.validator.QueueRejectionValidator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.ElasticSearchAnalysisGraph;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.QueueRejectionClusterRca;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(RcaItNotEncryptedRunner.class)
+
+@Category(RcaItMarker.class)
+@AClusterType(ClusterType.MULTI_NODE_DEDICATED_MASTER)
+@ARcaGraph(ElasticSearchAnalysisGraph.class)
+//specify a custom rca.conf to set the rejection-time-period-in-seconds to 5s to reduce runtime
+@ARcaConf(dataNode = QUEUE_TUNING_RESOURCES_DIR + "rca.conf")
+@AMetric(name = ThreadPool_RejectedReqs.class,
+    dimensionNames = {ThreadPoolDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = HostTag.DATA_0,
+            tuple = {
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.WRITE_NAME},
+                    sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.SEARCH_NAME},
+                    sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
+            }
+        )
+    }
+)
+
+@AMetric(name = ThreadPool_QueueCapacity.class,
+    dimensionNames = {ThreadPoolDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = HostTag.DATA_0,
+            tuple = {
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.WRITE_NAME},
+                    sum = 500, avg = 500, min = 500, max = 500),
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.SEARCH_NAME},
+                    sum = 1500, avg = 1500, min = 1500, max = 1500)
+            }
+        )
+    }
+)
+public class QueueRcaDedicatedMasterITest {
+  // This integ test is built to test queue rejection RCA + queue rejection cluster RCA
+  // This test injects queue rejection metrics on one of the data node and queries the
+  // rest API on master to check whether queue rejection cluster RCA becomes unhealthy
+  @Test
+  @AExpect(
+      what = AExpect.Type.REST_API,
+      on = HostTag.ELECTED_MASTER,
+      validator = QueueRejectionValidator.class,
+      forRca = QueueRejectionClusterRca.class,
+      timeoutSeconds = 500)
+  @AErrorPatternIgnored(pattern = "CacheUtil:getCacheMaxSize()",
+      reason = "Cache related configs are expected to be missing in this integ test")
+  @AErrorPatternIgnored(pattern = "AggregateMetric:gather()",
+      reason = "Cache metrics are expected to be missing in this integ test")
+  @AErrorPatternIgnored(pattern = "SubscribeResponseHandler:onError()",
+      reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+  public void testQueueRejectionRca() {
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/multi_node/QueueDeciderMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/multi_node/QueueDeciderMultiNodeITest.java
@@ -13,7 +13,9 @@
  *  permissions and limitations under the License.
  */
 
-package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning;
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.multi_node;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.Constants.QUEUE_TUNING_RESOURCES_DIR;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolType;
@@ -32,9 +34,9 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.fr
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.Consts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.validator.QueueRejectionValidator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.validator.QueueDeciderValidator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.ElasticSearchAnalysisGraph;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.QueueRejectionClusterRca;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -42,10 +44,10 @@ import org.junit.runner.RunWith;
 @RunWith(RcaItNotEncryptedRunner.class)
 
 @Category(RcaItMarker.class)
-@AClusterType(ClusterType.MULTI_NODE_CO_LOCATED_MASTER)
+@AClusterType(ClusterType.MULTI_NODE_DEDICATED_MASTER)
 @ARcaGraph(ElasticSearchAnalysisGraph.class)
 //specify a custom rca.conf to set the rejection-time-period-in-seconds to 5s to reduce runtime
-@ARcaConf(dataNode = RcaItQueueTuning.QUEUE_TUNING_RESOURCES_DIR + "rca.conf")
+@ARcaConf(dataNode = QUEUE_TUNING_RESOURCES_DIR + "rca.conf")
 @AMetric(name = ThreadPool_RejectedReqs.class,
     dimensionNames = {ThreadPoolDimension.Constants.TYPE_VALUE},
     tables = {
@@ -53,14 +55,6 @@ import org.junit.runner.RunWith;
             tuple = {
                 @ATuple(dimensionValues = {ThreadPoolType.Constants.WRITE_NAME},
                     sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
-                @ATuple(dimensionValues = {ThreadPoolType.Constants.SEARCH_NAME},
-                    sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
-            }
-        ),
-        @ATable(hostTag = {HostTag.ELECTED_MASTER},
-            tuple = {
-                @ATuple(dimensionValues = {ThreadPoolType.Constants.WRITE_NAME},
-                    sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
                 @ATuple(dimensionValues = {ThreadPoolType.Constants.SEARCH_NAME},
                     sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
             }
@@ -78,37 +72,26 @@ import org.junit.runner.RunWith;
                 @ATuple(dimensionValues = {ThreadPoolType.Constants.SEARCH_NAME},
                     sum = 1500, avg = 1500, min = 1500, max = 1500)
             }
-        ),
-        @ATable(hostTag = {HostTag.ELECTED_MASTER},
-            tuple = {
-                @ATuple(dimensionValues = {ThreadPoolType.Constants.WRITE_NAME},
-                    sum = 0.0, avg = 0.0, min = 0.0, max = 0.0),
-                @ATuple(dimensionValues = {ThreadPoolType.Constants.SEARCH_NAME},
-                    sum = 1500, avg = 1500, min = 1500, max = 1500)
-            }
         )
     }
 )
-public class RcaItQueueTuning {
-  public static final String QUEUE_TUNING_RESOURCES_DIR = Consts.INTEG_TESTS_SRC_DIR + "./tests/queue_tuning/resource/";
-
-  // This integ test is built to test queue rejection RCA + queue rejection cluster RCA
+public class QueueDeciderMultiNodeITest {
+  // This integ test is built to test Decision Maker framework and queue remediation actions
   // This test injects queue rejection metrics on one of the data node and queries the
-  // rest API on master to check whether queue rejection cluster RCA becomes unhealthy
-  //TODO : extend this integ test to cover Decision Maker framework and queue remediation actions
+  // sqlite table on master to check whether queue remediation actions has been published.
   @Test
   @AExpect(
-      what = AExpect.Type.REST_API,
+      what = AExpect.Type.DB_QUERY,
       on = HostTag.ELECTED_MASTER,
-      validator = QueueRejectionValidator.class,
-      forRca = QueueRejectionClusterRca.class,
-      timeoutSeconds = 500)
+      validator = QueueDeciderValidator.class,
+      forRca = PersistedAction.class,
+      timeoutSeconds = 1000)
   @AErrorPatternIgnored(pattern = "CacheUtil:getCacheMaxSize()",
       reason = "Cache related configs are expected to be missing in this integ test")
   @AErrorPatternIgnored(pattern = "AggregateMetric:gather()",
       reason = "Cache metrics are expected to be missing in this integ test")
   @AErrorPatternIgnored(pattern = "SubscribeResponseHandler:onError()",
       reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
-  public void testQueueRejectionRca() {
+  public void testQueueCapacityDecider() {
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/multi_node/QueueRcaMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/multi_node/QueueRcaMultiNodeITest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.multi_node;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.Constants.QUEUE_TUNING_RESOURCES_DIR;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolDimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_QueueCapacity;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_RejectedReqs;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AErrorPatternIgnored;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AExpect;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AMetric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaGraph;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.Consts;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.validator.QueueRejectionValidator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.ElasticSearchAnalysisGraph;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.QueueRejectionClusterRca;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(RcaItNotEncryptedRunner.class)
+
+@Category(RcaItMarker.class)
+@AClusterType(ClusterType.MULTI_NODE_CO_LOCATED_MASTER)
+@ARcaGraph(ElasticSearchAnalysisGraph.class)
+//specify a custom rca.conf to set the rejection-time-period-in-seconds to 5s to reduce runtime
+@ARcaConf(dataNode = QUEUE_TUNING_RESOURCES_DIR + "rca.conf")
+@AMetric(name = ThreadPool_RejectedReqs.class,
+    dimensionNames = {ThreadPoolDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = HostTag.DATA_0,
+            tuple = {
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.WRITE_NAME},
+                    sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.SEARCH_NAME},
+                    sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
+            }
+        )
+    }
+)
+
+@AMetric(name = ThreadPool_QueueCapacity.class,
+    dimensionNames = {ThreadPoolDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = HostTag.DATA_0,
+            tuple = {
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.WRITE_NAME},
+                    sum = 500, avg = 500, min = 500, max = 500),
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.SEARCH_NAME},
+                    sum = 1500, avg = 1500, min = 1500, max = 1500)
+            }
+        )
+    }
+)
+public class QueueRcaMultiNodeITest {
+  // This integ test is built to test queue rejection RCA + queue rejection cluster RCA
+  // This test injects queue rejection metrics on one of the data node and queries the
+  // rest API on master to check whether queue rejection cluster RCA becomes unhealthy
+  @Test
+  @AExpect(
+      what = AExpect.Type.REST_API,
+      on = HostTag.ELECTED_MASTER,
+      validator = QueueRejectionValidator.class,
+      forRca = QueueRejectionClusterRca.class,
+      timeoutSeconds = 500)
+  @AErrorPatternIgnored(pattern = "CacheUtil:getCacheMaxSize()",
+      reason = "Cache related configs are expected to be missing in this integ test")
+  @AErrorPatternIgnored(pattern = "AggregateMetric:gather()",
+      reason = "Cache metrics are expected to be missing in this integ test")
+  @AErrorPatternIgnored(pattern = "SubscribeResponseHandler:onError()",
+      reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+  public void testQueueRejectionRca() {
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/resource/rca.conf
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/resource/rca.conf
@@ -65,20 +65,16 @@
     }
   },
 
-  // Action Configurations
-  "action-config-settings": {
-    "cache-settings": {
-      "cool-off-period-in-seconds" : 10
-    },
-    "queue-settings": {
-      "cool-off-period-in-seconds" : 10
-    }
-  },
-
   "muted-rcas": [],
   "muted-deciders": [],
   "muted-actions": [],
 
-  "decider-config-settings": {
+  "decider-config-settings": {},
+
+  // Action Configurations
+  "action-config-settings": {
+    "queue-settings": {
+      "cool-off-period-in-seconds" : 10
+    }
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/validator/QueueDeciderValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/validator/QueueDeciderValidator.java
@@ -13,35 +13,35 @@
  *  permissions and limitations under the License.
  */
 
-package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.cache_tuning.validator;
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.validator;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ModifyCacheMaxSizeAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ModifyQueueCapacityAction;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.api.IValidator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
 import org.junit.Assert;
 
-public class ShardRequestCacheDeciderValidator implements IValidator {
+public class QueueDeciderValidator implements IValidator {
     AppContext appContext;
     long startTime;
 
-    public ShardRequestCacheDeciderValidator() {
+    public QueueDeciderValidator() {
         appContext = new AppContext();
         startTime = System.currentTimeMillis();
     }
 
     /**
-     * {"actionName":"ModifyCacheMaxSize",
-     * "resourceValue":11,
+     * {"actionName":"ModifyQueueCapacity",
+     * "resourceValue":4,
      * "timestamp":"1599257910923",
      * "nodeId":"node1",
-     * "nodeIp":1.1.1.1,
+     * "nodeIp":127.0.0.1,
      * "actionable":1,
-     * "coolOffPeriod": 300000,
-     * "muted": 1,
-     * "summary": "Id":"DATA_0","Ip":"127.0.0.1","resource":11,"desiredCacheMaxSizeInBytes":10000,"currentCacheMaxSizeInBytes":100,
-     *            "coolOffPeriodInMillis":300000,"canUpdate":true}
+     * "coolOffPeriod": 10000,
+     * "muted": 0
+     * "summary": "Id":"DATA_0","Ip":"127.0.0.1","resource":4,"desiredCapacity":547,
+     *            "currentCapacity":500,"coolOffPeriodInMillis":10000,"canUpdate":true}
      */
     @Override
     public boolean checkDbObj(Object object) {
@@ -53,29 +53,29 @@ public class ShardRequestCacheDeciderValidator implements IValidator {
     }
 
     /**
-     * {"actionName":"ModifyCacheMaxSize",
-     * "resourceValue":11,
+     * {"actionName":"ModifyQueueCapacity",
+     * "resourceValue":4,
      * "timestamp":"1599257910923",
      * "nodeId":"node1",
-     * "nodeIp":1.1.1.1,
+     * "nodeIp":127.0.0.1,
      * "actionable":1,
-     * "coolOffPeriod": 300000,
-     * "muted": 1
-     * "summary": "Id":"DATA_0","Ip":"127.0.0.1","resource":11,"desiredCacheMaxSizeInBytes":10000,"currentCacheMaxSizeInBytes":100,
-     *            "coolOffPeriodInMillis":300000,"canUpdate":true}
+     * "coolOffPeriod": 10000,
+     * "muted": 0
+     * "summary": "Id":"DATA_0","Ip":"127.0.0.1","resource":4,"desiredCapacity":547,
+     *            "currentCapacity":500,"coolOffPeriodInMillis":10000,"canUpdate":true}
      */
     private boolean checkPersistedAction(final PersistedAction persistedAction) {
-        ModifyCacheMaxSizeAction modifyCacheMaxSizeAction =
-                ModifyCacheMaxSizeAction.fromSummary(persistedAction.getSummary(), appContext);
-        Assert.assertEquals(ModifyCacheMaxSizeAction.NAME, persistedAction.getActionName());
+        ModifyQueueCapacityAction modifyQueueCapacityAction =
+                ModifyQueueCapacityAction.fromSummary(persistedAction.getSummary(), appContext);
+        Assert.assertEquals(ModifyQueueCapacityAction.NAME, persistedAction.getActionName());
         Assert.assertEquals("{DATA_0}", persistedAction.getNodeIds());
         Assert.assertEquals("{127.0.0.1}", persistedAction.getNodeIps());
         Assert.assertEquals(10000, persistedAction.getCoolOffPeriod());
         Assert.assertTrue(persistedAction.isActionable());
         Assert.assertFalse(persistedAction.isMuted());
-        Assert.assertEquals(ResourceEnum.SHARD_REQUEST_CACHE, modifyCacheMaxSizeAction.getCacheType());
-        Assert.assertEquals(100, modifyCacheMaxSizeAction.getCurrentCacheMaxSizeInBytes());
-        Assert.assertEquals(10000, modifyCacheMaxSizeAction.getDesiredCacheMaxSizeInBytes());
+        Assert.assertEquals(ResourceEnum.WRITE_THREADPOOL, modifyQueueCapacityAction.getThreadPool());
+        Assert.assertEquals(547, modifyQueueCapacityAction.getDesiredCapacity());
+        Assert.assertEquals(500, modifyQueueCapacityAction.getCurrentCapacity());
         return true;
     }
 }

--- a/src/test/resources/rca/rca_elected_master.conf
+++ b/src/test/resources/rca/rca_elected_master.conf
@@ -76,11 +76,11 @@
     },
     "field-data-cache-rca-config": {
       "field-data-cache-size-threshold" : 0.8,
-      "field-data-collector-time-period-in-sec" : 300
+      "field-data-collector-time-period-in-sec" : 10
     },
     "shard-request-cache-rca-config": {
       "shard-request-cache-threshold" : 0.9,
-      "shard-request-collector-time-period-in-sec" : 300
+      "shard-request-collector-time-period-in-sec" : 30
     }
   },
 
@@ -105,6 +105,16 @@
     "cache-bounds": {
       "field-data-cache-upper-bound" : 0.5,
       "shard-request-cache-upper-bound" : 0.1
+    }
+  },
+
+  // Action Configurations
+  "action-config-settings": {
+    "cache-settings": {
+      "cool-off-period-in-seconds" : 10
+    },
+    "queue-settings": {
+      "cool-off-period-in-seconds" : 10
     }
   }
 }

--- a/src/test/resources/rca/rca_elected_master.conf
+++ b/src/test/resources/rca/rca_elected_master.conf
@@ -80,7 +80,7 @@
     },
     "shard-request-cache-rca-config": {
       "shard-request-cache-threshold" : 0.9,
-      "shard-request-collector-time-period-in-sec" : 30
+      "shard-request-collector-time-period-in-sec" : 10
     }
   },
 


### PR DESCRIPTION
*Fixes #:*

*Description of changes:*
Added queue decider IT (for dedicated master and multi-node clusters)

*If new tests are added, how long do the new ones take to complete* 
```
com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.dedicated_master.QueueRcaDedicatedMasterITest
  Test testQueueRejectionRca PASSED (1m 59s)

com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.dedicated_master.QueueDeciderDedicatedMasterITest
  Test testQueueCapacityDecider PASSED (1m 59s)

com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.multi_node.QueueRcaMultiNodeITest
  Test testQueueRejectionRca PASSED (1m 59s)

com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.multi_node.QueueDeciderMultiNodeITest
  Test testQueueCapacityDecider PASSED (1m 59s)
```

*Tests:*
IT 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
