### PR TITLE
Persistable Alarms and YoungGenTuningPolicy

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/JvmGenAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/JvmGenAction.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
+import com.google.gson.JsonObject;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * JvmGenAction modifies a generational Garbage Collector's tuning parameters
+ *
+ * <p>This class is currently used to tune the young generation size when the CMS collector is being used
+ */
+public class JvmGenAction extends SuppressibleAction {
+  public static final String NAME = "JvmGenAction";
+  private static final ImpactVector NO_IMPACT = new ImpactVector();
+
+  private final long targetRatio;
+  private final long coolOffPeriodInMillis;
+  private final boolean canUpdate;
+
+  public JvmGenAction(
+      final AppContext appContext,
+      final int targetRatio,
+      final long coolOffPeriodInMillis,
+      final boolean canUpdate) {
+    super(appContext);
+    this.targetRatio = targetRatio;
+    this.coolOffPeriodInMillis = coolOffPeriodInMillis;
+    this.canUpdate = canUpdate;
+  }
+
+  public long getTargetRatio() {
+    return targetRatio;
+  }
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public boolean canUpdate() {
+    return canUpdate;
+  }
+
+  @Override
+  public long coolOffPeriodInMillis() {
+    return coolOffPeriodInMillis;
+  }
+
+  @Override
+  public List<NodeKey> impactedNodes() {
+    // all nodes are impacted by this change
+    return appContext.getDataNodeInstances().stream().map(NodeKey::new).collect(Collectors.toList());
+  }
+
+  /* TODO we can guess at this more accurately from metrics, but increasing/decreasing may have different
+      impacts at different times */
+  @Override
+  public Map<NodeKey, ImpactVector> impact() {
+    Map<NodeKey, ImpactVector> impact = new HashMap<>();
+    for (NodeKey key : impactedNodes()) {
+      impact.put(key, NO_IMPACT);
+    }
+    return impact;
+  }
+
+  @Override
+  public String summary() {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("resource", ResourceEnum.YOUNG_GEN.getNumber());
+    jsonObject.addProperty("targetRatio", targetRatio);
+    jsonObject.addProperty("coolOffPeriodInMillis", coolOffPeriodInMillis);
+    jsonObject.addProperty("canUpdate", canUpdate);
+    return jsonObject.toString();
+  }
+
+  @Override
+  public String toString() {
+    return summary();
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/configs/DeciderConfig.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/configs/DeciderConfig.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.configs;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.configs.jvm.JvmGenTuningPolicyConfig;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.configs.jvm.OldGenDecisionPolicyConfig;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.NestedConfig;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
@@ -35,7 +36,10 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
  *     },
  *     "old-gen-decision-policy-config": {
  *       XXXX
- *     }
+ *     },
+ *     "jvm-gen-tuning-policy-config": {
+ *       XXXX
+ *     },
  *   },
  */
 public class DeciderConfig {
@@ -43,10 +47,12 @@ public class DeciderConfig {
     private static final String CACHE_CONFIG_NAME = "cache-type";
     private static final String WORKLOAD_CONFIG_NAME = "workload-type";
     private static final String OLD_GEN_DECISION_POLICY_CONFIG_NAME = "old-gen-decision-policy-config";
+    private static final String JVM_GEN_TUNING_POLICY_CONFIG_NAME = "jvm-gen-tuning-policy-config";
 
     private final CachePriorityOrderConfig cachePriorityOrderConfig;
     private final WorkLoadTypeConfig workLoadTypeConfig;
     private final OldGenDecisionPolicyConfig oldGenDecisionPolicyConfig;
+    private final JvmGenTuningPolicyConfig jvmGenTuningPolicyConfig;
 
     public DeciderConfig(final RcaConf rcaConf) {
         cachePriorityOrderConfig = new CachePriorityOrderConfig(
@@ -57,6 +63,9 @@ public class DeciderConfig {
         );
         oldGenDecisionPolicyConfig = new OldGenDecisionPolicyConfig(
             new NestedConfig(OLD_GEN_DECISION_POLICY_CONFIG_NAME, rcaConf.getDeciderConfigSettings())
+        );
+        jvmGenTuningPolicyConfig = new JvmGenTuningPolicyConfig(
+            new NestedConfig(JVM_GEN_TUNING_POLICY_CONFIG_NAME, rcaConf.getDeciderConfigSettings())
         );
     }
 
@@ -70,5 +79,9 @@ public class DeciderConfig {
 
     public OldGenDecisionPolicyConfig getOldGenDecisionPolicyConfig() {
         return oldGenDecisionPolicyConfig;
+    }
+
+    public JvmGenTuningPolicyConfig getJvmGenTuningPolicyConfig() {
+        return jvmGenTuningPolicyConfig;
     }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/configs/jvm/JvmGenTuningPolicyConfig.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/configs/jvm/JvmGenTuningPolicyConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.configs.jvm;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.jvm.JvmGenTuningPolicy;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Config;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.NestedConfig;
+
+/**
+ * Configures various options for the
+ * {@link JvmGenTuningPolicy}
+ *
+ * <p>The config follows the format below
+ *  "decider-config-settings": {
+ *    "jvm-generation-tuning-policy-config": {
+ *       "enabled": true,
+ *       "allow-young-gen-downsize": false,
+ *       ...
+ *    }
+ * }
+ */
+public class JvmGenTuningPolicyConfig {
+  private static final String ENABLED = "enabled";
+  private static final String ALLOW_YOUNG_GEN_DOWNSIZE = "allow-young-gen-downsize";
+
+  public static final boolean DEFAULT_ENABLED = false;
+  public static final boolean DEFAULT_ALLOW_YOUNG_GEN_DOWNSIZE = false;
+
+  private Config<Boolean> enabled;
+  private Config<Boolean> allowYoungGenDownsize;
+
+  public JvmGenTuningPolicyConfig(NestedConfig config) {
+    enabled = new Config<>(ENABLED, config.getValue(), DEFAULT_ENABLED, Boolean.class);
+    allowYoungGenDownsize = new Config<>(ALLOW_YOUNG_GEN_DOWNSIZE, config.getValue(),
+        DEFAULT_ALLOW_YOUNG_GEN_DOWNSIZE, Boolean.class);
+  }
+
+  /**
+   * Whether or not to enable the policy. A disabled policy will not emit any actions.
+   * @return Whether or not to enable the policy
+   */
+  public boolean isEnabled() {
+    return enabled.getValue();
+  }
+
+  /**
+   * Whether or not the policy should suggest scaling down the young generation
+   * @return Whether or not the policy should suggest scaling down the young generation
+   */
+  public boolean allowYoungGenDownsize() {
+    return allowYoungGenDownsize.getValue();
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/HeapHealthDecider.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/HeapHealthDecider.java
@@ -31,12 +31,14 @@ public class HeapHealthDecider extends Decider {
 
   public static final String NAME = "HeapHealthDecider";
   private final OldGenDecisionPolicy oldGenDecisionPolicy;
+  private final JvmGenTuningPolicy jvmGenTuningPolicy;
   private int counter = 0;
 
   public HeapHealthDecider(int decisionFrequency, final HighHeapUsageClusterRca highHeapUsageClusterRca) {
     //TODO : refactor parent class to remove evalIntervalSeconds completely
     super(5, decisionFrequency);
     oldGenDecisionPolicy = new OldGenDecisionPolicy(highHeapUsageClusterRca);
+    jvmGenTuningPolicy = new JvmGenTuningPolicy(highHeapUsageClusterRca);
   }
 
   @Override
@@ -58,7 +60,9 @@ public class HeapHealthDecider extends Decider {
     oldGenPolicyActions.forEach(decision::addAction);
 
     // TODO: Add actions from JvmScaleUpPolicy (128gb heaps)
-    // TODO: If no JvmScaleUpPolicy actions found, fetch and add genTuningPolicy actions
+    //  only fetch jvmTuningActions if no JvmScaleUpPolicy actions are found
+    List<Action> jvmGenTuningActions = jvmGenTuningPolicy.evaluate();
+    jvmGenTuningActions.forEach(decision::addAction);
 
     return decision;
   }
@@ -67,11 +71,13 @@ public class HeapHealthDecider extends Decider {
   public void readRcaConf(RcaConf conf) {
     super.readRcaConf(conf);
     oldGenDecisionPolicy.setRcaConf(conf);
+    jvmGenTuningPolicy.setRcaConf(conf);
   }
 
   @Override
   public void setAppContext(final AppContext appContext) {
     super.setAppContext(appContext);
     oldGenDecisionPolicy.setAppContext(appContext);
+    jvmGenTuningPolicy.setAppContext(appContext);
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmActionsAlarmMonitor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmActionsAlarmMonitor.java
@@ -19,12 +19,20 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.dec
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.aggregators.BucketizedSlidingWindow;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.aggregators.SlidingWindowData;
 import com.google.common.annotations.VisibleForTesting;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 
 public class JvmActionsAlarmMonitor implements AlarmMonitor {
 
   private static final int DEFAULT_DAY_BREACH_THRESHOLD = 5;
   private static final int DEFAULT_WEEK_BREACH_THRESHOLD = 2;
+  private static final String DAY_PREFIX = "day-";
+  private static final String WEEK_PREFIX = "week-";
+
+  public static final int DAY_MONITOR_BUCKET_WINDOW_MINUTES = 30;
+  public static final int WEEK_MONITOR_BUCKET_WINDOW_MINUTES = 86400;
 
   private BucketizedSlidingWindow dayMonitor;
   private BucketizedSlidingWindow weekMonitor;
@@ -32,11 +40,27 @@ public class JvmActionsAlarmMonitor implements AlarmMonitor {
   private int weekBreachThreshold;
   private boolean alarmHealthy = true;
 
-  public JvmActionsAlarmMonitor(int dayBreachThreshold, int weekBreachThreshold) {
-    dayMonitor = new BucketizedSlidingWindow((int) TimeUnit.DAYS.toMinutes(1), 30, TimeUnit.MINUTES);
-    weekMonitor = new BucketizedSlidingWindow(4, 1, TimeUnit.DAYS);
+  public JvmActionsAlarmMonitor(int dayBreachThreshold, int weekBreachThreshold, @Nullable Path persistencePath) {
+    Path dayMonitorPath = null;
+    Path weekMonitorPath = null;
+    if (persistencePath != null) {
+      String persistenceBase = persistencePath.getParent().toString();
+      String persistenceFile = persistencePath.getFileName().toString();
+      dayMonitorPath = Paths.get(persistenceBase, DAY_PREFIX + persistenceFile);
+      weekMonitorPath = Paths.get(persistenceBase, WEEK_PREFIX + persistenceFile);
+    }
+    dayMonitor = new BucketizedSlidingWindow((int) TimeUnit.DAYS.toMinutes(1), 30, TimeUnit.MINUTES, dayMonitorPath);
+    weekMonitor = new BucketizedSlidingWindow(4, 1, TimeUnit.DAYS, weekMonitorPath);
     this.dayBreachThreshold = dayBreachThreshold;
     this.weekBreachThreshold = weekBreachThreshold;
+  }
+
+  public JvmActionsAlarmMonitor(int dayBreachThreshold, int weekBreachThreshold) {
+    this(dayBreachThreshold, weekBreachThreshold, null);
+  }
+
+  public JvmActionsAlarmMonitor(@Nullable Path persistencePath) {
+    this(DEFAULT_DAY_BREACH_THRESHOLD, DEFAULT_WEEK_BREACH_THRESHOLD, persistencePath);
   }
 
   public JvmActionsAlarmMonitor() {
@@ -77,6 +101,11 @@ public class JvmActionsAlarmMonitor implements AlarmMonitor {
 
   public int getWeekBreachThreshold() {
     return weekBreachThreshold;
+  }
+
+  public void clear() {
+    this.dayMonitor.clear();
+    this.weekMonitor.clear();
   }
 
   @VisibleForTesting

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmGenTuningPolicy.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmGenTuningPolicy.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.jvm;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil.FULL_GC_PAUSE_TIME;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil.MINOR_GC_PAUSE_TIME;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil.OLD_GEN_HEAP_USAGE;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil.YOUNG_GEN_PROMOTION_RATE;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.Action;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.JvmGenAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.AlarmMonitor;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.DecisionPolicy;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.configs.jvm.JvmGenTuningPolicyConfig;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.Resource;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotClusterSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.collector.NodeConfigCache;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HighHeapUsageClusterRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Decides if the JVM heap generations could be resized to improve application
+ * performance and suggests actions to take to achieve improved performance.
+ */
+public class JvmGenTuningPolicy implements DecisionPolicy {
+  private static final Logger LOG = LogManager.getLogger(JvmGenTuningPolicy.class);
+  private static final long COOLOFF_PERIOD_IN_MILLIS = 2L * 24L * 60L * 60L * 1000L;
+  private static final Path UNDERSIZED_DATA_FILE_PATH = Paths.get(RcaConsts.CONFIG_DIR_PATH, "JvmGenerationTuningPolicy_Undersized");
+  private static final Path OVERSIZED_DATA_FILE_PATH = Paths.get(RcaConsts.CONFIG_DIR_PATH, "JvmGenerationTuningPolicy_Oversized");
+  static final List<Resource> YOUNG_GEN_UNDERSIZED_SIGNALS = Lists.newArrayList(
+      YOUNG_GEN_PROMOTION_RATE,
+      FULL_GC_PAUSE_TIME
+  );
+  static final List<Resource> YOUNG_GEN_OVERSIZED_SIGNALS = Lists.newArrayList(
+      MINOR_GC_PAUSE_TIME,
+      OLD_GEN_HEAP_USAGE
+  );
+
+  private AppContext appContext;
+  private RcaConf rcaConf;
+  private JvmGenTuningPolicyConfig policyConfig;
+  private HighHeapUsageClusterRca highHeapUsageClusterRca;
+
+  // Tracks issues which suggest that the young generation is too small
+  @VisibleForTesting
+  AlarmMonitor tooSmallAlarm;
+  // Tracks issues which suggest that the young generation is too large
+  @VisibleForTesting
+  AlarmMonitor tooLargeAlarm;
+
+  public JvmGenTuningPolicy(HighHeapUsageClusterRca highHeapUsageClusterRca) {
+    this(highHeapUsageClusterRca, null, null);
+  }
+
+  public JvmGenTuningPolicy(HighHeapUsageClusterRca highHeapUsageClusterRca,
+                            AlarmMonitor tooSmallAlarm,
+                            AlarmMonitor tooLargeAlarm) {
+    this.highHeapUsageClusterRca = highHeapUsageClusterRca;
+    if (tooSmallAlarm == null) {
+      this.tooSmallAlarm = new JvmActionsAlarmMonitor(UNDERSIZED_DATA_FILE_PATH);
+    } else {
+      this.tooSmallAlarm = tooSmallAlarm;
+    }
+    if (tooLargeAlarm == null) {
+      this.tooLargeAlarm = new JvmActionsAlarmMonitor(OVERSIZED_DATA_FILE_PATH);
+    } else {
+      this.tooLargeAlarm = tooLargeAlarm;
+    }
+  }
+
+  /**
+   * records issues which the policy cares about and discards others
+   * @param issue an issue with the application
+   */
+  private void record(HotResourceSummary issue) {
+    if (YOUNG_GEN_OVERSIZED_SIGNALS.contains(issue.getResource())) {
+      tooLargeAlarm.recordIssue();
+    } else if (YOUNG_GEN_UNDERSIZED_SIGNALS.contains(issue.getResource())) {
+      tooSmallAlarm.recordIssue();
+    }
+  }
+
+  /**
+   * gathers and records all issues observed in the application
+   */
+  private void recordIssues() {
+    if (highHeapUsageClusterRca.getFlowUnits().isEmpty()) {
+      return;
+    }
+
+    ResourceFlowUnit<HotClusterSummary> flowUnit = highHeapUsageClusterRca.getFlowUnits().get(0);
+    if (!flowUnit.hasResourceSummary()) {
+      return;
+    }
+
+    HotClusterSummary clusterSummary = flowUnit.getSummary();
+    for (HotNodeSummary nodeSummary : clusterSummary.getHotNodeSummaryList()) {
+      for (HotResourceSummary summary : nodeSummary.getHotResourceSummaryList()) {
+        record(summary);
+      }
+    }
+  }
+
+  /**
+   * returns the current old:young generation sizing ratio
+   * @return the current old:young generation sizing ratio
+   */
+  public double getCurrentRatio() {
+    if (appContext == null) {
+      return -1;
+    }
+    NodeConfigCache cache = appContext.getNodeConfigCache();
+    NodeKey key = new NodeKey(appContext.getDataNodeInstances().get(0));
+    try {
+      Double oldGenMaxSizeInBytes = cache.get(key, ResourceUtil.OLD_GEN_MAX_SIZE);
+      Double youngGenMaxSizeInBytes = cache.get(key, ResourceUtil.YOUNG_GEN_MAX_SIZE);
+      return (oldGenMaxSizeInBytes / youngGenMaxSizeInBytes);
+    } catch (IllegalArgumentException | NullPointerException e) {
+      return -1;
+    }
+  }
+
+  /**
+   * Computes a ratio that will decrease the young generation size based on the current ratio
+   * @return a ratio that will decrease the young generation size based on the current ratio
+   */
+  public int computeDecrease(double currentRatio) {
+    // Don't decrease the (old:young) ratio beyond 5:1
+    if (currentRatio < 0 || currentRatio > 5) {
+      return -1;
+    }
+    return (int) Math.floor(currentRatio + 1);
+  }
+
+  /**
+   * Computes a ratio that will increase the young generation size based on the current ratio
+   * @return a ratio that will increase the young generation size based on the current ratio
+   */
+  public int computeIncrease(double currentRatio) {
+    // Don't increase the (old:young) ratio beyond 3:1
+    if (currentRatio < 3) {
+      return -1;
+    }
+    // If the current ratio is egregious (e.g. 50:1) set the ratio to 3:1 immediately
+    double newRatio = currentRatio > 5 ? 3 : currentRatio - 1;
+    return (int) Math.floor(newRatio);
+  }
+
+  /**
+   * Returns true if the young generation is too small
+   * @return true if the young generation is too small
+   */
+  public boolean youngGenerationIsTooSmall() {
+    return !tooSmallAlarm.isHealthy();
+  }
+
+  /**
+   * Returns true if the young generation is too large
+   * @return true if the young generation is too large
+   */
+  public boolean youngGenerationIsTooLarge() {
+    return !tooLargeAlarm.isHealthy();
+  }
+
+  @Override
+  public List<Action> evaluate() {
+    List<Action> actions = new ArrayList<>();
+    if (rcaConf == null || appContext ==  null) {
+      LOG.error("rca conf/app context is null, return empty action list");
+      return actions;
+    }
+    policyConfig = rcaConf.getDeciderConfig().getJvmGenTuningPolicyConfig();
+    if (!policyConfig.isEnabled()) {
+      LOG.debug("JvmGenerationTuningPolicy is disabled");
+      return actions;
+    }
+    recordIssues();
+    if (youngGenerationIsTooLarge()) {
+      // only decrease the young generation if the config allows it
+      if (policyConfig.allowYoungGenDownsize()) {
+        int newRatio = computeDecrease(getCurrentRatio());
+        if (newRatio >= 1) {
+          actions.add(
+              new JvmGenAction(appContext, newRatio, COOLOFF_PERIOD_IN_MILLIS, true));
+        }
+      }
+    } else if (youngGenerationIsTooSmall()) {
+      int newRatio = computeIncrease(getCurrentRatio());
+      if (newRatio >= 1) {
+        actions.add(new JvmGenAction(appContext, newRatio, COOLOFF_PERIOD_IN_MILLIS, true));
+      }
+    }
+    return actions;
+  }
+
+  public void setAppContext(AppContext appContext) {
+    this.appContext = appContext;
+  }
+
+  public void setRcaConf(final RcaConf rcaConf) {
+    this.rcaConf = rcaConf;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/SlidingWindow.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/SlidingWindow.java
@@ -102,4 +102,8 @@ public class SlidingWindow<E extends SlidingWindowData> {
   public int size() {
     return windowDeque.size();
   }
+
+  public void clear() {
+    this.windowDeque.clear();
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
@@ -42,7 +42,12 @@ public enum ExceptionsAndErrors implements MeasurementSet {
   /**
    * When persisting action or flowunits, the persistable throws an exception when it is unable to write to DB.
    */
-  EXCEPTION_IN_PERSIST("ExceptionInPersist", "namedCount", Statistics.NAMED_COUNTERS);
+  EXCEPTION_IN_PERSIST("ExceptionInPersist", "namedCount", Statistics.NAMED_COUNTERS),
+
+  /**
+   * When attempting to read data from some datastore fails unexpectedly
+   */
+  EXCEPTION_IN_READ("ExceptionInRead", "namedCount", Statistics.NAMED_COUNTERS);
 
   /** What we want to appear as the metric name. */
   private String name;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/RcaConsts.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/RcaConsts.java
@@ -36,7 +36,7 @@ public class RcaConsts {
   private static final String RCA_CONF_FILENAME = "rca.conf";
   private static final String RCA_CONF_IDLE_MASTER_FILENAME = "rca_idle_master.conf";
   private static final String THRESHOLDS_DIR_NAME = "thresholds";
-  private static final String CONFIG_DIR_PATH =
+  public static final String CONFIG_DIR_PATH =
       Paths.get(Util.READER_LOCATION, "pa_config").toString();
   public static final String RCA_CONF_PATH =
       Paths.get(CONFIG_DIR_PATH, RCA_CONF_FILENAME).toString();

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmGenTuningPolicyTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmGenTuningPolicyTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.jvm;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil.MINOR_GC_PAUSE_TIME;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil.YOUNG_GEN_PROMOTION_RATE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.Action;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.JvmGenAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.AlarmMonitor;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.configs.DeciderConfig;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.configs.jvm.JvmGenTuningPolicyConfig;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.Resource;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.NodeRole;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotClusterSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails.Id;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails.Ip;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.collector.NodeConfigCache;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HighHeapUsageClusterRca;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class JvmGenTuningPolicyTest {
+  private JvmGenTuningPolicy policy;
+  @Mock
+  private HighHeapUsageClusterRca rca;
+  @Mock
+  private JvmGenTuningPolicyConfig policyConfig;
+  @Mock
+  private AlarmMonitor tooSmallAlarm;
+  @Mock
+  private AlarmMonitor tooLargeAlarm;
+  @Mock
+  private RcaConf rcaConf;
+  @Mock
+  private AppContext appContext;
+
+  @Before
+  @SuppressWarnings("unchecked")
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    policy = new JvmGenTuningPolicy(rca, tooSmallAlarm, tooLargeAlarm);
+    policy.setRcaConf(rcaConf);
+    policy.setAppContext(appContext);
+    DeciderConfig deciderConfig = mock(DeciderConfig.class);
+    when(rcaConf.getDeciderConfig()).thenReturn(deciderConfig);
+    when(deciderConfig.getJvmGenTuningPolicyConfig()).thenReturn(policyConfig);
+    ResourceFlowUnit<HotClusterSummary> flowUnit = (ResourceFlowUnit<HotClusterSummary>) mock(ResourceFlowUnit.class);
+    when(rca.getFlowUnits()).thenReturn(Collections.singletonList(flowUnit));
+  }
+
+  /**
+   * After a call to this function, rca will return a FlowUnit containing n issues with resource
+   *
+   * <p>This is useful because the policy suggests actions based on resources and the count of issues
+   * observed for those resources.
+   *
+   * @param n the number of young gen issues
+   */
+  private void mockRcaIssues(int n, Resource resource) {
+    ResourceFlowUnit<HotClusterSummary> flowUnit = new ResourceFlowUnit<>(1);
+    HotNodeSummary nodeSummary = new HotNodeSummary(new Id("A"), new Ip("127.0.0.1"));
+    for (int i = 0; i < n; i++) {
+      nodeSummary.appendNestedSummary(new HotResourceSummary(resource, 1, 1, 1));
+    }
+    HotClusterSummary hotClusterSummary = new HotClusterSummary(3, 1);
+    hotClusterSummary.appendNestedSummary(nodeSummary);
+    flowUnit.setSummary(hotClusterSummary);
+    when(rca.getFlowUnits()).thenReturn(Collections.singletonList(flowUnit));
+  }
+
+  /**
+   * Causes the policy to view the old:young gen size ratio as desiredRatio
+   * @param desiredRatio the old:young gen size ratio; 3 means the old gen is 3X larger than young
+   */
+  private void mockCurrentRatio(double desiredRatio) {
+    NodeConfigCache cache = mock(NodeConfigCache.class);
+    when(appContext.getNodeConfigCache()).thenReturn(cache);
+    when(appContext.getDataNodeInstances()).thenReturn(Collections.singletonList(
+        new InstanceDetails(NodeRole.DATA, new Id("A"), new Ip("127.0.0.1"), false)));
+    when(cache.get(any(), eq(ResourceUtil.OLD_GEN_MAX_SIZE))).thenReturn(desiredRatio);
+    when(cache.get(any(), eq(ResourceUtil.YOUNG_GEN_MAX_SIZE))).thenReturn(1d);
+  }
+
+  /**
+   * When one of rcaConf, appContext is null, policy evaluation should return no actions
+   */
+  @Test
+  public void testEvaluate_withoutContext() {
+    policy.setRcaConf(null);
+    Assert.assertTrue(policy.evaluate().isEmpty());
+    policy.setAppContext(null);
+    Assert.assertTrue(policy.evaluate().isEmpty());
+    policy.setRcaConf(rcaConf);
+    Assert.assertTrue(policy.evaluate().isEmpty());
+  }
+
+  /**
+   * Tests that the evaluate() method returns the correct actions in various scenarios
+   */
+  @Test
+  public void testEvaluate() {
+    // The policy should not emit actions when it is disabled
+    when(policyConfig.isEnabled()).thenReturn(false);
+    Assert.assertTrue(policy.evaluate().isEmpty());
+    when(policyConfig.isEnabled()).thenReturn(true);
+    // Neither generation has had enough issues
+    mockRcaIssues(1, MINOR_GC_PAUSE_TIME);
+    // The policy should not suggest any actions when there are no issues
+    when(policyConfig.allowYoungGenDownsize()).thenReturn(false);
+    Assert.assertTrue(policy.evaluate().isEmpty());
+    verify(tooLargeAlarm, times(1)).recordIssue();
+    reset(tooLargeAlarm);
+    // Make the young generation seem oversized
+    mockRcaIssues(10, MINOR_GC_PAUSE_TIME);
+    // The policy should not suggest decreasing young gen when the option is disabled
+    when(tooLargeAlarm.isHealthy()).thenReturn(false);
+    when(policyConfig.allowYoungGenDownsize()).thenReturn(false);
+    Assert.assertTrue(policy.evaluate().isEmpty());
+    verify(tooLargeAlarm, times(10)).recordIssue();
+    // The policy should suggest decreasing young gen when it is oversized and the option is enabled
+    when(policyConfig.allowYoungGenDownsize()).thenReturn(true);
+    mockCurrentRatio(4);
+    List<Action> actions = policy.evaluate();
+    Assert.assertEquals(1, actions.size());
+    Assert.assertTrue(actions.get(0) instanceof JvmGenAction);
+    Assert.assertEquals(5, ((JvmGenAction) actions.get(0)).getTargetRatio());
+    // Make the young generation seem undersized
+    mockRcaIssues(10, YOUNG_GEN_PROMOTION_RATE);
+    // The policy should suggest increasing young gen when it is undersized
+    mockCurrentRatio(50);
+    when(tooLargeAlarm.isHealthy()).thenReturn(true);
+    when(tooSmallAlarm.isHealthy()).thenReturn(false);
+    actions = policy.evaluate();
+    verify(tooSmallAlarm, times(10)).recordIssue();
+    Assert.assertEquals(1, actions.size());
+    Assert.assertTrue(actions.get(0) instanceof JvmGenAction);
+    Assert.assertEquals(3, ((JvmGenAction) actions.get(0)).getTargetRatio());
+  }
+}


### PR DESCRIPTION
Fixes #: N/A

Description of changes: 
Each of the following is split into a logical commit to make reviewing easier using the Github UI
- Make JvmActionsAlarmMonitor persistable 
- Add logic to detect and fix missized JVM heap generations

Tests: JvmGenerationTuningPolicyTest

If new tests are added, how long do the new ones take to complete: Negligible

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.