### PR TITLE
Add bucketization logic (heap_usage) for cache and queue deciders

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/DecisionMakerConsts.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/DecisionMakerConsts.java
@@ -15,9 +15,20 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.bucket.UsageBucket;
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonParser;
 
 public class DecisionMakerConsts {
+    public static final String HEAP_TUNABLE_NAME = "heap-usage";
+
+    public static final ImmutableMap<UsageBucket, Double> HEAP_USAGE_MAP =
+            ImmutableMap.<UsageBucket, Double>builder()
+                    .put(UsageBucket.UNDER_UTILIZED, 30.0)
+                    .put(UsageBucket.HEALTHY_WITH_BUFFER, 60.0)
+                    .put(UsageBucket.HEALTHY, 90.0)
+                    .build();
+
     public static final String CACHE_MAX_WEIGHT = "maximumWeight";
 
     public static final JsonParser JSON_PARSER = new JsonParser();

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/DecisionMakerConsts.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/DecisionMakerConsts.java
@@ -22,6 +22,8 @@ import com.google.gson.JsonParser;
 public class DecisionMakerConsts {
     public static final String HEAP_TUNABLE_NAME = "heap-usage";
 
+    // Currently choosing 0.3, 0.6 and 0.9 as threshold for different usage buckets for heap_usage tunable.
+    // These values are chosen as starting point. We can tune these values after some experimentation.
     public static final ImmutableMap<UsageBucket, Double> HEAP_USAGE_MAP =
             ImmutableMap.<UsageBucket, Double>builder()
                     .put(UsageBucket.UNDER_UTILIZED, 30.0)

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/CacheHealthDecider.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/CacheHealthDecider.java
@@ -151,6 +151,8 @@ public class CacheHealthDecider extends Decider {
             NodeConfigCacheReaderUtil.readHeapMaxSizeInBytes(nodeConfigCache, esNode),
             NodeConfigCacheReaderUtil.readHeapUsageInBytes(nodeConfigCache, esNode));
 
+    // there is no difference in the action when state is UNDER_SIZED or HEALTHY_WITH_BUFFER.
+    // TODO: Tune action parameters based on the state.
     if (heapUsageBucketCalculator.compute(heapUsedPercent).equals(UsageBucket.HEALTHY_WITH_BUFFER)
                 || heapUsageBucketCalculator.compute(heapUsedPercent).equals(UsageBucket.UNDER_UTILIZED)) {
       return getAction(ModifyCacheMaxSizeAction.NAME, esNode, cacheType, true);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/QueueHealthDecider.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/QueueHealthDecider.java
@@ -114,6 +114,8 @@ public class QueueHealthDecider extends Decider {
             NodeConfigCacheReaderUtil.readHeapUsageInBytes(nodeConfigCache, esNode));
     Action action = null;
 
+    // there is no difference in the action when state is UNDER_SIZED or HEALTHY_WITH_BUFFER.
+    // TODO: Tune action parameters based on the state.
     if (heapUsageBucketCalculator.compute(heapUsedPercent).equals(UsageBucket.HEALTHY_WITH_BUFFER)
                 || heapUsageBucketCalculator.compute(heapUsedPercent).equals(UsageBucket.UNDER_UTILIZED)) {
       for (String actionName : actionsByUserPriority) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/util/HeapUtil.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/util/HeapUtil.java
@@ -1,0 +1,22 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.util;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class HeapUtil {
+    private static final Logger LOG = LogManager.getLogger(HeapUtil.class);
+
+    public static double getHeapUsedPercentage(final Long heapMaxInBytes, final Long heapUsedInBytes) {
+        double heapUsedPercent = 0;
+
+        if (heapMaxInBytes != null && heapMaxInBytes > 0 && heapUsedInBytes != null && heapUsedInBytes > 0) {
+            heapUsedPercent = ((double) heapUsedInBytes / heapMaxInBytes) * 100;
+        }
+
+        if (!Double.isNaN(heapUsedPercent)) {
+            return heapUsedPercent;
+        } else {
+            throw new IllegalArgumentException("invalid value: {} in heapUsedPercent" + Float.NaN);
+        }
+    }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/Heap_Used.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/Heap_Used.java
@@ -19,6 +19,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetric
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
 
 public class Heap_Used extends Metric {
+  public static final String NAME = AllMetrics.HeapValue.HEAP_USED.name();
+
   public Heap_Used(long evaluationIntervalSeconds) {
     super(AllMetrics.HeapValue.HEAP_USED.toString(), evaluationIntervalSeconds);
   }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/ResourceUtil.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/ResourceUtil.java
@@ -35,6 +35,9 @@ public class ResourceUtil {
   public static final Resource HEAP_MAX_SIZE = Resource.newBuilder()
           .setResourceEnum(ResourceEnum.HEAP)
           .setMetricEnum(MetricEnum.HEAP_MAX).build();
+  public static final Resource HEAP_USAGE = Resource.newBuilder()
+          .setResourceEnum(ResourceEnum.HEAP)
+          .setMetricEnum(MetricEnum.HEAP_USAGE).build();
   public static final Resource OLD_GEN_HEAP_USAGE = Resource.newBuilder()
       .setResourceEnum(ResourceEnum.OLD_GEN)
       .setMetricEnum(MetricEnum.HEAP_USAGE).build();

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
@@ -116,7 +116,7 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
 
   @Override
   public void construct() {
-    Metric heapUsed = new Heap_Used(EVALUATION_INTERVAL_SECONDS);
+    Heap_Used heapUsed = new Heap_Used(EVALUATION_INTERVAL_SECONDS);
     Metric gcEvent = new GC_Collection_Event(EVALUATION_INTERVAL_SECONDS);
     Heap_Max heapMax = new Heap_Max(EVALUATION_INTERVAL_SECONDS);
     Metric gc_Collection_Time = new GC_Collection_Time(EVALUATION_INTERVAL_SECONDS);
@@ -209,7 +209,7 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
     cacheMaxSize.addTag(TAG_LOCUS, LOCUS_DATA_MASTER_NODE);
     addLeaf(cacheMaxSize);
 
-    NodeConfigCollector nodeConfigCollector = new NodeConfigCollector(RCA_PERIOD, queueCapacity, cacheMaxSize, heapMax);
+    NodeConfigCollector nodeConfigCollector = new NodeConfigCollector(RCA_PERIOD, queueCapacity, cacheMaxSize, heapMax, heapUsed);
     nodeConfigCollector.addTag(TAG_LOCUS, LOCUS_DATA_MASTER_NODE);
     nodeConfigCollector.addAllUpstreams(Arrays.asList(queueCapacity, cacheMaxSize, heapMax));
     NodeConfigClusterCollector nodeConfigClusterCollector = new NodeConfigClusterCollector(nodeConfigCollector);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/util/NodeConfigCacheReaderUtil.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/util/NodeConfigCacheReaderUtil.java
@@ -64,4 +64,14 @@ public class NodeConfigCacheReaderUtil {
     }
     return null;
   }
+
+  public static Long readHeapUsageInBytes(
+          final NodeConfigCache nodeConfigCache, final NodeKey esNode) {
+    try {
+      return (long) nodeConfigCache.get(esNode, ResourceUtil.HEAP_USAGE);
+    } catch (final IllegalArgumentException e) {
+      LOG.error("Exception while reading heap usage from Node Config Cache", e);
+    }
+    return null;
+  }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/CacheHealthDeciderTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/CacheHealthDeciderTest.java
@@ -53,6 +53,7 @@ public class CacheHealthDeciderTest {
   @Before
   public void setupCluster() throws SQLException, ClassNotFoundException {
     final long heapMaxSizeInBytes = 12000 * 1_000_000L;
+    final long heapUsageInBytes = 120 * 1_000_000L;
     final long fieldDataCacheMaxSizeInBytes = 12000;
     final long shardRequestCacheMaxSizeInBytes = 12000;
 
@@ -92,6 +93,14 @@ public class CacheHealthDeciderTest {
                   new InstanceDetails.Ip(node.getHostAddress())),
               ResourceUtil.HEAP_MAX_SIZE,
               heapMaxSizeInBytes);
+      appContext
+          .getNodeConfigCache()
+          .put(
+              new NodeKey(
+                  new InstanceDetails.Id(node.getId()),
+                  new InstanceDetails.Ip(node.getHostAddress())),
+              ResourceUtil.HEAP_USAGE,
+              heapUsageInBytes);
       appContext
           .getNodeConfigCache()
           .put(

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/QueueHealthDeciderTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/QueueHealthDeciderTest.java
@@ -52,6 +52,9 @@ public class QueueHealthDeciderTest {
 
   @Before
   public void setupCluster() {
+    final long heapMaxSizeInBytes = 12000 * 1_000_000L;
+    final long heapUsageInBytes = 120 * 1_000_000L;
+
     ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
     ClusterDetailsEventProcessor.NodeDetails node1 =
         new ClusterDetailsEventProcessor.NodeDetails(NodeRole.DATA, "node1", "127.0.0.1", false);
@@ -76,6 +79,25 @@ public class QueueHealthDeciderTest {
     appContext.setClusterDetailsEventProcessor(clusterDetailsEventProcessor);
     String rcaConfPath = Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca.conf").toString();
     rcaConf = new RcaConf(rcaConfPath);
+
+    for (final ClusterDetailsEventProcessor.NodeDetails node : nodes) {
+      appContext
+              .getNodeConfigCache()
+              .put(
+                      new NodeKey(
+                              new InstanceDetails.Id(node.getId()),
+                              new InstanceDetails.Ip(node.getHostAddress())),
+                      ResourceUtil.HEAP_MAX_SIZE,
+                      heapMaxSizeInBytes);
+      appContext
+              .getNodeConfigCache()
+              .put(
+                      new NodeKey(
+                              new InstanceDetails.Id(node.getId()),
+                              new InstanceDetails.Ip(node.getHostAddress())),
+                      ResourceUtil.HEAP_USAGE,
+                      heapUsageInBytes);
+    }
   }
 
   @Test

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/dedicated_master/FieldDataCacheDeciderDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/dedicated_master/FieldDataCacheDeciderDedicatedMasterITest.java
@@ -24,6 +24,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Size;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Max_Size;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Max;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Used;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AClusterType;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AErrorPatternIgnored;
@@ -117,6 +118,25 @@ import org.junit.runner.RunWith;
                                         sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
                         })
         })
+@AMetric(
+        name = Heap_Used.class,
+        dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0)
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0)
+                        })
+        })
 
 public class FieldDataCacheDeciderDedicatedMasterITest {
     // Test CacheDecider for ModifyCacheAction (field data cache).
@@ -155,5 +175,8 @@ public class FieldDataCacheDeciderDedicatedMasterITest {
     @AErrorPatternIgnored(
             pattern = "CacheUtil:getCacheMaxSize()",
             reason = "Shard request cache metrics is expected to be missing.")
+    @AErrorPatternIgnored(
+            pattern = "HighHeapUsageYoungGenRca:operate()",
+            reason = "Young gen rca is expected to be missing in this integ test.")
     public void testFieldDataCacheAction() {}
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/dedicated_master/ShardRequestCacheDeciderDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/dedicated_master/ShardRequestCacheDeciderDedicatedMasterITest.java
@@ -25,6 +25,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Hit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Size;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Max;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Used;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AClusterType;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AErrorPatternIgnored;
@@ -133,6 +134,25 @@ import org.junit.runner.RunWith;
                                         sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
                         })
         })
+@AMetric(
+        name = Heap_Used.class,
+        dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0)
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0)
+                        })
+        })
 
 public class ShardRequestCacheDeciderDedicatedMasterITest {
     // Test CacheDecider for ModifyCacheAction (shard request cache).
@@ -171,6 +191,9 @@ public class ShardRequestCacheDeciderDedicatedMasterITest {
     @AErrorPatternIgnored(
             pattern = "CacheUtil:getCacheMaxSize()",
             reason = "Field data cache metrics is expected to be missing.")
+    @AErrorPatternIgnored(
+            pattern = "HighHeapUsageYoungGenRca:operate()",
+            reason = "Young gen rca is expected to be missing in this integ test.")
     public void testShardRequestCacheAction() {
     }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/multi_node/FieldDataCacheDeciderMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/multi_node/FieldDataCacheDeciderMultiNodeITest.java
@@ -24,6 +24,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_FieldData_Size;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Max_Size;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Max;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Used;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AClusterType;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AErrorPatternIgnored;
@@ -117,6 +118,25 @@ import org.junit.runner.RunWith;
                                         sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
                         })
         })
+@AMetric(
+        name = Heap_Used.class,
+        dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0)
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0)
+                        })
+        })
 
 public class FieldDataCacheDeciderMultiNodeITest {
     // Test CacheDecider for ModifyCacheAction (field data cache).
@@ -155,5 +175,8 @@ public class FieldDataCacheDeciderMultiNodeITest {
     @AErrorPatternIgnored(
             pattern = "CacheUtil:getCacheMaxSize()",
             reason = "Shard request cache metrics is expected to be missing.")
+    @AErrorPatternIgnored(
+            pattern = "HighHeapUsageYoungGenRca:operate()",
+            reason = "Young gen rca is expected to be missing in this integ test.")
     public void testFieldDataCacheAction() {}
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/multi_node/ShardRequestCacheDeciderMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/cache_tuning/multi_node/ShardRequestCacheDeciderMultiNodeITest.java
@@ -25,6 +25,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Hit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Request_Size;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Max;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Used;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AClusterType;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AErrorPatternIgnored;
@@ -133,6 +134,25 @@ import org.junit.runner.RunWith;
                                         sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
                         })
         })
+@AMetric(
+        name = Heap_Used.class,
+        dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+        tables = {
+                @ATable(
+                        hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0)
+                        }),
+                @ATable(
+                        hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(
+                                        dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0)
+                        })
+        })
 
 public class ShardRequestCacheDeciderMultiNodeITest {
     // Test CacheDecider for ModifyCacheAction (shard request cache).
@@ -171,6 +191,9 @@ public class ShardRequestCacheDeciderMultiNodeITest {
     @AErrorPatternIgnored(
             pattern = "CacheUtil:getCacheMaxSize()",
             reason = "Field data cache metrics is expected to be missing.")
+    @AErrorPatternIgnored(
+            pattern = "HighHeapUsageYoungGenRca:operate()",
+            reason = "Young gen rca is expected to be missing in this integ test.")
     public void testShardRequestCacheAction() {
     }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/dedicated_master/QueueDeciderDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/dedicated_master/QueueDeciderDedicatedMasterITest.java
@@ -17,8 +17,11 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.t
 
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.Constants.QUEUE_TUNING_RESOURCES_DIR;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Max;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Used;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_QueueCapacity;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_RejectedReqs;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
@@ -61,7 +64,6 @@ import org.junit.runner.RunWith;
         )
     }
 )
-
 @AMetric(name = ThreadPool_QueueCapacity.class,
     dimensionNames = {ThreadPoolDimension.Constants.TYPE_VALUE},
     tables = {
@@ -75,6 +77,37 @@ import org.junit.runner.RunWith;
         )
     }
 )
+@AMetric(name = Heap_Max.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = HostTag.DATA_0,
+            tuple = {
+                @ATuple(dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
+            }),
+        @ATable(hostTag = {HostTag.ELECTED_MASTER},
+            tuple = {
+                @ATuple(dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
+            })
+    }
+)
+@AMetric(name = Heap_Used.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = HostTag.DATA_0,
+            tuple = {
+                @ATuple(dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0)
+                }),
+        @ATable(hostTag = {HostTag.ELECTED_MASTER},
+            tuple = {
+                @ATuple(dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0)
+                })
+    }
+)
+
 public class QueueDeciderDedicatedMasterITest {
   // This integ test is built to test Decision Maker framework and queue remediation actions
   // This test injects queue rejection metrics on one of the data node and queries the
@@ -92,6 +125,14 @@ public class QueueDeciderDedicatedMasterITest {
       reason = "Cache metrics are expected to be missing in this integ test")
   @AErrorPatternIgnored(pattern = "SubscribeResponseHandler:onError()",
       reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+  @AErrorPatternIgnored(pattern = "SQLParsingUtil:readDataFromSqlResult()",
+      reason = "Old gen metrics is expected to be missing in this integ test.")
+  @AErrorPatternIgnored(pattern = "HighHeapUsageOldGenRca:operate()",
+      reason = "Old gen rca is expected to be missing in this integ test.")
+  @AErrorPatternIgnored(pattern = "HighHeapUsageYoungGenRca:operate()",
+      reason = "Young gen rca is expected to be missing in this integ test.")
+  @AErrorPatternIgnored(pattern = "NodeConfigCollector:collectAndPublishMetric()",
+      reason = "Metrics is expected to be missing")
   public void testQueueCapacityDecider() {
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/dedicated_master/QueueRcaDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/dedicated_master/QueueRcaDedicatedMasterITest.java
@@ -92,6 +92,8 @@ public class QueueRcaDedicatedMasterITest {
       reason = "Cache metrics are expected to be missing in this integ test")
   @AErrorPatternIgnored(pattern = "SubscribeResponseHandler:onError()",
       reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+  @AErrorPatternIgnored(pattern = "NodeConfigCacheReaderUtil",
+      reason = "Node Config Cache are expected to be missing in this integ test.")
   public void testQueueRejectionRca() {
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/multi_node/QueueDeciderMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/multi_node/QueueDeciderMultiNodeITest.java
@@ -17,8 +17,11 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.t
 
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.Constants.QUEUE_TUNING_RESOURCES_DIR;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Max;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Used;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_QueueCapacity;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_RejectedReqs;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
@@ -61,7 +64,6 @@ import org.junit.runner.RunWith;
         )
     }
 )
-
 @AMetric(name = ThreadPool_QueueCapacity.class,
     dimensionNames = {ThreadPoolDimension.Constants.TYPE_VALUE},
     tables = {
@@ -75,6 +77,37 @@ import org.junit.runner.RunWith;
         )
     }
 )
+@AMetric(name = Heap_Max.class,
+        dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+        tables = {
+                @ATable(hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
+                        }),
+                @ATable(hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 1000000.0, avg = 1000000.0, min = 1000000.0, max = 1000000.0)
+                        })
+        }
+)
+@AMetric(name = Heap_Used.class,
+        dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+        tables = {
+                @ATable(hostTag = HostTag.DATA_0,
+                        tuple = {
+                                @ATuple(dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0)
+                        }),
+                @ATable(hostTag = {HostTag.ELECTED_MASTER},
+                        tuple = {
+                                @ATuple(dimensionValues = {AllMetrics.GCType.Constants.HEAP_VALUE},
+                                        sum = 10000.0, avg = 10000.0, min = 10000.0, max = 10000.0)
+                        })
+        }
+)
+
 public class QueueDeciderMultiNodeITest {
   // This integ test is built to test Decision Maker framework and queue remediation actions
   // This test injects queue rejection metrics on one of the data node and queries the
@@ -92,6 +125,14 @@ public class QueueDeciderMultiNodeITest {
       reason = "Cache metrics are expected to be missing in this integ test")
   @AErrorPatternIgnored(pattern = "SubscribeResponseHandler:onError()",
       reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+  @AErrorPatternIgnored(pattern = "SQLParsingUtil:readDataFromSqlResult()",
+      reason = "Old gen metrics is expected to be missing in this integ test.")
+  @AErrorPatternIgnored(pattern = "HighHeapUsageOldGenRca:operate()",
+      reason = "Old gen rca is expected to be missing in this integ test.")
+  @AErrorPatternIgnored(pattern = "HighHeapUsageYoungGenRca:operate()",
+      reason = "Young gen rca is expected to be missing in this integ test.")
+  @AErrorPatternIgnored(pattern = "NodeConfigCollector:collectAndPublishMetric()",
+      reason = "Metrics is expected to be missing")
   public void testQueueCapacityDecider() {
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/multi_node/QueueRcaMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/multi_node/QueueRcaMultiNodeITest.java
@@ -92,6 +92,8 @@ public class QueueRcaMultiNodeITest {
       reason = "Cache metrics are expected to be missing in this integ test")
   @AErrorPatternIgnored(pattern = "SubscribeResponseHandler:onError()",
       reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+  @AErrorPatternIgnored(pattern = "NodeConfigCacheReaderUtil",
+      reason = "Node Config Cache are expected to be missing in this integ test.")
   public void testQueueRejectionRca() {
   }
 }


### PR DESCRIPTION
*Fixes #:*

*Description of changes:*
Add bucketization logic (heap_usage) for cache and queue deciders

Created a bucket for heap usage percentage. 
Cache and queue deciders take an action only heap usage is in healthy_with_buffer state.

* Currently choosing 0.3, 0.6 and 0.9 as threshold for different usage buckets for heap_usage tunable.
These values are chosen as starting point. We can tune these values after some experimentations.
* Also, there is no difference in the action when state is UNDER_SIZED or HEALTHY_WITH_BUFFER. We can chose to alter the step size based on this. This will be the next step.

*Tests:*
unit tests

*If new tests are added, how long do the new ones take to complete*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
