### PR TITLE
Add operational metrics for batch metrics api

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerApp.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerApp.java
@@ -34,9 +34,11 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.met
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaRuntimeMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaVerticesMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.ReaderMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.sys.AllJvmSamplers;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.listener.MisbehavingGraphOperateMethodListener;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.samplers.BatchMetricsEnabledSampler;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.samplers.RcaStateSamplers;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.RcaStatsReporter;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.collectors.SampleAggregator;
@@ -84,6 +86,8 @@ public class PerformanceAnalyzerApp {
       new SampleAggregator(RcaRuntimeMetrics.values());
   public static final SampleAggregator RCA_VERTICES_METRICS_AGGREGATOR =
       new SampleAggregator(RcaVerticesMetrics.values());
+  public static final SampleAggregator READER_METRICS_AGGREGATOR =
+      new SampleAggregator(ReaderMetrics.values());
 
   private static final IListener MISBEHAVING_NODES_LISTENER =
       new MisbehavingGraphOperateMethodListener();
@@ -98,6 +102,7 @@ public class PerformanceAnalyzerApp {
   public static final RcaStatsReporter RCA_STATS_REPORTER =
       new RcaStatsReporter(Arrays.asList(RCA_GRAPH_METRICS_AGGREGATOR,
           RCA_RUNTIME_METRICS_AGGREGATOR, RCA_VERTICES_METRICS_AGGREGATOR,
+          READER_METRICS_AGGREGATOR,
           ERRORS_AND_EXCEPTIONS_AGGREGATOR, PERIODIC_SAMPLE_AGGREGATOR));
   public static PeriodicSamplers PERIODIC_SAMPLERS;
   public static final BlockingQueue<PAThreadException> exceptionQueue =
@@ -296,6 +301,7 @@ public class PerformanceAnalyzerApp {
     List<ISampler> allSamplers = new ArrayList<>();
     allSamplers.addAll(AllJvmSamplers.getJvmSamplers());
     allSamplers.add(RcaStateSamplers.getRcaEnabledSampler(appContext));
+    allSamplers.add(new BatchMetricsEnabledSampler(appContext));
 
     return allSamplers;
   }
@@ -304,6 +310,7 @@ public class PerformanceAnalyzerApp {
     List<MeasurementSet> measurementSets = new ArrayList<>();
     measurementSets.addAll(Arrays.asList(JvmMetrics.values()));
     measurementSets.add(RcaRuntimeMetrics.RCA_ENABLED);
+    measurementSets.add(ReaderMetrics.BATCH_METRICS_ENABLED);
 
     return measurementSets.toArray(new MeasurementSet[]{});
   }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metricsdb/MetricsDB.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metricsdb/MetricsDB.java
@@ -16,9 +16,11 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.DBUtils;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatExceptionCode;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.Removable;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -95,8 +97,14 @@ public class MetricsDB implements Removable {
   public MetricsDB(long windowStartTime) throws Exception {
     this.windowStartTime = windowStartTime;
     String url = DB_URL + getDBFilePath();
-    conn = DriverManager.getConnection(url);
-    conn.setAutoCommit(false);
+    try {
+      conn = DriverManager.getConnection(url);
+      conn.setAutoCommit(false);
+    } catch (Exception e) {
+      PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+          ExceptionsAndErrors.READER_METRICSDB_ACCESS_ERRORS, "", 1);
+      throw e;
+    }
     create = DSL.using(conn, SQLDialect.SQLITE);
   }
 
@@ -110,6 +118,8 @@ public class MetricsDB implements Removable {
   public static MetricsDB fetchExisting(long windowStartTime) throws Exception {
     String filePath = getDBFilePath(windowStartTime);
     if (!(new File(filePath)).exists()) {
+      PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+          ExceptionsAndErrors.READER_METRICSDB_ACCESS_ERRORS, "", 1);
       throw new FileNotFoundException(String.format("MetricsDB file %s could not be found.", filePath));
     }
     return new MetricsDB(windowStartTime);
@@ -325,9 +335,10 @@ public class MetricsDB implements Removable {
     try {
       Files.delete(dbFilePath);
     } catch (IOException | SecurityException e) {
-            LOG.error("Failed to delete File - {} with ExceptionCode: {}",
-              dbFilePath, StatExceptionCode.OTHER.toString(), e);
-      StatsCollector.instance().logException();
+      LOG.error("Failed to delete File - {} with ExceptionCode: {}",
+          dbFilePath, ExceptionsAndErrors.READER_METRICSDB_ACCESS_ERRORS, e);
+      PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+          ExceptionsAndErrors.READER_METRICSDB_ACCESS_ERRORS, "", 1);
     }
   }
 
@@ -355,8 +366,9 @@ public class MetricsDB implements Removable {
               });
     } catch (IOException | SecurityException e) {
       LOG.error("Failed to access metricsdb directory - {} with ExceptionCode: {}",
-              parentPath, StatExceptionCode.OTHER.toString(), e);
-      StatsCollector.instance().logException();
+          parentPath, ExceptionsAndErrors.READER_METRICSDB_ACCESS_ERRORS, e);
+      PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+          ExceptionsAndErrors.READER_METRICSDB_ACCESS_ERRORS, "", 1);
     }
     return found;
   }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
@@ -42,7 +42,12 @@ public enum ExceptionsAndErrors implements MeasurementSet {
   /**
    * When persisting action or flowunits, the persistable throws an exception when it is unable to write to DB.
    */
-  EXCEPTION_IN_PERSIST("ExceptionInPersist", "namedCount", Statistics.NAMED_COUNTERS);
+  EXCEPTION_IN_PERSIST("ExceptionInPersist", "namedCount", Statistics.NAMED_COUNTERS),
+
+  /**
+   * When the reader encounters errors accessing metricsdb files.
+   */
+  READER_METRICSDB_ACCESS_ERRORS("ReaderMetricsdbAccessError");
 
   /** What we want to appear as the metric name. */
   private String name;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ReaderMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ReaderMetrics.java
@@ -1,0 +1,103 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
+
+public enum ReaderMetrics implements MeasurementSet {
+
+    /**
+     * Size of generated metricsdb files.
+     */
+    METRICSDB_FILE_SIZE("MetricsdbFileSize", "bytes", Arrays.asList(Statistics.MAX, Statistics.MEAN)),
+
+    /**
+     * Whether or not batch metrics is enabled (0 for enabled, 1 for disabled).
+     */
+    BATCH_METRICS_ENABLED("BatchMetricsEnabled", "count", Statistics.SAMPLE),
+
+    /**
+     * Number of http requests where the client gave a bad request.
+     */
+    BATCH_METRICS_HTTP_CLIENT_ERROR("BatchMetricsHttpClientError", "count", Statistics.COUNT),
+
+    /**
+     * Number of http requests where the host could not generate a correct response.
+     */
+    BATCH_METRICS_HTTP_HOST_ERROR("BatchMetricsHttpHostError", "count", Statistics.COUNT),
+
+    /**
+     * Number of successful queries.
+     */
+    BATCH_METRICS_HTTP_SUCCESS("BatchMetricsHttpSuccess", "count", Statistics.COUNT),
+
+    /**
+     * Number of times a query for batch metrics exceeded the maximum number of requestable datapoints.
+     */
+    BATCH_METRICS_EXCEEDED_MAX_DATAPOINTS("ExceededBatchMetricsMaxDatapoints", "count", Statistics.COUNT),
+
+    /**
+     * Amount of time required to process valid batch metrics requests.
+     */
+    BATCH_METRICS_QUERY_PROCESSING_TIME("BatchMetricsQueryProcessingTime", "millis",
+        Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
+
+    /**
+     * Number of metricsdb files associated with batch metrics.
+     */
+    BATCH_METRICS_NUM_METRICSDB_FILES("BatchMetricsNumMetricsdbFiles", "count",
+        Arrays.asList(Statistics.MAX, Statistics.MEAN)),
+
+    /**
+     * Amount of locally stored data within the batch metrics retention period.
+     */
+    BATCH_METRICS_DATA_SIZE("BatchMetricsDataSize", "bytes",
+        Arrays.asList(Statistics.MAX, Statistics.MEAN));
+
+    /** What we want to appear as the metric name. */
+    private String name;
+
+    /**
+     * The unit the measurement is in. This is not used for the statistics calculations but as an
+     * information that will be dumped with the metrics.
+     */
+    private String unit;
+
+    /**
+     * Multiple statistics can be collected for each measurement like MAX, MIN and MEAN. This is a
+     * collection of one or more such statistics.
+     */
+    private List<Statistics> statsList;
+
+    ReaderMetrics(String name, String unit, List<Statistics> stats) {
+        this.name = name;
+        this.unit = unit;
+        this.statsList = stats;
+    }
+
+    ReaderMetrics(String name, String unit, Statistics stats) {
+        this(name, unit, Collections.singletonList(stats));
+    }
+
+    public String toString() {
+        return new StringBuilder(name).append("-").append(unit).toString();
+    }
+
+    @Override
+    public List<Statistics> getStatsList() {
+        return statsList;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getUnit() {
+        return unit;
+    }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ReaderMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ReaderMetrics.java
@@ -1,11 +1,11 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.eval.Statistics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.eval.Statistics;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
 
 public enum ReaderMetrics implements MeasurementSet {
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/BatchMetricsEnabledSampler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/BatchMetricsEnabledSampler.java
@@ -1,13 +1,13 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.samplers;
 
-import java.util.Objects;
-
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.ReaderMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.collectors.SampleAggregator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.emitters.ISampler;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ReaderMetricsProcessor;
+
+import java.util.Objects;
 
 public class BatchMetricsEnabledSampler implements ISampler {
   private final AppContext appContext;
@@ -20,7 +20,7 @@ public class BatchMetricsEnabledSampler implements ISampler {
   @Override
   public void sample(SampleAggregator sampleCollector) {
     sampleCollector.updateStat(ReaderMetrics.BATCH_METRICS_ENABLED, "",
-        isBatchMetricsEnabled()? 1 : 0);
+        isBatchMetricsEnabled() ? 1 : 0);
   }
 
   boolean isBatchMetricsEnabled() {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/BatchMetricsEnabledSampler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/samplers/BatchMetricsEnabledSampler.java
@@ -1,0 +1,33 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.samplers;
+
+import java.util.Objects;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.ReaderMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.collectors.SampleAggregator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.emitters.ISampler;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ReaderMetricsProcessor;
+
+public class BatchMetricsEnabledSampler implements ISampler {
+  private final AppContext appContext;
+
+  public BatchMetricsEnabledSampler(final AppContext appContext) {
+    Objects.requireNonNull(appContext);
+    this.appContext = appContext;
+  }
+
+  @Override
+  public void sample(SampleAggregator sampleCollector) {
+    sampleCollector.updateStat(ReaderMetrics.BATCH_METRICS_ENABLED, "",
+        isBatchMetricsEnabled()? 1 : 0);
+  }
+
+  boolean isBatchMetricsEnabled() {
+    InstanceDetails currentNode = appContext.getMyInstanceDetails();
+    if (currentNode != null && currentNode.getIsMaster()) {
+      return ReaderMetricsProcessor.getInstance().getBatchMetricsEnabled();
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
*Fixes #:*
N/A

*Description of changes:*
* READER_METRICSDB_ACCESS_ERRORS: errors accessing metricsdb files
* METRICSDB_FILE_SIZE: size of generated metricsdb files
* BATCH_METRICS_ENABLED: whether or not batch metrics is enabled
* BATCH_METRICS_HTTP_CLIENT_ERROR: number of bad batch metrics requests
* BATCH_METRICS_HTTP_HOST_ERROR: number of batch metrics requests where
    the host ran into errors
* BATCH_METRICS_HTTP_SUCCESS: number of successful batch metrics
    requests
* BATCH_METRICS_EXCEEDED_MAX_DATAPOINTS: requests where the user
    requested for more datapoints than the hardcoded limit of 100800
* BATCH_METRICS_QUERY_PROCESSING_TIME: amount of time required to
    process batch metrics requests
* BATCH_METRICS_NUM_METRICSDB_FILES: number of metricsdb files within
    the batch metrics retention period
* BATCH_METRICS_DATA_SIZE: amount of data batch metrics is storing

*Tests:*
- Manually tested that stats get emitted

*If new tests are added, how long do the new ones take to complete*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
