### PR TITLE
Make JvmActionsAlarmMonitor persistable

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/BucketizedSlidingWindow.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/BucketizedSlidingWindow.java
@@ -15,7 +15,11 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.aggregators;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * The BucketizedSlidingWindow provides a SlidingWindow implementation that can aggregate all
@@ -23,12 +27,29 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>All data within a single bucket window time range is summed by default.
  */
-public class BucketizedSlidingWindow extends SlidingWindow<SlidingWindowData> {
-
+public class BucketizedSlidingWindow extends PersistableSlidingWindow {
+  private static final Logger LOG = LogManager.getLogger(BucketizedSlidingWindow.class);
   private final long BUCKET_WINDOW_SIZE;
 
+  /**
+   * Creates a BucketizedSlidingWindow which won't persist data on disk
+   * @param SLIDING_WINDOW_SIZE Length of the window in units of time
+   * @param BUCKET_WINDOW_SIZE Length of each bucket in units of time
+   * @param timeUnit The unit of time
+   */
   public BucketizedSlidingWindow(int SLIDING_WINDOW_SIZE, int BUCKET_WINDOW_SIZE, TimeUnit timeUnit) {
-    super(SLIDING_WINDOW_SIZE, timeUnit);
+    this(SLIDING_WINDOW_SIZE, BUCKET_WINDOW_SIZE, timeUnit, null);
+  }
+
+  /**
+   * Creates a BucketizedSlidingWindow which will persist data on disk
+   * @param SLIDING_WINDOW_SIZE Length of the window in units of time
+   * @param BUCKET_WINDOW_SIZE Length of each bucket in units of time
+   * @param timeUnit The unit of time
+   * @param persistFilePath Path to the file to use for persistence
+   */
+  public BucketizedSlidingWindow(int SLIDING_WINDOW_SIZE, int BUCKET_WINDOW_SIZE, TimeUnit timeUnit, Path persistFilePath) {
+    super(SLIDING_WINDOW_SIZE, timeUnit, persistFilePath);
     assert BUCKET_WINDOW_SIZE < SLIDING_WINDOW_SIZE : "BucketWindow size should be less than SlidingWindow size";
     this.BUCKET_WINDOW_SIZE = timeUnit.toMillis(BUCKET_WINDOW_SIZE);
   }
@@ -41,6 +62,11 @@ public class BucketizedSlidingWindow extends SlidingWindow<SlidingWindowData> {
         firstElement.value += e.getValue();
         add(e);
         pruneExpiredEntries(e.getTimeStamp());
+        try {
+          write(); // Try to persist the data whenever we complete writing a bucket
+        } catch (IOException ex) {
+          LOG.error("Failed to persist {} data", this.getClass().getSimpleName(), ex);
+        }
         return;
       }
     }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/RcaConsts.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/util/RcaConsts.java
@@ -36,7 +36,7 @@ public class RcaConsts {
   private static final String RCA_CONF_FILENAME = "rca.conf";
   private static final String RCA_CONF_IDLE_MASTER_FILENAME = "rca_idle_master.conf";
   private static final String THRESHOLDS_DIR_NAME = "thresholds";
-  private static final String CONFIG_DIR_PATH =
+  public static final String CONFIG_DIR_PATH =
       Paths.get(Util.READER_LOCATION, "pa_config").toString();
   public static final String RCA_CONF_PATH =
       Paths.get(CONFIG_DIR_PATH, RCA_CONF_FILENAME).toString();


### PR DESCRIPTION
*Fixes #:* N/A

*Description of changes:*
- BucketizedSlidingWindow now extends PersistableSlidingWindow which
means it can write and load window data from a file on disk
- JvmActionsAlarmMonitor has a new constructor that will allow its data
to be written to and loaded from the disk

*Tests:* 
- PersistableSlidingWindowTest
- JvmActionsAlarmMonitorTest

*If new tests are added, how long do the new ones take to complete*: Negligible

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
