### PR TITLE
Using to buckets to suppress queue length increase action

### DIFF
--- a/checkstyle/findbugs-exclude.xml
+++ b/checkstyle/findbugs-exclude.xml
@@ -71,6 +71,10 @@
         <Bug pattern="MS_MUTABLE_COLLECTION"/>
     </Match>
     <Match>
+        <Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.jvm.JvmActionsAlarmMonitor"/>
+        <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
+    </Match>
+    <Match>
         <Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.FileRotate"/>
         <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
     </Match>

--- a/pa_config/rca.conf
+++ b/pa_config/rca.conf
@@ -93,5 +93,12 @@
     "ClusterTemperatureRca"
   ],
   "muted-deciders": [],
-  "muted-actions": []
+  "muted-actions": [],
+  "bucketization": {
+    "old-gen": {
+      "UNDER_UTILIZED": 10.0,
+      "HEALTHY_WITH_BUFFER": 30.0,
+      "HEALTHY": 70.0
+    }
+  }
 }

--- a/pa_config/rca.conf
+++ b/pa_config/rca.conf
@@ -97,8 +97,8 @@
   "bucketization": {
     "old-gen": {
       "UNDER_UTILIZED": 10.0,
-      "HEALTHY_WITH_BUFFER": 30.0,
-      "HEALTHY": 70.0
+      "HEALTHY_WITH_BUFFER": 60.0,
+      "HEALTHY": 80.0
     }
   }
 }

--- a/pa_config/rca_idle_master.conf
+++ b/pa_config/rca_idle_master.conf
@@ -124,5 +124,12 @@
       "field-data-cache-upper-bound" : 0.4,
       "shard-request-cache-upper-bound" : 0.05
     }
+  },
+  "bucketization": {
+    "old-gen": {
+      "UNDER_UTILIZED": 10.0,
+      "HEALTHY_WITH_BUFFER": 60.0,
+      "HEALTHY": 80.0
+    }
   }
 }

--- a/pa_config/rca_master.conf
+++ b/pa_config/rca_master.conf
@@ -155,8 +155,8 @@
   "bucketization": {
     "old-gen": {
       "UNDER_UTILIZED": 10.0,
-      "HEALTHY_WITH_BUFFER": 30.0,
-      "HEALTHY": 70.0
+      "HEALTHY_WITH_BUFFER": 60.0,
+      "HEALTHY": 80.0
     }
   }
 }

--- a/pa_config/rca_master.conf
+++ b/pa_config/rca_master.conf
@@ -151,5 +151,12 @@
          "lower-bound": 50
        }
      }
-   }
+   },
+  "bucketization": {
+    "old-gen": {
+      "UNDER_UTILIZED": 10.0,
+      "HEALTHY_WITH_BUFFER": 30.0,
+      "HEALTHY": 70.0
+    }
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/CacheHealthDecider.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/CacheHealthDecider.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.Action;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ModifyCacheMaxSizeAction;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum;
@@ -22,6 +23,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotClusterSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaRuntimeMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HighHeapUsageClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.BaseClusterRca;
@@ -135,6 +137,9 @@ public class CacheHealthDecider extends HeapBasedDecider {
     Action action = null;
     if (canUseMoreHeap(esNode)) {
       action = getAction(ModifyCacheMaxSizeAction.NAME, esNode, cacheType, true);
+    } else {
+      PerformanceAnalyzerApp.RCA_RUNTIME_METRICS_AGGREGATOR.updateStat(
+          RcaRuntimeMetrics.NO_INCREASE_ACTION_SUGGESTED, NAME + ":" + esNode.getHostAddress(), 1);
     }
     return action;
   }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/CacheHealthDecider.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/CacheHealthDecider.java
@@ -23,6 +23,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HighHeapUsageClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.BaseClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.FieldDataCacheClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
@@ -37,7 +38,7 @@ import org.apache.logging.log4j.Logger;
 
 // TODO: 1. Create separate ActionConfig objects for different actions
 
-public class CacheHealthDecider extends Decider {
+public class CacheHealthDecider extends HeapBasedDecider {
   private static final Logger LOG = LogManager.getLogger(CacheHealthDecider.class);
   public static final String NAME = "cacheHealthDecider";
 
@@ -52,8 +53,9 @@ public class CacheHealthDecider extends Decider {
       final long evalIntervalSeconds,
       final int decisionFrequency,
       final FieldDataCacheClusterRca fieldDataCacheClusterRca,
-      final ShardRequestCacheClusterRca shardRequestCacheClusterRca) {
-    super(evalIntervalSeconds, decisionFrequency);
+      final ShardRequestCacheClusterRca shardRequestCacheClusterRca,
+      final HighHeapUsageClusterRca highHeapUsageClusterRca) {
+    super(evalIntervalSeconds, decisionFrequency, highHeapUsageClusterRca);
     configureModifyCacheActionPriority();
 
     this.fieldDataCacheClusterRca = fieldDataCacheClusterRca;
@@ -130,7 +132,11 @@ public class CacheHealthDecider extends Decider {
    * signals going forward.
    */
   private Action computeBestAction(final NodeKey esNode, final ResourceEnum cacheType) {
-    return getAction(ModifyCacheMaxSizeAction.NAME, esNode, cacheType, true);
+    Action action = null;
+    if (canUseMoreHeap(esNode)) {
+      action = getAction(ModifyCacheMaxSizeAction.NAME, esNode, cacheType, true);
+    }
+    return action;
   }
 
   private Action getAction(

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/HeapBasedDecider.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/HeapBasedDecider.java
@@ -31,7 +31,7 @@ public abstract class HeapBasedDecider extends Decider {
   /**
    * The Queue and Cache deciders should only be able to suggest increase of the queue size or increase of cache size if the Java heap can
    * sustain more live objects in it without de-gradation. What is an acceptable heap usage limit to determine this, comes from the
-   * <i>bucketization</> object in rca.conf. We compare the oldGen usage percent reported by the HighHeapUsage RCA to determine that.
+   * bucketization object in rca.conf. We compare the oldGen usage percent reported by the HighHeapUsage RCA to determine that.
    *
    * @param esNode The EsNode we are trying to make a decision for.
    * @return return if the OldGen heap is under-utilized or healthy and yet more can be consumed, return true; or false otherwise.

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/HeapBasedDecider.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/HeapBasedDecider.java
@@ -19,7 +19,7 @@ public abstract class HeapBasedDecider extends Decider {
   private static final Logger LOG = LogManager.getLogger(HeapBasedDecider.class);
   private static final String OLD_GEN_TUNABLE_KEY = "old-gen";
   private static final ResourceEnum DECIDING_HEAP_RESOURCE_TYPE = ResourceEnum.OLD_GEN;
-  public static final ImmutableMap<UsageBucket, Double> HEAP_USAGE_MAP = ImmutableMap.<UsageBucket, Double>builder()
+  public static final ImmutableMap<UsageBucket, Double> DEFAULT_HEAP_USAGE_THRESHOLDS = ImmutableMap.<UsageBucket, Double>builder()
       .put(UsageBucket.UNDER_UTILIZED, 10.0)
       .put(UsageBucket.HEALTHY_WITH_BUFFER, 60.0)
       .put(UsageBucket.HEALTHY, 80.0)
@@ -56,7 +56,7 @@ public abstract class HeapBasedDecider extends Decider {
                 try {
                   bucketCalculator = rcaConf.getBucketizationSettings(OLD_GEN_TUNABLE_KEY);
                 } catch (Exception jsonEx) {
-                  bucketCalculator = new BasicBucketCalculator(HEAP_USAGE_MAP);
+                  bucketCalculator = new BasicBucketCalculator(DEFAULT_HEAP_USAGE_THRESHOLDS);
                   LOG.debug("rca.conf does not have bucketization limits specified. Using default map.");
                 }
                 UsageBucket bucket = bucketCalculator.compute(oldGenUsedPercent);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/HeapBasedDecider.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/HeapBasedDecider.java
@@ -1,0 +1,47 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.Resource;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotClusterSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.bucket.UsageBucket;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HighHeapUsageClusterRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
+
+public abstract class HeapBasedDecider extends Decider {
+  private HighHeapUsageClusterRca highHeapUsageClusterRca;
+
+  public HeapBasedDecider(long evalIntervalSeconds, int decisionFrequency, HighHeapUsageClusterRca highHeapUsageClusterRca) {
+    super(evalIntervalSeconds, decisionFrequency);
+    this.highHeapUsageClusterRca = highHeapUsageClusterRca;
+  }
+
+  protected boolean canUseMoreHeap(NodeKey esNode) {
+    // we add action only if heap is under-utilized or healthy and yet more can be consumed.
+    for (ResourceFlowUnit<HotClusterSummary> clusterSummary : highHeapUsageClusterRca.getFlowUnits()) {
+      if (clusterSummary.hasResourceSummary()) {
+        for (HotNodeSummary nodeSummary : clusterSummary.getSummary().getHotNodeSummaryList()) {
+          NodeKey thisNode = new NodeKey(nodeSummary.getNodeID(), nodeSummary.getHostAddress());
+          if (thisNode.equals(esNode)) {
+            for (HotResourceSummary hotResourceSummary : nodeSummary.getHotResourceSummaryList()) {
+              Resource resource = hotResourceSummary.getResource();
+              if (resource.getResourceEnum() == ResourceEnum.OLD_GEN) {
+                double oldGenUsedRatio = hotResourceSummary.getValue();
+                double oldGenUsedPercent = oldGenUsedRatio * 100;
+                UsageBucket bucket = rcaConf.getBucketizationSettings("old-gen").compute(oldGenUsedPercent);
+                if (bucket == UsageBucket.HEALTHY || bucket == UsageBucket.UNHEALTHY) {
+                  return false;
+                } else {
+                  return true;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    return true;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/HeapBasedDecider.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/HeapBasedDecider.java
@@ -6,18 +6,36 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotClusterSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.bucket.BasicBucketCalculator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.bucket.BucketCalculator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.bucket.UsageBucket;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HighHeapUsageClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
+import com.google.common.collect.ImmutableMap;
 
 public abstract class HeapBasedDecider extends Decider {
   private HighHeapUsageClusterRca highHeapUsageClusterRca;
+  private static final String OLD_GEN_TUNABLE_KEY = "old-gen";
+  private static final ResourceEnum DECIDING_HEAP_RESOURCE_TYPE = ResourceEnum.OLD_GEN;
+  public static final ImmutableMap<UsageBucket, Double> HEAP_USAGE_MAP = ImmutableMap.<UsageBucket, Double>builder()
+      .put(UsageBucket.UNDER_UTILIZED, 10.0)
+      .put(UsageBucket.HEALTHY_WITH_BUFFER, 60.0)
+      .put(UsageBucket.HEALTHY, 80.0)
+      .build();
 
   public HeapBasedDecider(long evalIntervalSeconds, int decisionFrequency, HighHeapUsageClusterRca highHeapUsageClusterRca) {
     super(evalIntervalSeconds, decisionFrequency);
     this.highHeapUsageClusterRca = highHeapUsageClusterRca;
   }
 
+  /**
+   * The Queue and Cache deciders should only be able to suggest increase of the queue size or increase of cache size if the Java heap can
+   * sustain more live objects in it without de-gradation. What is an acceptable heap usage limit to determine this, comes from the
+   * <i>bucketization</> object in rca.conf. We compare the oldGen usage percent reported by the HighHeapUsage RCA to determine that.
+   *
+   * @param esNode The EsNode we are trying to make a decision for.
+   * @return return if the OldGen heap is under-utilized or healthy and yet more can be consumed, return true; or false otherwise.
+   */
   protected boolean canUseMoreHeap(NodeKey esNode) {
     // we add action only if heap is under-utilized or healthy and yet more can be consumed.
     for (ResourceFlowUnit<HotClusterSummary> clusterSummary : highHeapUsageClusterRca.getFlowUnits()) {
@@ -27,14 +45,20 @@ public abstract class HeapBasedDecider extends Decider {
           if (thisNode.equals(esNode)) {
             for (HotResourceSummary hotResourceSummary : nodeSummary.getHotResourceSummaryList()) {
               Resource resource = hotResourceSummary.getResource();
-              if (resource.getResourceEnum() == ResourceEnum.OLD_GEN) {
+              if (resource.getResourceEnum() == DECIDING_HEAP_RESOURCE_TYPE) {
                 double oldGenUsedRatio = hotResourceSummary.getValue();
                 double oldGenUsedPercent = oldGenUsedRatio * 100;
-                UsageBucket bucket = rcaConf.getBucketizationSettings("old-gen").compute(oldGenUsedPercent);
-                if (bucket == UsageBucket.HEALTHY || bucket == UsageBucket.UNHEALTHY) {
-                  return false;
-                } else {
+                BucketCalculator bucketCalculator;
+                try {
+                  bucketCalculator = rcaConf.getBucketizationSettings(OLD_GEN_TUNABLE_KEY);
+                } catch (Exception jsonEx) {
+                  bucketCalculator = new BasicBucketCalculator(HEAP_USAGE_MAP);
+                }
+                UsageBucket bucket = bucketCalculator.compute(oldGenUsedPercent);
+                if (bucket == UsageBucket.UNDER_UTILIZED || bucket == UsageBucket.HEALTHY_WITH_BUFFER) {
                   return true;
+                } else {
+                  return false;
                 }
               }
             }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/QueueHealthDecider.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/QueueHealthDecider.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.Action;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ModifyQueueCapacityAction;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.Resource;
@@ -24,6 +25,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.bucket.UsageBucket;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaRuntimeMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HighHeapUsageClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HotNodeClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
@@ -104,6 +106,9 @@ public class QueueHealthDecider extends HeapBasedDecider {
           break;
         }
       }
+    } else {
+      PerformanceAnalyzerApp.RCA_RUNTIME_METRICS_AGGREGATOR.updateStat(
+          RcaRuntimeMetrics.NO_INCREASE_ACTION_SUGGESTED, NAME + ":" + esNode.getHostAddress(), 1);
     }
     return action;
   }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/SlidingWindow.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/SlidingWindow.java
@@ -28,13 +28,11 @@ public class SlidingWindow<E extends SlidingWindowData> {
   protected final Deque<E> windowDeque;
   protected final long SLIDING_WINDOW_SIZE;
   protected double sum;
-  protected TimeUnit timeUnit;
 
   public SlidingWindow(int SLIDING_WINDOW_SIZE_IN_TIMESTAMP, TimeUnit timeUnit) {
     this.windowDeque = new LinkedList<>();
     this.SLIDING_WINDOW_SIZE = timeUnit.toSeconds(SLIDING_WINDOW_SIZE_IN_TIMESTAMP);
     this.sum = 0.0;
-    this.timeUnit = timeUnit;
   }
 
   /**

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/GC_Collection_Event.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/GC_Collection_Event.java
@@ -19,6 +19,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetric
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
 
 public class GC_Collection_Event extends Metric {
+  public static final String NAME = AllMetrics.HeapValue.GC_COLLECTION_EVENT.toString();
+
   public GC_Collection_Event(long evaluationIntervalSeconds) {
     super(AllMetrics.HeapValue.GC_COLLECTION_EVENT.toString(), evaluationIntervalSeconds);
   }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/Heap_Used.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/Heap_Used.java
@@ -19,6 +19,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetric
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
 
 public class Heap_Used extends Metric {
+  public static final String NAME = AllMetrics.HeapValue.HEAP_USED.toString();
+
   public Heap_Used(long evaluationIntervalSeconds) {
     super(AllMetrics.HeapValue.HEAP_USED.toString(), evaluationIntervalSeconds);
   }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaRuntimeMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/RcaRuntimeMetrics.java
@@ -48,6 +48,11 @@ public enum RcaRuntimeMetrics implements MeasurementSet {
   /**
    * Metric tracking the actions published by the publisher that are persisted in sqlite.
    */
+  NO_INCREASE_ACTION_SUGGESTED("NoIncreaseAction", "namedCount", Collections.singletonList(Statistics.NAMED_COUNTERS)),
+
+  /**
+   * Metric tracking the actions published by the publisher that are persisted in sqlite.
+   */
   ACTIONS_PUBLISHED("ActionsPublished", "namedCount", Collections.singletonList(Statistics.NAMED_COUNTERS));
 
   /**

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
@@ -270,9 +270,9 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
 
     // Cache Health Decider
     CacheHealthDecider cacheHealthDecider = new CacheHealthDecider(
-            EVALUATION_INTERVAL_SECONDS, 12, fieldDataCacheClusterRca, shardRequestCacheClusterRca);
+            EVALUATION_INTERVAL_SECONDS, 12, fieldDataCacheClusterRca, shardRequestCacheClusterRca, highHeapUsageClusterRca);
     cacheHealthDecider.addTag(TAG_LOCUS, LOCUS_MASTER_NODE);
-    cacheHealthDecider.addAllUpstreams(Arrays.asList(fieldDataCacheClusterRca, shardRequestCacheClusterRca));
+    cacheHealthDecider.addAllUpstreams(Arrays.asList(fieldDataCacheClusterRca, shardRequestCacheClusterRca, highHeapUsageClusterRca));
 
     constructShardResourceUsageGraph();
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
@@ -167,8 +167,7 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
     highHeapUsageClusterRca.addAllUpstreams(Collections.singletonList(hotJVMNodeRca));
     highHeapUsageClusterRca.addTag(TAG_AGGREGATE_UPSTREAM, LOCUS_DATA_NODE);
 
-    Rca<ResourceFlowUnit<HotClusterSummary>> hotNodeClusterRca =
-            new HotNodeClusterRca(RCA_PERIOD, hotJVMNodeRca);
+    HotNodeClusterRca hotNodeClusterRca = new HotNodeClusterRca(RCA_PERIOD, hotJVMNodeRca);
     hotNodeClusterRca.addTag(TAG_LOCUS, LOCUS_MASTER_NODE);
     hotNodeClusterRca.addAllUpstreams(Collections.singletonList(hotJVMNodeRca));
 
@@ -196,9 +195,10 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
     queueRejectionClusterRca.addTag(TAG_AGGREGATE_UPSTREAM, LOCUS_DATA_NODE);
 
     // Queue Health Decider
-    QueueHealthDecider queueHealthDecider = new QueueHealthDecider(EVALUATION_INTERVAL_SECONDS, 12, queueRejectionClusterRca);
+    QueueHealthDecider queueHealthDecider = new QueueHealthDecider(
+        EVALUATION_INTERVAL_SECONDS, 12, queueRejectionClusterRca, highHeapUsageClusterRca);
     queueHealthDecider.addTag(TAG_LOCUS, LOCUS_MASTER_NODE);
-    queueHealthDecider.addAllUpstreams(Collections.singletonList(queueRejectionClusterRca));
+    queueHealthDecider.addAllUpstreams(Arrays.asList(queueRejectionClusterRca, highHeapUsageClusterRca));
 
     // Node Config Collector
     ThreadPool_QueueCapacity queueCapacity = new ThreadPool_QueueCapacity();

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HotNodeRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/HotNodeRca.java
@@ -48,14 +48,6 @@ public class HotNodeRca extends Rca<ResourceFlowUnit<HotNodeSummary>> {
     hasUnhealthyFlowUnit = false;
   }
 
-  public <R extends Rca<ResourceFlowUnit<HotResourceSummary>>> HotNodeRca(final int rcaPeriod, Collection<R> hotResourceRcas) {
-    super(5);
-    this.hotResourceRcas = hotResourceRcas.toArray(new Rca[hotResourceRcas.size()]);
-    this.rcaPeriod = rcaPeriod;
-    this.counter = 0;
-    hasUnhealthyFlowUnit = false;
-  }
-
   @Override
   public ResourceFlowUnit<HotNodeSummary> operate() {
     counter++;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/CacheHealthDeciderTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/CacheHealthDeciderTest.java
@@ -30,6 +30,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HighHeapUsageClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.FieldDataCacheClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.ShardRequestCacheClusterRca;
@@ -167,8 +168,12 @@ public class CacheHealthDeciderTest {
     shardRequestCacheClusterRca.setAppContext(appContext);
     shardRequestCacheClusterRca.generateFlowUnitListFromLocal(null);
 
+
+    RcaTestHelper<HotNodeSummary> nodeRca = new RcaTestHelper<>("QueueRejectionNodeRca");
+    nodeRca.setAppContext(appContext);
+    HighHeapUsageClusterRca clusterRca = new HighHeapUsageClusterRca(1, nodeRca);
     CacheHealthDecider decider =
-        new CacheHealthDecider(5, 12, fieldDataCacheClusterRca, shardRequestCacheClusterRca);
+        new CacheHealthDecider(5, 12, fieldDataCacheClusterRca, shardRequestCacheClusterRca, clusterRca);
     decider.setAppContext(appContext);
     decider.readRcaConf(rcaConf);
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/HeapBasedDeciderTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/HeapBasedDeciderTest.java
@@ -1,0 +1,73 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil.OLD_GEN_HEAP_USAGE;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.RcaTestHelper;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Resources;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.contexts.ResourceContext;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotClusterSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.bucket.UsageBucket;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HighHeapUsageClusterRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HeapBasedDeciderTest {
+  private HeapBasedDecider createClusterRcaWithOldGenVal(double oldGenValue, NodeKey nodeKey) {
+    RcaTestHelper<HotNodeSummary> nodeRca = new RcaTestHelper<>("QueueRejectionNodeRca");
+    nodeRca.setAppContext(new AppContext());
+    HighHeapUsageClusterRca highHeapUsageClusterRca = new HighHeapUsageClusterRca(1, nodeRca);
+
+    ResourceContext context = new ResourceContext(Resources.State.UNHEALTHY);
+
+    HotNodeSummary nodeSummary = new HotNodeSummary(nodeKey.getNodeId(), nodeKey.getHostAddress());
+    nodeSummary.appendNestedSummary(new HotResourceSummary(OLD_GEN_HEAP_USAGE, 60, oldGenValue, 60));
+    HotClusterSummary clusterSummary = new HotClusterSummary(1, 1);
+
+    clusterSummary.appendNestedSummary(nodeSummary);
+
+    highHeapUsageClusterRca.setLocalFlowUnit(new ResourceFlowUnit<>(System.currentTimeMillis(), context, clusterSummary, true));
+    HeapBasedDecider heapBasedDecider = new HeapBasedDecider(1, 1, highHeapUsageClusterRca) {
+      @Override
+      public String name() {
+        return null;
+      }
+
+      @Override
+      public Decision operate() {
+        return null;
+      }
+    };
+    return heapBasedDecider;
+  }
+
+  @Test
+  public void canUseMoreHeap() {
+    NodeKey nodeKey = new NodeKey(new InstanceDetails.Id("xyz"), new InstanceDetails.Ip("1.1.1.1"));
+
+    double percent = HeapBasedDecider.HEAP_USAGE_MAP.get(UsageBucket.UNDER_UTILIZED);
+    double ratio = percent / 100.0;
+    HeapBasedDecider heapBasedDecider = createClusterRcaWithOldGenVal(ratio, nodeKey);
+    Assert.assertTrue(heapBasedDecider.canUseMoreHeap(nodeKey));
+
+    percent = HeapBasedDecider.HEAP_USAGE_MAP.get(UsageBucket.HEALTHY_WITH_BUFFER);
+    ratio = percent / 100.0;
+    heapBasedDecider = createClusterRcaWithOldGenVal(ratio, nodeKey);
+    Assert.assertTrue(heapBasedDecider.canUseMoreHeap(nodeKey));
+
+    percent = HeapBasedDecider.HEAP_USAGE_MAP.get(UsageBucket.HEALTHY);
+    ratio = percent / 100.0;
+    heapBasedDecider = createClusterRcaWithOldGenVal(ratio, nodeKey);
+    Assert.assertFalse(heapBasedDecider.canUseMoreHeap(nodeKey));
+
+    percent = HeapBasedDecider.HEAP_USAGE_MAP.get(UsageBucket.HEALTHY) + 10;
+    ratio = percent / 100.0;
+    heapBasedDecider = createClusterRcaWithOldGenVal(ratio, nodeKey);
+    Assert.assertFalse(heapBasedDecider.canUseMoreHeap(nodeKey));
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/HeapBasedDeciderTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/HeapBasedDeciderTest.java
@@ -50,22 +50,22 @@ public class HeapBasedDeciderTest {
   public void canUseMoreHeap() {
     NodeKey nodeKey = new NodeKey(new InstanceDetails.Id("xyz"), new InstanceDetails.Ip("1.1.1.1"));
 
-    double percent = HeapBasedDecider.HEAP_USAGE_MAP.get(UsageBucket.UNDER_UTILIZED);
+    double percent = HeapBasedDecider.DEFAULT_HEAP_USAGE_THRESHOLDS.get(UsageBucket.UNDER_UTILIZED);
     double ratio = percent / 100.0;
     HeapBasedDecider heapBasedDecider = createClusterRcaWithOldGenVal(ratio, nodeKey);
     Assert.assertTrue(heapBasedDecider.canUseMoreHeap(nodeKey));
 
-    percent = HeapBasedDecider.HEAP_USAGE_MAP.get(UsageBucket.HEALTHY_WITH_BUFFER);
+    percent = HeapBasedDecider.DEFAULT_HEAP_USAGE_THRESHOLDS.get(UsageBucket.HEALTHY_WITH_BUFFER);
     ratio = percent / 100.0;
     heapBasedDecider = createClusterRcaWithOldGenVal(ratio, nodeKey);
     Assert.assertTrue(heapBasedDecider.canUseMoreHeap(nodeKey));
 
-    percent = HeapBasedDecider.HEAP_USAGE_MAP.get(UsageBucket.HEALTHY);
+    percent = HeapBasedDecider.DEFAULT_HEAP_USAGE_THRESHOLDS.get(UsageBucket.HEALTHY);
     ratio = percent / 100.0;
     heapBasedDecider = createClusterRcaWithOldGenVal(ratio, nodeKey);
     Assert.assertFalse(heapBasedDecider.canUseMoreHeap(nodeKey));
 
-    percent = HeapBasedDecider.HEAP_USAGE_MAP.get(UsageBucket.HEALTHY) + 10;
+    percent = HeapBasedDecider.DEFAULT_HEAP_USAGE_THRESHOLDS.get(UsageBucket.HEALTHY) + 10;
     ratio = percent / 100.0;
     heapBasedDecider = createClusterRcaWithOldGenVal(ratio, nodeKey);
     Assert.assertFalse(heapBasedDecider.canUseMoreHeap(nodeKey));

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/QueueHealthDeciderTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/QueueHealthDeciderTest.java
@@ -32,6 +32,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HighHeapUsageClusterRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.HotNodeClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.QueueRejectionClusterRca;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
@@ -106,7 +108,9 @@ public class QueueHealthDeciderTest {
     QueueRejectionClusterRca queueClusterRca = new QueueRejectionClusterRca(1, nodeRca);
     queueClusterRca.setAppContext(appContext);
     queueClusterRca.generateFlowUnitListFromLocal(null);
-    QueueHealthDecider decider = new QueueHealthDecider(5, 12, queueClusterRca);
+
+    HighHeapUsageClusterRca clusterRca = new HighHeapUsageClusterRca(1, nodeRca);
+    QueueHealthDecider decider = new QueueHealthDecider(5, 12, queueClusterRca, clusterRca);
     decider.setAppContext(appContext);
     decider.readRcaConf(rcaConf);
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Host.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Host.java
@@ -254,7 +254,11 @@ public class Host {
     }
     clientServers.getHttpServer().stop(10);
     clientServers.getNetClient().stop();
-    clientServers.getNetServer().shutdown();
+    try {
+      clientServers.getNetServer().shutdown();
+    } catch (Exception ex) {
+      ex.printStackTrace();
+    }
 
     connectionManager.shutdown();
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/dedicated_master/QueueDeciderDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/dedicated_master/QueueDeciderDedicatedMasterITest.java
@@ -98,6 +98,8 @@ public class QueueDeciderDedicatedMasterITest {
       reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
   @AErrorPatternIgnored(pattern = "NodeConfigCacheReaderUtil:readQueueCapacity()",
       reason = "Metrics is expected to be missing")
+  @AErrorPatternIgnored(pattern = "ModifyQueueCapacityAction:build()",
+      reason = "Metrics is expected to be missing")
   public void testQueueCapacityDecider() {
   }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/dedicated_master/QueueDeciderDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/dedicated_master/QueueDeciderDedicatedMasterITest.java
@@ -96,6 +96,8 @@ public class QueueDeciderDedicatedMasterITest {
       reason = "Cache metrics are expected to be missing in this integ test")
   @AErrorPatternIgnored(pattern = "SubscribeResponseHandler:onError()",
       reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+  @AErrorPatternIgnored(pattern = "NodeConfigCacheReaderUtil:readQueueCapacity()",
+      reason = "Metrics is expected to be missing")
   public void testQueueCapacityDecider() {
   }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/dedicated_master/QueueDeciderDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/dedicated_master/QueueDeciderDedicatedMasterITest.java
@@ -17,8 +17,12 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.t
 
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.Constants.QUEUE_TUNING_RESOURCES_DIR;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.GC_Collection_Event;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Max;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Used;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_QueueCapacity;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_RejectedReqs;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
@@ -31,9 +35,9 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.fr
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.Consts;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.validator.QDeciderNoActionOnUnhealthyValidator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.validator.QueueDeciderValidator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.ElasticSearchAnalysisGraph;
@@ -93,5 +97,92 @@ public class QueueDeciderDedicatedMasterITest {
   @AErrorPatternIgnored(pattern = "SubscribeResponseHandler:onError()",
       reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
   public void testQueueCapacityDecider() {
+  }
+
+
+  @AMetric(name = ThreadPool_RejectedReqs.class,
+      dimensionNames = {ThreadPoolDimension.Constants.TYPE_VALUE},
+      tables = {
+          @ATable(hostTag = HostTag.DATA_0,
+              tuple = {
+                  @ATuple(dimensionValues = {ThreadPoolType.Constants.WRITE_NAME},
+                      sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                  @ATuple(dimensionValues = {ThreadPoolType.Constants.SEARCH_NAME},
+                      sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
+              }
+          )
+      }
+  )
+
+  @AMetric(name = ThreadPool_QueueCapacity.class,
+      dimensionNames = {ThreadPoolDimension.Constants.TYPE_VALUE},
+      tables = {
+          @ATable(hostTag = HostTag.DATA_0,
+              tuple = {
+                  @ATuple(dimensionValues = {ThreadPoolType.Constants.WRITE_NAME},
+                      sum = 500, avg = 500, min = 500, max = 500),
+                  @ATuple(dimensionValues = {ThreadPoolType.Constants.SEARCH_NAME},
+                      sum = 1500, avg = 1500, min = 1500, max = 1500)
+              }
+          )
+      }
+  )
+
+  @AMetric(name = Heap_Used.class,
+      dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+      tables = {
+          @ATable(hostTag = {HostTag.DATA_0, HostTag.DATA_1},
+              tuple = {
+                  @ATuple(dimensionValues = AllMetrics.GCType.Constants.OLD_GEN_VALUE,
+                      sum = 65695944, avg = 65695944, min = 65695944, max = 65695944),
+              }
+          )
+      }
+  )
+  @AMetric(name = GC_Collection_Event.class,
+      dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+      tables = {
+          @ATable(hostTag = {HostTag.DATA_0, HostTag.DATA_1},
+              tuple = {
+                  @ATuple(dimensionValues = AllMetrics.GCType.Constants.TOT_FULL_GC_VALUE,
+                      sum = 2, avg = 2, min = 2, max = 2),
+              }
+          )
+      }
+  )
+  @AMetric(name = Heap_Max.class,
+      dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+      tables = {
+          @ATable(hostTag = {HostTag.DATA_0, HostTag.DATA_1},
+              tuple = {
+                  @ATuple(dimensionValues = AllMetrics.GCType.Constants.OLD_GEN_VALUE,
+                      sum = 65695945, avg = 65695945, min = 65695945, max = 65695945),
+              }
+          )
+      }
+  )
+
+  @Test
+  @AExpect(
+      what = AExpect.Type.DB_QUERY,
+      on = HostTag.ELECTED_MASTER,
+      validator = QDeciderNoActionOnUnhealthyValidator.class,
+      forRca = PersistedAction.class,
+      timeoutSeconds = 1000)
+  @AErrorPatternIgnored(pattern = "CacheUtil:getCacheMaxSize()",
+      reason = "Cache related configs are expected to be missing in this integ test")
+  @AErrorPatternIgnored(pattern = "AggregateMetric:gather()",
+      reason = "Cache metrics are expected to be missing in this integ test")
+  @AErrorPatternIgnored(pattern = "SubscribeResponseHandler:onError()",
+      reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+  @AErrorPatternIgnored(pattern = "NodeConfigCollector:collectAndPublishMetric()",
+      reason = "Metrics is expected to be missing")
+  @AErrorPatternIgnored(pattern = "NodeConfigCollector:readQueueCapacity()",
+      reason = "Metrics is expected to be missing")
+  @AErrorPatternIgnored(pattern = "NodeConfigCacheReaderUtil:readQueueCapacity()",
+      reason = "Metrics is expected to be missing")
+  @AErrorPatternIgnored(pattern = "ModifyQueueCapacityAction:build()",
+      reason = "Metrics is expected to be missing")
+  public void testNoCapacityIncreaseOnUnHealthy() {
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/validator/QDeciderNoActionOnUnhealthyValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/queue_tuning/validator/QDeciderNoActionOnUnhealthyValidator.java
@@ -1,0 +1,66 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.queue_tuning.validator;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ModifyQueueCapacityAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.api.IValidator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
+import org.junit.Assert;
+
+public class QDeciderNoActionOnUnhealthyValidator implements IValidator {
+  AppContext appContext;
+  long startTime;
+
+  public QDeciderNoActionOnUnhealthyValidator() {
+    appContext = new AppContext();
+    startTime = System.currentTimeMillis();
+  }
+
+  /**
+   * {"actionName":"ModifyQueueCapacity",
+   * "resourceValue":4,
+   * "timestamp":"1599257910923",
+   * "nodeId":"node1",
+   * "nodeIp":127.0.0.1,
+   * "actionable":1,
+   * "coolOffPeriod": 300000,
+   * "muted": 0
+   * "summary": "Id":"DATA_0","Ip":"127.0.0.1","resource":4,"desiredCapacity":547,
+   *            "currentCapacity":500,"coolOffPeriodInMillis":10000,"canUpdate":true}
+   */
+  @Override
+  public boolean checkDbObj(Object object) {
+    if (object == null) {
+      return false;
+    }
+    PersistedAction persistedAction = (PersistedAction) object;
+    return checkPersistedAction(persistedAction);
+  }
+
+  /**
+   * {"actionName":"ModifyQueueCapacity",
+   * "resourceValue":4,
+   * "timestamp":"1599257910923",
+   * "nodeId":"node1",
+   * "nodeIp":127.0.0.1,
+   * "actionable":1,
+   * "coolOffPeriod": 300000,
+   * "muted": 0
+   * "summary": "Id":"DATA_0","Ip":"127.0.0.1","resource":4,"desiredCapacity":547,
+   *            "currentCapacity":500,"coolOffPeriodInMillis":10000,"canUpdate":true}
+   */
+  private boolean checkPersistedAction(final PersistedAction persistedAction) {
+    ModifyQueueCapacityAction modifyQueueCapacityAction =
+        ModifyQueueCapacityAction.fromSummary(persistedAction.getSummary(), appContext);
+    Assert.assertEquals(ModifyQueueCapacityAction.NAME, persistedAction.getActionName());
+    Assert.assertEquals("{DATA_0}", persistedAction.getNodeIds());
+    Assert.assertEquals("{127.0.0.1}", persistedAction.getNodeIps());
+    Assert.assertEquals(ModifyQueueCapacityAction.Builder.DEFAULT_COOL_OFF_PERIOD_IN_MILLIS, persistedAction.getCoolOffPeriod());
+    Assert.assertTrue(persistedAction.isActionable());
+    Assert.assertFalse(persistedAction.isMuted());
+    Assert.assertEquals(ResourceEnum.WRITE_THREADPOOL, modifyQueueCapacityAction.getThreadPool());
+    Assert.assertEquals(547, modifyQueueCapacityAction.getDesiredCapacity());
+    Assert.assertEquals(500, modifyQueueCapacityAction.getCurrentCapacity());
+    return true;
+  }
+}

--- a/src/test/resources/rca/rca_elected_master.conf
+++ b/src/test/resources/rca/rca_elected_master.conf
@@ -109,5 +109,13 @@
   },
 
   // Action Configurations
-  "action-config-settings": {}
+  "action-config-settings": {},
+
+  "bucketization": {
+    "old-gen": {
+      "UNDER_UTILIZED": 10.0,
+      "HEALTHY_WITH_BUFFER": 30.0,
+      "HEALTHY": 70.0
+    }
+  }
 }


### PR DESCRIPTION
*Fixes #:* #467

*Description of changes:* The Queue And Cache Deciders generates the actions to increase the Queue or Cache size if there are no errors. But this can have consequences if the Jvm Heap is already contended. This patch adds a check to make sure that the old gen heap occupancy after GC is underutilized or healthy and more of it can be consumed. The buckets to determine the usage limits are obtained from the `rca.conf`. If rca.conf does not contain them, then the defaults in the `HeapBasedDecider::DEFAULT_HEAP_USAGE_THRESHOLDS`.

*Tests:*
- Added unit tests to check the `canUseMoreHeap()` works as expected.
- Added an integration test. 

*If new tests are added, how long do the new ones take to complete*

` Test testNoCapacityIncreaseOnUnHealthy PASSED (1m 59s)`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
