### PR TITLE
Add Master Throttling Metric

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/AllMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/AllMetrics.java
@@ -822,7 +822,13 @@ public class AllMetrics {
   }
 
   public enum MasterThrottlingValue implements MetricValue {
+    /**
+     * Sum of total pending tasks throttled by master node.
+     */
     MASTER_THROTTLED_PENDING_TASK_COUNT(MasterThrottlingValue.Constants.THROTTLED_PENDING_TASK_COUNT),
+    /**
+     * Number of pending tasks on which data nodes are actively performing retries.
+     */
     DATA_RETRYING_TASK_COUNT(MasterThrottlingValue.Constants.RETRYING_TASK_COUNT);
 
     private final String value;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/AllMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/AllMetrics.java
@@ -821,6 +821,27 @@ public class AllMetrics {
     }
   }
 
+  public enum MasterThrottlingValue implements MetricValue {
+    MASTER_THROTTLED_PENDING_TASK_COUNT(MasterThrottlingValue.Constants.THROTTLED_PENDING_TASK_COUNT),
+    DATA_RETRYING_TASK_COUNT(MasterThrottlingValue.Constants.RETRYING_TASK_COUNT);
+
+    private final String value;
+
+    MasterThrottlingValue(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return value;
+    }
+
+    public static class Constants {
+      public static final String THROTTLED_PENDING_TASK_COUNT = "Master_ThrottledPendingTasksCount";
+      public static final String RETRYING_TASK_COUNT = "Data_RetryingPendingTasksCount";
+    }
+  }
+
   public enum OSMetrics {
     CPU_UTILIZATION(Constants.CPU_VALUE),
     PAGING_MAJ_FLT_RATE(Constants.PAGING_MAJFLT_VALUE),

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
@@ -48,6 +48,7 @@ public class PerformanceAnalyzerMetrics {
   public static final String sHeapPath = "heap_metrics";
   public static final String sNodesPath = "node_metrics";
   public static final String sPendingTasksPath = "pending_tasks";
+  public static final String sMasterThrottledTasksPath = "master_throttling_metrics";
   public static final String sDisksPath = "disk_metrics";
   public static final String sTCPPath = "tcp_metrics";
   public static final String sIPPath = "ip_metrics";

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/model/MetricsModel.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/model/MetricsModel.java
@@ -340,6 +340,15 @@ public class MetricsModel {
         new MetricAttributes(
             MetricUnits.MILLISECOND.toString(), AllMetrics.MasterMetricDimensions.values()));
 
+    // Master Throttling Metrics
+    allMetricsInitializer.put(
+            AllMetrics.MasterThrottlingValue.MASTER_THROTTLED_PENDING_TASK_COUNT.toString(),
+            new MetricAttributes(MetricUnits.COUNT.toString(), EmptyDimension.values()));
+
+    allMetricsInitializer.put(
+            AllMetrics.MasterThrottlingValue.DATA_RETRYING_TASK_COUNT.toString(),
+            new MetricAttributes(MetricUnits.COUNT.toString(),
+                    EmptyDimension.values()));
 
     ALL_METRICS = Collections.unmodifiableMap(allMetricsInitializer);
   }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
@@ -49,7 +49,9 @@ public enum ExceptionsAndErrors implements MeasurementSet {
    */
   READER_METRICSDB_ACCESS_ERRORS("ReaderMetricsdbAccessError"),
 
-  SHARD_STATE_COLLECTOR_ERROR("ShardStateCollectorError");
+  SHARD_STATE_COLLECTOR_ERROR("ShardStateCollectorError"),
+
+  MASTER_THROTTLING_COLLECTOR_ERROR("MasterThrottlingMetricsCollector");
 
   /** What we want to appear as the metric name. */
   private String name;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ReaderMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ReaderMetrics.java
@@ -61,6 +61,12 @@ public enum ReaderMetrics implements MeasurementSet {
      * Amount of time taken to emit Shard State metrics.
      */
     SHARD_STATE_EMITTER_EXECUTION_TIME("ShardStateEmitterExecutionTime", "millis",
+        Arrays.asList(Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
+
+    /**
+     * Amount of time taken to emit Master throttling metrics.
+     */
+    MASTER_THROTTLING_EMITTER_EXECUTION_TIME("MasterThrottlingEmitterExecutionTime", "millis",
         Arrays.asList(Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM));
 
     /** What we want to appear as the metric name. */

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
@@ -24,6 +24,12 @@ import java.util.List;
 
 public enum WriterMetrics implements MeasurementSet {
     SHARD_STATE_COLLECTOR_EXECUTION_TIME("ShardStateCollectorExecutionTime", "millis", Arrays.asList(
+            Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
+
+    MASTER_THROTTLING_COLLECTOR_EXECUTION_TIME("MasterThrottlingCollectorExecutionTime", "millis", Arrays.asList(
+            Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
+
+    MASTER_THROTTLING_COLLECTOR_NOT_AVAILABLE("MasterThrottlingCollectorNotAvailable", "count", Arrays.asList(
             Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM));
 
     /** What we want to appear as the metric name. */

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MasterThrottlingMetricsEventProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MasterThrottlingMetricsEventProcessor.java
@@ -1,0 +1,101 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.sql.Connection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NavigableMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jooq.BatchBindStep;
+
+public class MasterThrottlingMetricsEventProcessor implements EventProcessor {
+    private static final Logger LOG = LogManager.getLogger(MasterThrottlingMetricsEventProcessor.class);
+    private MasterThrottlingMetricsSnapshot masterThrottlingMetricsSnapshot;
+    private BatchBindStep handle;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final TypeReference<HashMap<String, String>> TYPE_REF = new TypeReference<HashMap<String, String>>() {};
+
+    private MasterThrottlingMetricsEventProcessor(MasterThrottlingMetricsSnapshot snapshot) {
+        this.masterThrottlingMetricsSnapshot = snapshot;
+    }
+
+    static MasterThrottlingMetricsEventProcessor buildMasterThrottlingMetricEventsProcessor(
+            long currWindowStartTime,
+            Connection conn,
+            NavigableMap<Long, MasterThrottlingMetricsSnapshot> masterThroEventMetricsMap) {
+        MasterThrottlingMetricsSnapshot masterThrottlingSnapshot = masterThroEventMetricsMap.get(currWindowStartTime);
+        if (masterThrottlingSnapshot == null) {
+            masterThrottlingSnapshot = new MasterThrottlingMetricsSnapshot(conn, currWindowStartTime);
+            masterThroEventMetricsMap.put(currWindowStartTime, masterThrottlingSnapshot);
+        }
+        return new MasterThrottlingMetricsEventProcessor(masterThrottlingSnapshot);
+    }
+
+    @Override
+    public void initializeProcessing(long startTime, long endTime) {
+        this.handle = masterThrottlingMetricsSnapshot.startBatchPut();
+    }
+
+    @Override
+    public void finalizeProcessing() {
+        if (handle.size() > 0) {
+            handle.execute();
+        }
+        LOG.debug("Final Master Throttling metrics {}", masterThrottlingMetricsSnapshot.fetchAll());
+    }
+
+    /**
+     * Sample event:
+     * ^master_throttling_metrics
+     * {"current_time":1602617137529}
+     * {"Data_RetryingPendingTasksCount":0,"Master_ThrottledPendingTasksCount":0}$
+     *
+     * @param event event
+     */
+    @Override
+    public void processEvent(Event event) {
+        String[] lines = event.value.split(System.lineSeparator());
+        for (String line : lines) {
+            Map<String, String> masterThrottlingMap = extractEntryData(line);
+            if (!masterThrottlingMap.containsKey(PerformanceAnalyzerMetrics.METRIC_CURRENT_TIME)) {
+                handle.bind(
+                        Long.parseLong(masterThrottlingMap.get(
+                                AllMetrics.MasterThrottlingValue.DATA_RETRYING_TASK_COUNT.toString())),
+                        Long.parseLong(masterThrottlingMap.get(
+                                AllMetrics.MasterThrottlingValue.MASTER_THROTTLED_PENDING_TASK_COUNT.toString())));
+            }
+        }
+    }
+
+    @Override
+    public boolean shouldProcessEvent(Event event) {
+        return event.key.contains(PerformanceAnalyzerMetrics.sMasterThrottledTasksPath);
+    }
+
+    @Override
+    public void commitBatchIfRequired() {
+        if (handle.size() > BATCH_LIMIT) {
+            handle.execute();
+            handle = masterThrottlingMetricsSnapshot.startBatchPut();
+        }
+    }
+
+    static Map<String, String> extractEntryData(String line) {
+        try {
+            Map<String, String> map = MAPPER.readValue(line, TYPE_REF);
+            return map;
+        } catch (IOException ioe) {
+            LOG.error("Error occurred while parsing tmp file", ioe);
+        }
+        return new HashMap<>();
+    }
+}
+

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MasterThrottlingMetricsEventProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MasterThrottlingMetricsEventProcessor.java
@@ -1,3 +1,18 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
@@ -73,7 +88,7 @@ public class MasterThrottlingMetricsEventProcessor implements EventProcessor {
                             Long.parseLong(masterThrottlingMap.get(
                                     AllMetrics.MasterThrottlingValue.MASTER_THROTTLED_PENDING_TASK_COUNT.toString())));
                 } catch (Exception ex) {
-                    LOG.error( "Fail to get master throttling metrics ",  ex);
+                    LOG.error("Fail to get master throttling metrics ",  ex);
                 }
             }
         }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MasterThrottlingMetricsSnapshot.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MasterThrottlingMetricsSnapshot.java
@@ -1,0 +1,208 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.DBUtils;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
+import com.google.common.annotations.VisibleForTesting;
+
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jooq.BatchBindStep;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.jooq.SQLDialect;
+import org.jooq.SelectField;
+import org.jooq.impl.DSL;
+
+public class MasterThrottlingMetricsSnapshot implements Removable {
+    private static final Logger LOG = LogManager.getLogger(MasterThrottlingMetricsSnapshot.class);
+
+    private final DSLContext create;
+    private final Long windowStartTime;
+    private final String tableName;
+    private List<Field<?>> columns;
+
+    public MasterThrottlingMetricsSnapshot(Connection conn, Long windowStartTime) {
+        this.create = DSL.using(conn, SQLDialect.SQLITE);
+        this.windowStartTime = windowStartTime;
+        this.tableName = "master_throttling_" + windowStartTime;
+
+        this.columns =
+                new ArrayList<Field<?>>() {
+                    {
+                        this.add(
+                                DSL.field(
+                                        DSL.name(AllMetrics.MasterThrottlingValue.DATA_RETRYING_TASK_COUNT.toString()),
+                                        Long.class));
+                        this.add(
+                                DSL.field(
+                                        DSL.name(AllMetrics.MasterThrottlingValue.MASTER_THROTTLED_PENDING_TASK_COUNT.toString()),
+                                        Long.class));
+                    }
+                };
+        create.createTable(this.tableName).columns(columns).execute();
+    }
+
+    @Override
+    public void remove() throws Exception {
+        create.dropTable(DSL.table(this.tableName)).execute();
+    }
+
+    /**
+     * Return all master throttling metric in the current window.
+     *
+     * <p>Actual Table
+     * Data_RetryingPendingTasksCount|Master_ThrottledPendingTasksCount
+     * 5 |10
+     * <p/>
+     *
+     * @return aggregated master task
+     */
+    public Result<Record> fetchAll() {
+        return create.select().from(DSL.table(this.tableName)).fetch();
+    }
+
+    public BatchBindStep startBatchPut() {
+        List<Object> dummyValues = new ArrayList<>();
+        for (int i = 0; i < columns.size(); i++) {
+            dummyValues.add(null);
+        }
+        return create.batch(create.insertInto(DSL.table(this.tableName)).values(dummyValues));
+    }
+
+    /**
+     * Return one row per master throttling metric. It has 8 columns
+     *
+     * <p>|SUM_MASTER_THROTTLED_COUNT|AVG_MASTER_THROTTLED_COUNT|MIN_MASTER_THROTTLED_COUNT|MAX_MASTER_THROTTLED_COUNT|
+     * SUM_DATA_RETRYING_COUNT|AVG_DATA_RETRYING_COUNT|MIN_DATA_RETRYING_COUNT|MAX_DATA_RETRYING_COUNT
+     * <p/>
+     *
+     * @return aggregated master task
+     */
+    public Result<Record> fetchAggregatedMetrics() {
+
+        List<SelectField<?>> fields =
+                new ArrayList<SelectField<?>>() {
+                    {
+                        this.add(
+                                DSL.sum(
+                                        DSL.field(
+                                                DSL.name(
+                                                        AllMetrics.MasterThrottlingValue.MASTER_THROTTLED_PENDING_TASK_COUNT
+                                                                .toString()),
+                                                Long.class))
+                                        .as(
+                                                DBUtils.getAggFieldName(
+                                                        AllMetrics.MasterThrottlingValue.MASTER_THROTTLED_PENDING_TASK_COUNT.toString(),
+                                                        MetricsDB.SUM)));
+                        this.add(
+                                DSL.avg(
+                                        DSL.field(
+                                                DSL.name(
+                                                        AllMetrics.MasterThrottlingValue.MASTER_THROTTLED_PENDING_TASK_COUNT
+                                                                .toString()),
+                                                Double.class))
+                                        .as(
+                                                DBUtils.getAggFieldName(
+                                                        AllMetrics.MasterThrottlingValue.MASTER_THROTTLED_PENDING_TASK_COUNT.toString(),
+                                                        MetricsDB.AVG)));
+                        this.add(
+                                DSL.min(
+                                        DSL.field(
+                                                DSL.name(
+                                                        AllMetrics.MasterThrottlingValue.MASTER_THROTTLED_PENDING_TASK_COUNT
+                                                                .toString()),
+                                                Long.class))
+                                        .as(
+                                                DBUtils.getAggFieldName(
+                                                        AllMetrics.MasterThrottlingValue.MASTER_THROTTLED_PENDING_TASK_COUNT.toString(),
+                                                        MetricsDB.MIN)));
+                        this.add(
+                                DSL.max(
+                                        DSL.field(
+                                                DSL.name(
+                                                        AllMetrics.MasterThrottlingValue.MASTER_THROTTLED_PENDING_TASK_COUNT
+                                                                .toString()),
+                                                Long.class))
+                                        .as(
+                                                DBUtils.getAggFieldName(
+                                                        AllMetrics.MasterThrottlingValue.MASTER_THROTTLED_PENDING_TASK_COUNT.toString(),
+                                                        MetricsDB.MAX)));
+
+                        this.add(
+                                DSL.sum(
+                                        DSL.field(
+                                                DSL.name(
+                                                        AllMetrics.MasterThrottlingValue.DATA_RETRYING_TASK_COUNT
+                                                                .toString()),
+                                                Long.class))
+                                        .as(
+                                                DBUtils.getAggFieldName(
+                                                        AllMetrics.MasterThrottlingValue.DATA_RETRYING_TASK_COUNT.toString(),
+                                                        MetricsDB.SUM)));
+                        this.add(
+                                DSL.avg(
+                                        DSL.field(
+                                                DSL.name(
+                                                        AllMetrics.MasterThrottlingValue.DATA_RETRYING_TASK_COUNT
+                                                                .toString()),
+                                                Double.class))
+                                        .as(
+                                                DBUtils.getAggFieldName(
+                                                        AllMetrics.MasterThrottlingValue.DATA_RETRYING_TASK_COUNT.toString(),
+                                                        MetricsDB.AVG)));
+                        this.add(
+                                DSL.min(
+                                        DSL.field(
+                                                DSL.name(
+                                                        AllMetrics.MasterThrottlingValue.DATA_RETRYING_TASK_COUNT
+                                                                .toString()),
+                                                Long.class))
+                                        .as(
+                                                DBUtils.getAggFieldName(
+                                                        AllMetrics.MasterThrottlingValue.DATA_RETRYING_TASK_COUNT.toString(),
+                                                        MetricsDB.MIN)));
+                        this.add(
+                                DSL.max(
+                                        DSL.field(
+                                                DSL.name(
+                                                        AllMetrics.MasterThrottlingValue.DATA_RETRYING_TASK_COUNT
+                                                                .toString()),
+                                                Long.class))
+                                        .as(
+                                                DBUtils.getAggFieldName(
+                                                        AllMetrics.MasterThrottlingValue.DATA_RETRYING_TASK_COUNT.toString(),
+                                                        MetricsDB.MAX)));
+                    }
+                };
+        ArrayList<Field<?>> groupByFields =
+                new ArrayList<Field<?>>();
+
+        return create.select(fields).from(DSL.table(this.tableName)).groupBy(groupByFields).fetch();
+    }
+
+    @VisibleForTesting
+    public void putMetrics(long retrying_task, Map<String, String> dimensions) {
+        Map<Field<?>, String> dimensionMap = new HashMap<>();
+        for (Map.Entry<String, String> dimension : dimensions.entrySet()) {
+            dimensionMap.put(DSL.field(DSL.name(dimension.getKey()), String.class), dimension.getValue());
+        }
+        create
+                .insertInto(DSL.table(this.tableName))
+                .set(DSL.field(DSL.name(AllMetrics.MasterThrottlingValue.DATA_RETRYING_TASK_COUNT.toString()), Long.class),
+                        retrying_task)
+                .set(DSL.field(DSL.name(AllMetrics.MasterThrottlingValue.MASTER_THROTTLED_PENDING_TASK_COUNT.toString()), Long.class),
+                        0L)
+                .set(dimensionMap)
+                .execute();
+    }
+}
+

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MasterThrottlingMetricsSnapshot.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MasterThrottlingMetricsSnapshot.java
@@ -1,3 +1,18 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.DBUtils;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MasterThrottlingMetricsSnapshot.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MasterThrottlingMetricsSnapshot.java
@@ -11,8 +11,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jooq.BatchBindStep;
 import org.jooq.DSLContext;
 import org.jooq.Field;
@@ -23,7 +21,6 @@ import org.jooq.SelectField;
 import org.jooq.impl.DSL;
 
 public class MasterThrottlingMetricsSnapshot implements Removable {
-    private static final Logger LOG = LogManager.getLogger(MasterThrottlingMetricsSnapshot.class);
 
     private final DSLContext create;
     private final Long windowStartTime;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MetricsEmitter.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MetricsEmitter.java
@@ -875,7 +875,9 @@ public class MetricsEmitter {
 
     long mFinalT = System.currentTimeMillis();
     LOG.debug(
-            "Total time taken for writing master throttling state event queue metrics metricsdb: {}", mFinalT - mCurrT);
+            "Total time taken for writing master throttling metrics metricsdb: {}", mFinalT - mCurrT);
+    PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(ReaderMetrics.MASTER_THROTTLING_EMITTER_EXECUTION_TIME,
+            "", mFinalT - mCurrT);
   }
 
   public static void emitMasterThrottlingCount(MetricsDB metricsDB, Result<Record> res, List<String> dims) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MetricsEmitter.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MetricsEmitter.java
@@ -847,4 +847,126 @@ public class MetricsEmitter {
           "Total time taken for writing {} metrics metricsdb: {}", tableName, mFinalT - mCurrT);
     }
   }
+
+  public static void emitMasterThrottledTaskMetric(
+          MetricsDB metricsDB, MasterThrottlingMetricsSnapshot masterThrottlingMetricsSnapshot) {
+    long mCurrT = System.currentTimeMillis();
+    Result<Record> masterThrottlingMetrics = masterThrottlingMetricsSnapshot.fetchAggregatedMetrics();
+
+    List<String> dims =
+            new ArrayList<String>();
+    emitMasterThrottlingCount(metricsDB, masterThrottlingMetrics, dims);
+    emitDataThrottlingRetryingCount(metricsDB, masterThrottlingMetrics, dims);
+
+    long mFinalT = System.currentTimeMillis();
+    LOG.debug(
+            "Total time taken for writing master throttling state event queue metrics metricsdb: {}", mFinalT - mCurrT);
+  }
+
+  public static void emitMasterThrottlingCount(MetricsDB metricsDB, Result<Record> res, List<String> dims) {
+    metricsDB.createMetric(
+            new Metric<Double>(AllMetrics.MasterThrottlingValue.MASTER_THROTTLED_PENDING_TASK_COUNT.toString(), 0d),
+            dims);
+
+    BatchBindStep handle =
+            metricsDB.startBatchPut(
+                    new Metric<Double>(AllMetrics.MasterThrottlingValue.MASTER_THROTTLED_PENDING_TASK_COUNT.toString(), 0d),
+                    dims);
+
+    for (Record r : res) {
+
+      Double sumMasterThrottledTask =
+              Double.parseDouble(
+                      r.get(
+                              DBUtils.getAggFieldName(
+                                      AllMetrics.MasterThrottlingValue.MASTER_THROTTLED_PENDING_TASK_COUNT.toString(),
+                                      MetricsDB.SUM))
+                              .toString());
+
+      Double avgMasterThrottledTask =
+              Double.parseDouble(
+                      r.get(
+                              DBUtils.getAggFieldName(
+                                      AllMetrics.MasterThrottlingValue.MASTER_THROTTLED_PENDING_TASK_COUNT.toString(),
+                                      MetricsDB.AVG))
+                              .toString());
+
+      Double minMasterThrottledTask =
+              Double.parseDouble(
+                      r.get(
+                              DBUtils.getAggFieldName(
+                                      AllMetrics.MasterThrottlingValue.MASTER_THROTTLED_PENDING_TASK_COUNT.toString(),
+                                      MetricsDB.MIN))
+                              .toString());
+
+      Double maxMasterThrottledTask =
+              Double.parseDouble(
+                      r.get(
+                              DBUtils.getAggFieldName(
+                                      AllMetrics.MasterThrottlingValue.MASTER_THROTTLED_PENDING_TASK_COUNT.toString(),
+                                      MetricsDB.MAX))
+                              .toString());
+
+      handle.bind(
+              sumMasterThrottledTask,
+              avgMasterThrottledTask,
+              minMasterThrottledTask,
+              maxMasterThrottledTask);
+    }
+
+    handle.execute();
+  }
+
+  public static void emitDataThrottlingRetryingCount(MetricsDB metricsDB, Result<Record> res, List<String> dims) {
+    metricsDB.createMetric(
+            new Metric<Double>(AllMetrics.MasterThrottlingValue.DATA_RETRYING_TASK_COUNT.toString(), 0d),
+            dims);
+
+    BatchBindStep handle =
+            metricsDB.startBatchPut(
+                    new Metric<Double>(AllMetrics.MasterThrottlingValue.DATA_RETRYING_TASK_COUNT.toString(), 0d),
+                    dims);
+
+    for (Record r : res) {
+
+      Double sumDataRetryingTask =
+              Double.parseDouble(
+                      r.get(
+                              DBUtils.getAggFieldName(
+                                      AllMetrics.MasterThrottlingValue.DATA_RETRYING_TASK_COUNT.toString(),
+                                      MetricsDB.SUM))
+                              .toString());
+
+      Double avgDataRetryingTask =
+              Double.parseDouble(
+                      r.get(
+                              DBUtils.getAggFieldName(
+                                      AllMetrics.MasterThrottlingValue.DATA_RETRYING_TASK_COUNT.toString(),
+                                      MetricsDB.AVG))
+                              .toString());
+
+      Double minDataRetryingTask =
+              Double.parseDouble(
+                      r.get(
+                              DBUtils.getAggFieldName(
+                                      AllMetrics.MasterThrottlingValue.DATA_RETRYING_TASK_COUNT.toString(),
+                                      MetricsDB.MIN))
+                              .toString());
+
+      Double maxDataRetryingTask =
+              Double.parseDouble(
+                      r.get(
+                              DBUtils.getAggFieldName(
+                                      AllMetrics.MasterThrottlingValue.DATA_RETRYING_TASK_COUNT.toString(),
+                                      MetricsDB.MAX))
+                              .toString());
+
+      handle.bind(
+              sumDataRetryingTask,
+              avgDataRetryingTask,
+              minDataRetryingTask,
+              maxDataRetryingTask);
+    }
+    handle.execute();
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessor.java
@@ -72,12 +72,14 @@ public class ReaderMetricsProcessor implements Runnable {
   private NavigableMap<Long, MasterEventMetricsSnapshot> masterEventMetricsMap;
   private NavigableMap<Long, GarbageCollectorInfoSnapshot> gcInfoMap;
   private Map<AllMetrics.MetricName, NavigableMap<Long, MemoryDBSnapshot>> nodeMetricsMap;
+  private NavigableMap<Long, MasterThrottlingMetricsSnapshot> masterThrottlingMetricsMap;
   private static final int MAX_DATABASES = 2;
   private static final int OS_SNAPSHOTS = 4;
   private static final int RQ_SNAPSHOTS = 4;
   private static final int HTTP_RQ_SNAPSHOTS = 4;
   private static final int MASTER_EVENT_SNAPSHOTS = 4;
   private static final int GC_INFO_SNAPSHOTS = 4;
+  private static final int MASTER_THROTTLING_SNAPSHOTS = 2;
   private final String rootLocation;
   private static final Map<String, Double> TIMING_STATS = new HashMap<>();
   private static final Map<String, String> STATS_DATA = new HashMap<>();
@@ -120,6 +122,7 @@ public class ReaderMetricsProcessor implements Runnable {
     httpRqMetricsMap = new TreeMap<>();
     masterEventMetricsMap = new TreeMap<>();
     gcInfoMap = new TreeMap<>();
+    masterThrottlingMetricsMap = new TreeMap<>();
     this.rootLocation = rootLocation;
     this.configOverridesApplier = new ConfigOverridesApplier();
 
@@ -241,6 +244,7 @@ public class ReaderMetricsProcessor implements Runnable {
     trimMap(httpRqMetricsMap, HTTP_RQ_SNAPSHOTS);
     trimMap(masterEventMetricsMap, MASTER_EVENT_SNAPSHOTS);
     trimMap(gcInfoMap, GC_INFO_SNAPSHOTS);
+    trimMap(masterThrottlingMetricsMap, MASTER_THROTTLING_SNAPSHOTS);
 
     for (NavigableMap<Long, MemoryDBSnapshot> snap : nodeMetricsMap.values()) {
       // do the same thing as OS_SNAPSHOTS.  Eventually MemoryDBSnapshot
@@ -353,6 +357,7 @@ public class ReaderMetricsProcessor implements Runnable {
     emitShardRequestMetrics(prevWindowStartTime, alignedOSSnapHolder, osAlignedSnap, metricsDB);
     emitHttpRequestMetrics(prevWindowStartTime, metricsDB);
     emitNodeMetrics(currWindowStartTime, metricsDB);
+    emitMasterThrottlingMetrics(prevWindowStartTime, metricsDB);
 
     metricsDB.commit();
     metricsDBMap.put(prevWindowStartTime, metricsDB);
@@ -372,6 +377,16 @@ public class ReaderMetricsProcessor implements Runnable {
       LOG.debug("Garbage collector information snapshot does not exist for the previous window. "
           + "Not emitting metrics.");
     }
+  }
+
+  private void emitMasterThrottlingMetrics(long prevWindowStartTime, MetricsDB metricsDB) {
+      if (masterThrottlingMetricsMap.containsKey(prevWindowStartTime)) {
+        MasterThrottlingMetricsSnapshot prevShardsStateMetricsSnapshot = masterThrottlingMetricsMap.get(prevWindowStartTime);
+        MetricsEmitter.emitMasterThrottledTaskMetric(metricsDB, prevShardsStateMetricsSnapshot);
+      } else {
+        LOG.debug(
+                "Master Throttling snapshot for the previous window does not exist. Not emitting metrics.");
+      }
   }
 
   private void emitHttpRequestMetrics(long prevWindowStartTime, MetricsDB metricsDB)
@@ -522,6 +537,9 @@ public class ReaderMetricsProcessor implements Runnable {
     EventProcessor garbageCollectorInfoProcessor =
         GarbageCollectorInfoProcessor.buildGarbageCollectorInfoProcessor(
             currWindowStartTime, conn, gcInfoMap);
+    EventProcessor masterThrottlingEventsProcessor =
+            MasterThrottlingMetricsEventProcessor.buildMasterThrottlingMetricEventsProcessor(
+                    currWindowStartTime, conn, masterThrottlingMetricsMap);
     ClusterDetailsEventProcessor clusterDetailsEventsProcessor =
         new ClusterDetailsEventProcessor(configOverridesApplier);
 
@@ -539,6 +557,7 @@ public class ReaderMetricsProcessor implements Runnable {
     eventDispatcher.registerEventProcessor(httpProcessor);
     eventDispatcher.registerEventProcessor(nodeEventsProcessor);
     eventDispatcher.registerEventProcessor(masterEventsProcessor);
+    eventDispatcher.registerEventProcessor(masterThrottlingEventsProcessor);
     eventDispatcher.registerEventProcessor(clusterDetailsEventsProcessor);
     eventDispatcher.registerEventProcessor(garbageCollectorInfoProcessor);
 
@@ -928,6 +947,11 @@ public class ReaderMetricsProcessor implements Runnable {
   @VisibleForTesting
   NavigableMap<Long, MasterEventMetricsSnapshot> getMasterEventMetricsMap() {
     return masterEventMetricsMap;
+  }
+
+  @VisibleForTesting
+  NavigableMap<Long, MasterThrottlingMetricsSnapshot> getMasterThrottlingMetricsMap() {
+    return masterThrottlingMetricsMap;
   }
 
   @VisibleForTesting

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MasterThrottlingMetricsSnapshotTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MasterThrottlingMetricsSnapshotTests.java
@@ -1,0 +1,48 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
+
+import static org.junit.Assert.assertEquals;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import org.jooq.BatchBindStep;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MasterThrottlingMetricsSnapshotTests {
+    private static final String DB_URL = "jdbc:sqlite:";
+    private Connection conn;
+
+    @Before
+    public void setup() throws Exception {
+        Class.forName("org.sqlite.JDBC");
+        System.setProperty("java.io.tmpdir", "/tmp");
+        conn = DriverManager.getConnection(DB_URL);
+    }
+
+    @Test
+    public void testPutMetrics() {
+        MasterThrottlingMetricsSnapshot masterThrottlingMetricsSnapshot =
+                new MasterThrottlingMetricsSnapshot(conn, 1535065195000L);
+        BatchBindStep handle = masterThrottlingMetricsSnapshot.startBatchPut();
+
+        handle.bind(1, 5);
+        handle.execute();
+        Result<Record> rt = masterThrottlingMetricsSnapshot.fetchAggregatedMetrics();
+
+        assertEquals(1, rt.size());
+        Double total_throttled = Double.parseDouble(rt.get(0).get(
+                "max_" + AllMetrics.MasterThrottlingValue.MASTER_THROTTLED_PENDING_TASK_COUNT
+                .toString()).toString());
+        assertEquals(
+                5.0, total_throttled.doubleValue(), 0);
+
+        Double retrying_task = Double.parseDouble(rt.get(0).get(
+                "max_" + AllMetrics.MasterThrottlingValue.DATA_RETRYING_TASK_COUNT
+                .toString()).toString());
+        assertEquals(
+                1.0, retrying_task.doubleValue(), 0);
+    }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MasterThrottlingMetricsSnapshotTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MasterThrottlingMetricsSnapshotTests.java
@@ -1,3 +1,18 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/resources/reader/1566413960000
+++ b/src/test/resources/reader/1566413960000
@@ -5,6 +5,10 @@
 {"DestAddr":"00000000000000000000000000000000","Net_TCP_NumFlows":4,"Net_TCP_TxQ":0.0,"Net_TCP_RxQ":0.0,"Net_TCP_Lost":0.0,"Net_TCP_SendCWND":10.0,"Net_TCP_SSThresh":0.0}
 {"DestAddr":"0000000000000000FFFF0000534ED40A","Net_TCP_NumFlows":26,"Net_TCP_TxQ":0.0,"Net_TCP_RxQ":0.0,"Net_TCP_Lost":0.0,"Net_TCP_SendCWND":14.461538461538462,"Net_TCP_SSThresh":13.153846153846153}
 $
+^master_throttling_metrics
+{"current_time":1566413936555}
+{"Data_RetryingPendingTasksCount":0,"Master_ThrottledPendingTasksCount":33}
+$
 ^thread_pool
 {"current_time":1566413936488}
 {"ThreadPoolType":"analyze","ThreadPool_QueueSize":0,"ThreadPool_RejectedReqs":0,"ThreadPool_TotalThreads":0,"ThreadPool_ActiveThreads":0}

--- a/src/test/resources/reader/1566413965000
+++ b/src/test/resources/reader/1566413965000
@@ -4,6 +4,10 @@
 {"DestAddr":"00000000000000000000000000000000","Net_TCP_NumFlows":4,"Net_TCP_TxQ":0.0,"Net_TCP_RxQ":0.0,"Net_TCP_Lost":0.0,"Net_TCP_SendCWND":10.0,"Net_TCP_SSThresh":0.0}
 {"DestAddr":"0000000000000000FFFF0000534ED40A","Net_TCP_NumFlows":26,"Net_TCP_TxQ":0.0,"Net_TCP_RxQ":0.0,"Net_TCP_Lost":0.0,"Net_TCP_SendCWND":14.461538461538462,"Net_TCP_SSThresh":13.153846153846153}
 $
+^master_throttling_metrics
+{"current_time":1566413966544}
+{"Data_RetryingPendingTasksCount":0,"Master_ThrottledPendingTasksCount":33}
+$
 ^thread_pool
 {"current_time":1566413966493}
 {"ThreadPoolType":"analyze","ThreadPool_QueueSize":0,"ThreadPool_RejectedReqs":0,"ThreadPool_TotalThreads":0,"ThreadPool_ActiveThreads":0}

--- a/src/test/resources/reader/1566413970000
+++ b/src/test/resources/reader/1566413970000
@@ -5,6 +5,10 @@
 {"DestAddr":"00000000000000000000000000000000","Net_TCP_NumFlows":4,"Net_TCP_TxQ":0.0,"Net_TCP_RxQ":0.0,"Net_TCP_Lost":0.0,"Net_TCP_SendCWND":10.0,"Net_TCP_SSThresh":0.0}
 {"DestAddr":"0000000000000000FFFF0000534ED40A","Net_TCP_NumFlows":26,"Net_TCP_TxQ":6077.807692307692,"Net_TCP_RxQ":0.0,"Net_TCP_Lost":0.0,"Net_TCP_SendCWND":14.576923076923077,"Net_TCP_SSThresh":12.0}
 $
+^master_throttling_metrics
+{"current_time":1566413996947}
+{"Data_RetryingPendingTasksCount":0,"Master_ThrottledPendingTasksCount":33}
+$
 ^thread_pool
 {"current_time":1566413996664}
 {"ThreadPoolType":"analyze","ThreadPool_QueueSize":0,"ThreadPool_RejectedReqs":0,"ThreadPool_TotalThreads":0,"ThreadPool_ActiveThreads":0}


### PR DESCRIPTION
*Description of changes:*
Add Metrics for Master Throttling of Pending tasks. It will publish two metric 1) Total throttled tasks at master node 2) Number of task on which data node is actively retrying. This feature is yet to be contributed to Opensource ES. I have added the check for availability of this feature in collector so building with or without this feature will pass. If this feature is not available then collector will simply return. 

PR of Performance Analyzer Plugin : https://github.com/opendistro-for-elasticsearch/performance-analyzer/pull/217

*Tests:*

Testing

1. /gradlew test Successful
```
SUCCESS: Executed 455 tests in 40m 43s (1 skipped)

BUILD SUCCESSFUL in 41m 8s
11 actionable tasks: 8 executed, 3 up-to-date
```
2. Tested in test domain by replacing JAR.

Tmp file
```
^master_throttling_metrics
{"current_time":1602617137529}
{"Data_RetryingPendingTasksCount":0,"Master_ThrottledPendingTasksCount":0}$
```

Verified metric from table
```
sqlite> select * from Master_ThrottledPendingTasksCount;
0.0|0.0|0.0|0.0
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
