### PR TITLE
Add missing upstream rca node for heap health decider

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
@@ -61,7 +61,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_QueueCapacity;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_RejectedReqs;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.VersionMap_Memory;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotClusterSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Node;
@@ -200,7 +199,7 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
     HeapHealthDecider heapHealthDecider = new HeapHealthDecider(RCA_PERIOD, highHeapUsageClusterRca,
         largeHeapClusterRca);
     heapHealthDecider.addTag(TAG_LOCUS, LOCUS_MASTER_NODE);
-    heapHealthDecider.addAllUpstreams(Collections.singletonList(highHeapUsageClusterRca));
+    heapHealthDecider.addAllUpstreams(Arrays.asList(highHeapUsageClusterRca, largeHeapClusterRca));
 
     /* Queue Rejection RCAs
      */


### PR DESCRIPTION
*Fixes #:*
#476 
*Description of changes:*
Adds LargeHeapClusterRca - the cluster level RCA for detecting heap size increase opportunities - as an upstream to the HeapHealthDecider.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
