### PR TITLE
Operational metrics for 128GB heap decider components

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
@@ -45,6 +45,8 @@ public enum StatExceptionCode {
   RCA_SCHEDULER_THREAD_STOPPED("RcaSchedulerThreadStopped"),
   JVM_THREAD_ID_NO_LONGER_EXISTS("JVM_THREAD_ID_NO_LONGER_EXISTS"),
   ES_REQUEST_INTERCEPTOR_ERROR("ES_REQUEST_INTERCEPTOR_ERROR"),
+  INVALID_OLD_GEN_SIZE("InvalidOldGenSize"),
+  MISCONFIGURED_OLD_GEN_RCA("MisconfiguredOldGenRca"),
   OTHER("Other");
 
   private final String value;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
@@ -46,7 +46,9 @@ public enum StatExceptionCode {
   JVM_THREAD_ID_NO_LONGER_EXISTS("JVM_THREAD_ID_NO_LONGER_EXISTS"),
   ES_REQUEST_INTERCEPTOR_ERROR("ES_REQUEST_INTERCEPTOR_ERROR"),
   INVALID_OLD_GEN_SIZE("InvalidOldGenSize"),
-  MISCONFIGURED_OLD_GEN_RCA("MisconfiguredOldGenRca"),
+  MISCONFIGURED_OLD_GEN_RCA_HEAP_MAX_MISSING("MisconfiguredOldGenRcaHeapMaxMissing"),
+  MISCONFIGURED_OLD_GEN_RCA_HEAP_USED_MISSING("MisconfiguredOldGenRcaHeapUsedMissing"),
+  MISCONFIGURED_OLD_GEN_RCA_GC_EVENTS_MISSING("MisconfiguredOldGenRcaGcEventsMissing"),
   OTHER("Other");
 
   private final String value;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/sizing/HeapSizeIncreasePolicy.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/sizing/HeapSizeIncreasePolicy.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.jvm.sizing;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.Action;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.HeapSizeIncreaseAction;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.AlarmMonitor;
@@ -39,6 +40,7 @@ import javax.annotation.Nonnull;
 
 public class HeapSizeIncreasePolicy implements DecisionPolicy {
 
+  private static final String HEAP_SIZE_INCREASE_ACTION_RECOMMENDED = "RecommendHeapSizeIncrease";
   private final LargeHeapClusterRca largeHeapClusterRca;
   private AppContext appContext;
   private RcaConf rcaConf;
@@ -59,6 +61,7 @@ public class HeapSizeIncreasePolicy implements DecisionPolicy {
     if (!heapSizeIncreaseClusterMonitor.isHealthy()) {
       Action heapSizeIncreaseAction = new HeapSizeIncreaseAction(appContext);
       if (heapSizeIncreaseAction.isActionable()) {
+        StatsCollector.instance().logMetric(HEAP_SIZE_INCREASE_ACTION_RECOMMENDED);
         actions.add(heapSizeIncreaseAction);
       }
     }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/OldGenRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/OldGenRca.java
@@ -19,6 +19,8 @@ import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.Al
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCType.TOT_FULL_GC;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.HeapDimension.MEM_TYPE;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatExceptionCode;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Rca;
@@ -50,6 +52,7 @@ public abstract class OldGenRca<T extends ResourceFlowUnit<?>> extends Rca<T> {
 
   protected double getMaxOldGenSizeOrDefault(final double defaultValue) {
     if (heap_Max == null) {
+      StatsCollector.instance().logException(StatExceptionCode.MISCONFIGURED_OLD_GEN_RCA);
       throw new IllegalStateException("RCA: " + this.name() + "was not configured in the graph to "
           + "take heap_Max as a metric. Please check the analysis graph!");
     }
@@ -75,6 +78,7 @@ public abstract class OldGenRca<T extends ResourceFlowUnit<?>> extends Rca<T> {
 
   protected int getFullGcEventsOrDefault(final double defaultValue) {
     if (gc_event == null) {
+      StatsCollector.instance().logException(StatExceptionCode.MISCONFIGURED_OLD_GEN_RCA);
       throw new IllegalStateException("RCA: " + this.name() + "was not configured in the graph to "
           + "take gc_event as a metric. Please check the analysis graph!");
     }
@@ -100,6 +104,7 @@ public abstract class OldGenRca<T extends ResourceFlowUnit<?>> extends Rca<T> {
 
   protected double getOldGenUsedOrDefault(final double defaultValue) {
     if (heap_Used == null) {
+      StatsCollector.instance().logException(StatExceptionCode.MISCONFIGURED_OLD_GEN_RCA);
       throw new IllegalStateException("RCA: " + this.name() + "was not configured in the graph to "
           + "take heap_Used as a metric. Please check the analysis graph!");
     }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/OldGenRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/OldGenRca.java
@@ -52,7 +52,7 @@ public abstract class OldGenRca<T extends ResourceFlowUnit<?>> extends Rca<T> {
 
   protected double getMaxOldGenSizeOrDefault(final double defaultValue) {
     if (heap_Max == null) {
-      StatsCollector.instance().logException(StatExceptionCode.MISCONFIGURED_OLD_GEN_RCA);
+      StatsCollector.instance().logException(StatExceptionCode.MISCONFIGURED_OLD_GEN_RCA_HEAP_MAX_MISSING);
       throw new IllegalStateException("RCA: " + this.name() + "was not configured in the graph to "
           + "take heap_Max as a metric. Please check the analysis graph!");
     }
@@ -78,7 +78,7 @@ public abstract class OldGenRca<T extends ResourceFlowUnit<?>> extends Rca<T> {
 
   protected int getFullGcEventsOrDefault(final double defaultValue) {
     if (gc_event == null) {
-      StatsCollector.instance().logException(StatExceptionCode.MISCONFIGURED_OLD_GEN_RCA);
+      StatsCollector.instance().logException(StatExceptionCode.MISCONFIGURED_OLD_GEN_RCA_GC_EVENTS_MISSING);
       throw new IllegalStateException("RCA: " + this.name() + "was not configured in the graph to "
           + "take gc_event as a metric. Please check the analysis graph!");
     }
@@ -104,7 +104,7 @@ public abstract class OldGenRca<T extends ResourceFlowUnit<?>> extends Rca<T> {
 
   protected double getOldGenUsedOrDefault(final double defaultValue) {
     if (heap_Used == null) {
-      StatsCollector.instance().logException(StatExceptionCode.MISCONFIGURED_OLD_GEN_RCA);
+      StatsCollector.instance().logException(StatExceptionCode.MISCONFIGURED_OLD_GEN_RCA_HEAP_USED_MISSING);
       throw new IllegalStateException("RCA: " + this.name() + "was not configured in the graph to "
           + "take heap_Used as a metric. Please check the analysis graph!");
     }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/jvmsizing/HighOldGenOccupancyRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/jvmsizing/HighOldGenOccupancyRca.java
@@ -115,6 +115,8 @@ public class HighOldGenOccupancyRca extends OldGenRca<ResourceFlowUnit<HotResour
     if (maxOldGen == 0d) {
       LOG.info("Max Old Gen capacity cannot be 0. Skipping.");
       StatsCollector.instance().logException(StatExceptionCode.INVALID_OLD_GEN_SIZE);
+      // TODO: Unit test for this RCA and OldGenReclamation are in the PR where we are checking
+      //  for GC type before evaluating.
       return;
     }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/jvmsizing/HighOldGenOccupancyRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/jvmsizing/HighOldGenOccupancyRca.java
@@ -15,6 +15,8 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.jvmsizing;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatExceptionCode;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.configs.HighOldGenOccupancyRcaConfig;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Resources.State;
@@ -112,6 +114,8 @@ public class HighOldGenOccupancyRca extends OldGenRca<ResourceFlowUnit<HotResour
 
     if (maxOldGen == 0d) {
       LOG.info("Max Old Gen capacity cannot be 0. Skipping.");
+      StatsCollector.instance().logException(StatExceptionCode.INVALID_OLD_GEN_SIZE);
+      return;
     }
 
     this.oldGenUtilizationSlidingWindow.next(new SlidingWindowData(System.currentTimeMillis(),


### PR DESCRIPTION
*Fixes #:*
#477 

*Description of changes:*
This PR adds a few operational metrics of interest concerning the 128GB heap decider components. This change also fixes a potential div by 0 bug.

*Tests:*
Tests for the div by 0 bug is coming in the other PR - for evaluating GC type before running JVM tuning RCAs.

*If new tests are added, how long do the new ones take to complete*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
