### PR TITLE
Fix bug where collector startTime is in nanoseconds

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/PerformanceAnalyzerMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/PerformanceAnalyzerMetricsCollector.java
@@ -54,7 +54,6 @@ public abstract class PerformanceAnalyzerMetricsCollector implements Runnable {
 
   public void run() {
     try {
-      long startTime = System.nanoTime();
       Util.invokePrivileged(() -> collectMetrics(startTime));
     } catch (Exception ex) {
       // - should not be any...but in case, absorbing here
@@ -66,7 +65,6 @@ public abstract class PerformanceAnalyzerMetricsCollector implements Runnable {
           () -> StatExceptionCode.OTHER_COLLECTION_ERROR.toString());
       StatsCollector.instance().logException(StatExceptionCode.OTHER_COLLECTION_ERROR);
     } finally {
-      LOG.debug("{} took {} time to execute", collectorName, System.nanoTime() - startTime);
       bInProgress.set(false);
     }
   }


### PR DESCRIPTION
*Fixes #:*
#485 

*Description of changes:*
This PR fixes a bug where the instance variable startTime was being hidden by the local variable startTime(#436) causing the collector's timestamp to be recorded in nanoseconds.

*Tests:*
Made sure docker build was fine, and that perftop showed metrics correctly.

*If new tests are added, how long do the new ones take to complete*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
