### PR TITLE
Adding collectors to ConfigOverrides to enable disable them dynamically

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/overrides/ConfigOverrides.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/overrides/ConfigOverrides.java
@@ -49,18 +49,20 @@ public class ConfigOverrides {
 
     /**
      * Class containing the overridable attributes of the system. Currently, overriding the
-     * enabled/disabled state for RCAs, deciders, and actions are supported. More attributes can
+     * enabled/disabled state for RCAs, deciders, actions and collectors are supported. More attributes can
      * be added as needed.
      */
     public static class Overrides {
         private List<String> rcas;
         private List<String> deciders;
         private List<String> actions;
+        private List<String> collectors;
 
         public Overrides() {
             this.rcas = new ArrayList<>();
             this.deciders = new ArrayList<>();
             this.actions = new ArrayList<>();
+            this.collectors = new ArrayList<>();
         }
 
         public List<String> getRcas() {
@@ -85,6 +87,14 @@ public class ConfigOverrides {
 
         public void setActions(List<String> actions) {
             this.actions = actions;
+        }
+
+        public List<String> getCollectors() {
+            return collectors;
+        }
+
+        public void setCollectors(List<String> collectors) {
+            this.collectors = collectors;
         }
     }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/overrides/ConfigOverridesHelperTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/overrides/ConfigOverridesHelperTests.java
@@ -51,10 +51,12 @@ public class ConfigOverridesHelperTests {
     assertEquals(validTestOverrides.getEnable().getRcas(), deserializedOverrides.getEnable().getRcas());
     assertEquals(validTestOverrides.getEnable().getDeciders(), deserializedOverrides.getEnable().getDeciders());
     assertEquals(validTestOverrides.getEnable().getActions(), deserializedOverrides.getEnable().getActions());
+    assertEquals(validTestOverrides.getEnable().getCollectors(), deserializedOverrides.getEnable().getCollectors());
 
     assertEquals(validTestOverrides.getDisable().getRcas(), deserializedOverrides.getDisable().getRcas());
     assertEquals(validTestOverrides.getDisable().getDeciders(), deserializedOverrides.getDisable().getDeciders());
     assertEquals(validTestOverrides.getDisable().getActions(), deserializedOverrides.getDisable().getActions());
+    assertEquals(validTestOverrides.getDisable().getCollectors(), deserializedOverrides.getDisable().getCollectors());
   }
 
   @Test(expected = IOException.class)
@@ -69,6 +71,7 @@ public class ConfigOverridesHelperTests {
     overrides.getDisable().setActions(Arrays.asList("action1", "action2"));
     overrides.getEnable().setRcas(Arrays.asList("rca3", "rca4"));
     overrides.getEnable().setDeciders(Collections.singletonList("decider1"));
+    overrides.getDisable().setCollectors(Collections.singletonList("collector1"));
 
     return overrides;
   }


### PR DESCRIPTION
*Fixes #:https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/issues/487

*Description of changes:* This change is to add support for enabling and disabling collectors through Rest API

*Tests:*

Tested using the following command

```
c[root@214d9f4eda93 performanceanalyzer]# curl -X POST "localhost:9200/_opendistro/_performanceanalyzer/override/cluster/config" -H 'Content-Type: application/json' -d'
> {
>   "enable": {
>    },
>   "disable": {
>       "collectors": ["MasterServiceMetrics"]
>    }
> }
> '

{"override triggered":true}[root@214d9f4eda93 performanceanalyzer]#
[root@214d9f4eda93 performanceanalyzer]# curl -X GET "localhost:9200/_opendistro/_performanceanalyzer/override/cluster/config"
{"overrides":"{\"enable\":{\"rcas\":[],\"deciders\":[],\"actions\":[],\"collectors\":[]},\"disable\":{\"rcas\":[],\"deciders\":[],\"actions\":[],\"collectors\":[\"MasterServiceMetrics\"]}}"}
```

Tests

    Current - No collectors in disabled list
    Update - Add MasterServiceMetrics in disabled list
    Result - MasterServiceMetrics gets disabled

    Current - MasterServiceMetrics in disabled list
    Update - Add MasterServiceMetrics in enabled list
    Result - MasterServiceMetrics gets enabled

    Current - MasterServiceMetrics in enabled list
    Update - pass both the lists as empty.
    Result - MasterServiceMetrics stays enabled.
    When both lists are passed as empty, it retains its former behavior.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
