### PR TITLE
enable young gen tuning by default

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/configs/jvm/young_gen/JvmGenTuningPolicyConfig.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/configs/jvm/young_gen/JvmGenTuningPolicyConfig.java
@@ -49,7 +49,7 @@ public class JvmGenTuningPolicyConfig {
   private static final String DAY_MONITOR_BUCKET_SIZE_MINUTES = "day-monitor-bucket-size-minutes";
   private static final String WEEK_MONITOR_BUCKET_SIZE_MINUTES = "week-monitor-bucket-size-minutes";
 
-  public static final boolean DEFAULT_ENABLED = false;
+  public static final boolean DEFAULT_ENABLED = true;
   public static final boolean DEFAULT_ALLOW_YOUNG_GEN_DOWNSIZE = false;
   public static final int DEFAULT_DAY_BREACH_THRESHOLD = 5;
   public static final int DEFAULT_WEEK_BREACH_THRESHOLD = 2;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/ElasticSearchAnalysisGraph.java
@@ -126,7 +126,7 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
     Metric gcEvent = new GC_Collection_Event(EVALUATION_INTERVAL_SECONDS);
     Heap_Max heapMax = new Heap_Max(EVALUATION_INTERVAL_SECONDS);
     Metric gc_Collection_Time = new GC_Collection_Time(EVALUATION_INTERVAL_SECONDS);
-    Metric gcType = new GC_Type(EVALUATION_INTERVAL_SECONDS);
+    GC_Type gcType = new GC_Type(EVALUATION_INTERVAL_SECONDS);
     Metric cpuUtilizationGroupByOperation = new AggregateMetric(1, CPU_Utilization.NAME,
             AggregateFunction.SUM,
             MetricsDB.AVG, CommonDimension.OPERATION.toString());
@@ -156,9 +156,9 @@ public class ElasticSearchAnalysisGraph extends AnalysisGraph {
     highHeapUsageOldGenRca.addAllUpstreams(upstream);
 
     Rca<ResourceFlowUnit<HotResourceSummary>> highHeapUsageYoungGenRca = new HighHeapUsageYoungGenRca(RCA_PERIOD, heapUsed,
-            gc_Collection_Time, gcEvent);
+            gc_Collection_Time, gcEvent, gcType);
     highHeapUsageYoungGenRca.addTag(TAG_LOCUS, LOCUS_DATA_MASTER_NODE);
-    highHeapUsageYoungGenRca.addAllUpstreams(Arrays.asList(heapUsed, gc_Collection_Time, gcEvent));
+    highHeapUsageYoungGenRca.addAllUpstreams(Arrays.asList(heapUsed, gc_Collection_Time, gcEvent, gcType));
 
     Rca<ResourceFlowUnit<HotResourceSummary>> highCpuRca = new HighCpuRca(RCA_PERIOD, cpuUtilizationGroupByOperation);
     highCpuRca.addTag(TAG_LOCUS, LOCUS_DATA_MASTER_NODE);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotheap/HighHeapUsageYoungGenRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotheap/HighHeapUsageYoungGenRca.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotheap;
 
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCType.EDEN;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCType.OLD_GEN;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCType.TOT_FULL_GC;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCType.TOT_YOUNG_GC;
@@ -24,6 +25,7 @@ import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framew
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil.YOUNG_GEN_PROMOTION_RATE;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCInfoDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.configs.HighHeapUsageYoungGenRcaConfig;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
@@ -34,15 +36,20 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.contexts.ResourceContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.MetricFlowUnit;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.GC_Type;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.persist.SQLParsingUtil;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.RcaVerticesMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import java.time.Clock;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jooq.Field;
+import org.jooq.Record;
+import org.jooq.Result;
 
 /**
  * This RCA is used to decide whether the young generation in CMS garbage collector is healthy or
@@ -59,6 +66,7 @@ public class HighHeapUsageYoungGenRca extends Rca<ResourceFlowUnit<HotResourceSu
   private static final String PROMOTION_RATE_TOO_HIGH = "promotionRateTooHigh";
   private static final String YOUNG_GC_TIME_TOO_HIGH = "youngGcTimeTooHigh";
   private static final String PREMATURE_PROMOTION_TOO_HIGH = "prematurePromotionTooHigh";
+  private static final String CMS_COLLECTOR = "ConcurrentMarkSweep";
 
   private static final int PROMOTION_RATE_SLIDING_WINDOW_IN_MINS = 10;
   private static final double FULL_GC_TIME_THRES_MS = 10 * 1_000;
@@ -66,6 +74,7 @@ public class HighHeapUsageYoungGenRca extends Rca<ResourceFlowUnit<HotResourceSu
   private final Metric heap_Used;
   private final Metric gc_Collection_Time;
   private final Metric gc_Collection_Event;
+  private final Metric gc_type;
   // the amount of RCA period this RCA needs to run before sending out a flowunit
   private final int rcaPeriod;
   // The lower bound threshold in percentage to decide whether to send out summary.
@@ -92,12 +101,14 @@ public class HighHeapUsageYoungGenRca extends Rca<ResourceFlowUnit<HotResourceSu
                                                      final double lowerBoundThreshold,
                                                      final M heap_Used,
                                                      final M gc_Collection_Time,
-                                                     final M gc_Collection_Event) {
+                                                     final M gc_Collection_Event,
+                                                     final M gc_Type) {
     super(5);
     this.clock = Clock.systemUTC();
     this.heap_Used = heap_Used;
     this.gc_Collection_Time = gc_Collection_Time;
     this.gc_Collection_Event = gc_Collection_Event;
+    this.gc_type = gc_Type;
     this.rcaPeriod = rcaPeriod;
     this.lowerBoundThreshold = (lowerBoundThreshold >= 0 && lowerBoundThreshold <= 1.0)
         ? lowerBoundThreshold : 1.0;
@@ -138,8 +149,8 @@ public class HighHeapUsageYoungGenRca extends Rca<ResourceFlowUnit<HotResourceSu
   }
 
   public <M extends Metric> HighHeapUsageYoungGenRca(final int rcaPeriod,
-      final M heap_Used, final M gc_Collection_Time, final M gc_Collection_Event) {
-    this(rcaPeriod, 1.0, heap_Used, gc_Collection_Time, gc_Collection_Event);
+      final M heap_Used, final M gc_Collection_Time, final M gc_Collection_Event, final M gcType) {
+    this(rcaPeriod, 1.0, heap_Used, gc_Collection_Time, gc_Collection_Event, gcType);
   }
 
   private boolean fullGcTimeTooHigh(double avgFullGcTime) {
@@ -237,7 +248,7 @@ public class HighHeapUsageYoungGenRca extends Rca<ResourceFlowUnit<HotResourceSu
     double promoted = currOldGen - prevOldGen;
     if (promoted >= 0) {
       youngGenPromotedBytes += promoted;
-    } else if (fullGcCount > 0) {
+    } else if (fullGcCount > 0 && youngGenPromotedBytes > 0) {
       double reclaimed = maxOldGen - currOldGen;
       double garbageReclaimedPct = reclaimed / youngGenPromotedBytes;
       if (garbageReclaimedPct <= 1 && garbageReclaimedPct >= 0) {
@@ -250,8 +261,42 @@ public class HighHeapUsageYoungGenRca extends Rca<ResourceFlowUnit<HotResourceSu
     prevOldGen = currOldGen;
   }
 
+  protected boolean isCollectorCMS() {
+    if (gc_type == null) {
+      throw new IllegalStateException("RCA: " + this.name() + "was not configured in the graph to "
+          + "take GC_Type as a metric. Please check the analysis graph!");
+    }
+
+    final List<MetricFlowUnit> gcTypeFlowUnits = gc_type.getFlowUnits();
+    Field<String> memTypeField = GCInfoDimension.MEMORY_POOL.getField();
+    Field<String> collectorField = GCInfoDimension.COLLECTOR_NAME.getField();
+    for (MetricFlowUnit gcTypeFlowUnit : gcTypeFlowUnits) {
+      if (gcTypeFlowUnit.isEmpty()) {
+        continue;
+      }
+
+      Result<Record> records = gcTypeFlowUnit.getData();
+      for (final Record record : records) {
+        final String memType = record.get(memTypeField);
+        if (EDEN.toString().equals(memType)) {
+          return CMS_COLLECTOR.equals(record.get(collectorField));
+        }
+      }
+    }
+
+    // We want to return true here because we don't want to hold up evaluation of RCAs due to
+    // transient metric delays. We don't want to tune the JVM only when we know for sure that the
+    // collector is not CMS, in all other cases, give JVM RCAs the benefit of the doubt.
+    return true;
+  }
+
   @Override
   public ResourceFlowUnit<HotResourceSummary> operate() {
+    if (!isCollectorCMS()) {
+      // return an empty flow unit. We don't want to tune the JVM when the collector is not CMS.
+      return new ResourceFlowUnit<>(System.currentTimeMillis());
+    }
+
     long currTimeStamp = this.clock.millis();
     counter += 1;
 


### PR DESCRIPTION
*Description of changes:*
- young gen tuning is now enabled by default
- young gen tuning only occurs when CMS is being used

*Tests:* N/A

*If new tests are added, how long do the new ones take to complete* N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
