### PR TITLE
Fix total memory being read incorrectly

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
@@ -49,6 +49,7 @@ public enum StatExceptionCode {
   MISCONFIGURED_OLD_GEN_RCA_HEAP_MAX_MISSING("MisconfiguredOldGenRcaHeapMaxMissing"),
   MISCONFIGURED_OLD_GEN_RCA_HEAP_USED_MISSING("MisconfiguredOldGenRcaHeapUsedMissing"),
   MISCONFIGURED_OLD_GEN_RCA_GC_EVENTS_MISSING("MisconfiguredOldGenRcaGcEventsMissing"),
+  TOTAL_MEM_READ_ERROR("TotalMemReadError"),
   OTHER("Other");
 
   private final String value;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/jvmsizing/OldGenContendedRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/jvmsizing/OldGenContendedRca.java
@@ -28,6 +28,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.util.MemInfoParser;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -42,12 +43,14 @@ public class OldGenContendedRca extends Rca<ResourceFlowUnit<HotNodeSummary>> {
   private Rca<ResourceFlowUnit<HotResourceSummary>> highOldGenOccupancyRca;
   private Rca<ResourceFlowUnit<HotResourceSummary>> oldGenReclamationRca;
   private int minTotalMemoryThresholdInGB = DEFAULT_MIN_TOTAL_MEMORY_IN_GB;
+  private final long totalMemory;
 
   public OldGenContendedRca(final Rca<ResourceFlowUnit<HotResourceSummary>> highOldGenOccupancyRca,
       final Rca<ResourceFlowUnit<HotResourceSummary>> oldGenReclamationRca) {
     super(EVAL_INTERVAL_IN_S);
     this.highOldGenOccupancyRca = highOldGenOccupancyRca;
     this.oldGenReclamationRca = oldGenReclamationRca;
+    this.totalMemory = MemInfoParser.getTotalMemory();
   }
 
   @Override
@@ -78,7 +81,7 @@ public class OldGenContendedRca extends Rca<ResourceFlowUnit<HotNodeSummary>> {
       return new ResourceFlowUnit<>(currTime);
     }
 
-    if (Runtime.getRuntime().totalMemory() < minTotalMemoryThresholdInGB * GB_TO_B) {
+    if (this.totalMemory < minTotalMemoryThresholdInGB * GB_TO_B) {
       return new ResourceFlowUnit<>(currTime);
     }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/MemInfoParser.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/MemInfoParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/MemInfoParser.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/util/MemInfoParser.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.util;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatExceptionCode;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsCollector;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class MemInfoParser {
+
+  private static final Logger LOG = LogManager.getLogger(MemInfoParser.class);
+  private static final String MEM_INFO_PATH = "/proc/meminfo";
+  private static final String MEM_TOTAL_PREFIX = "MemTotal:";
+  private static final long KB_TO_B = 1024L;
+
+  public static long getTotalMemory() {
+    try {
+      List<String> lines = Files.readAllLines(Paths.get(MEM_INFO_PATH));
+      for (String line : lines) {
+        if (line.startsWith(MEM_TOTAL_PREFIX)) {
+          return extractTotalMemory(line);
+        }
+      }
+    } catch (IOException e) {
+      LOG.error("Unable to read total memory", e);
+      StatsCollector.instance().logException(StatExceptionCode.TOTAL_MEM_READ_ERROR);
+    }
+
+    return -1;
+  }
+
+  private static long extractTotalMemory(final String memLine) {
+    String[] parsedLine = memLine.trim().replaceAll("\\s+", " ").split(" ");
+    if (parsedLine.length != 3) {
+      return -1;
+    }
+
+    try {
+      return Long.parseLong(parsedLine[1]) * KB_TO_B;
+    } catch (NumberFormatException numberFormatException) {
+      LOG.error("Unable to parse memInfoLine: " + memLine, numberFormatException);
+      StatsCollector.instance().logException(StatExceptionCode.TOTAL_MEM_READ_ERROR);
+    }
+
+    return -1;
+  }
+}


### PR DESCRIPTION
*Fixes #:*

*Description of changes:*
Read the contents of /proc/meminfo to get total memory on the instance instead of JVM Runtime object which reads total memory incorrectly.

*Tests:*
Tested on an ec2 instance.

*If new tests are added, how long do the new ones take to complete*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
