### PR TITLE
PersistableSlidingWindow#load() modification

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/PersistableSlidingWindow.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/PersistableSlidingWindow.java
@@ -72,6 +72,10 @@ public class PersistableSlidingWindow extends SlidingWindow<SlidingWindowData> {
     if (!enablePersistence) {
       return;
     }
+    if (!Files.exists(path)) {
+      LOG.debug("{}#load({}) called but the file doesn't exist", this.getClass().getSimpleName(), path);
+      return;
+    }
     LineIterator it = FileUtils.lineIterator(path.toFile(), "UTF-8");
     try {
       while (it.hasNext()) {


### PR DESCRIPTION
*Fixes #:* A series of ITs that failed on this error log line

*Description of changes:*
- PersistableSlidingWindow#load() will no longer throw an IOException
when it is called with a Path that doesn't exist

*Tests:*
- PersistableSlidingWindowTest

*If new tests are added, how long do the new ones take to complete* N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
