### PR TITLE
Relocate batch metrics operational metrics emission

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessor.java
@@ -339,10 +339,6 @@ public class ReaderMetricsProcessor implements Runnable {
       }
       batchMetricsTotalData -= batchMetricsDBSizes.remove(timestamp);
     }
-    PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
-        ReaderMetrics.BATCH_METRICS_NUM_METRICSDB_FILES, "", batchMetricsDBSizes.size());
-    PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
-        ReaderMetrics.BATCH_METRICS_DATA_SIZE, "", batchMetricsTotalData);
   }
 
   /** Deletes the lowest entries in the map till the size of the map is equal to maxSize. */
@@ -410,6 +406,10 @@ public class ReaderMetricsProcessor implements Runnable {
     PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
         ReaderMetrics.METRICSDB_FILE_SIZE, "", metricsDBSize);
     if (batchMetricsEnabled) {
+      PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
+          ReaderMetrics.BATCH_METRICS_NUM_METRICSDB_FILES, "", batchMetricsDBSizes.size());
+      PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
+          ReaderMetrics.BATCH_METRICS_DATA_SIZE, "", batchMetricsTotalData);
       batchMetricsDBSet.add(prevWindowStartTime);
       batchMetricsDBSizes.put(prevWindowStartTime, metricsDBSize);
       batchMetricsTotalData += metricsDBSize;


### PR DESCRIPTION
*Fixes #:*

*Description of changes:*
Relocate BATCH_METRICS_NUM_METRICSDB_FILES and BATCH_METRICS_DATA_SIZE so they are only emitted when batch metrics is enabled.

*Tests:*
Tested on docker.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
