### PR TITLE
Add ITs for JVM old gen policy

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/GC_Collection_Event.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/GC_Collection_Event.java
@@ -20,8 +20,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetric
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
 
 public class GC_Collection_Event extends Metric {
-
-  public static final String NAME = HeapValue.GC_COLLECTION_EVENT.toString();
+  public static final String NAME = HeapValue.GC_COLLECTION_EVENT.name();
 
   public GC_Collection_Event(long evaluationIntervalSeconds) {
     super(AllMetrics.HeapValue.GC_COLLECTION_EVENT.toString(), evaluationIntervalSeconds);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/Heap_Used.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/Heap_Used.java
@@ -20,8 +20,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetric
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
 
 public class Heap_Used extends Metric {
-
-  public static final String NAME = HeapValue.HEAP_USED.toString();
+  public static final String NAME = HeapValue.HEAP_USED.name();
 
   public Heap_Used(long evaluationIntervalSeconds) {
     super(AllMetrics.HeapValue.HEAP_USED.toString(), evaluationIntervalSeconds);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
@@ -278,7 +278,9 @@ class SQLitePersistor extends PersistorBase {
       recordsWithMaxFieldValue = create.select().from(tableName).where(DSL.field(field)
               .eq(create.select(max(field)).from(tableName))).fetch();
     } catch (DataAccessException dex) {
-      //LOG.warn("Error querying table {}", tableName, dex);
+      // it should be ok to run into this exception because the PersistedAction table
+      // might not be ready yet at the time when the querying the DB
+      LOG.debug("Error querying table {}", tableName, dex);
       return null;
     }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
@@ -278,7 +278,7 @@ class SQLitePersistor extends PersistorBase {
       recordsWithMaxFieldValue = create.select().from(tableName).where(DSL.field(field)
               .eq(create.select(max(field)).from(tableName))).fetch();
     } catch (DataAccessException dex) {
-      LOG.error("Error querying table {}", tableName, dex);
+      //LOG.warn("Error querying table {}", tableName, dex);
       return null;
     }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/OldGenRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/OldGenRca.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca;
 
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCType.HEAP;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCType.OLD_GEN;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCType.TOT_FULL_GC;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.HeapDimension.MEM_TYPE;
@@ -72,7 +73,7 @@ public abstract class OldGenRca<T extends ResourceFlowUnit<?>> extends Rca<T> {
       }
       double ret =
           SQLParsingUtil
-              .readDataFromSqlResult(heapMaxMetric.getData(), MEM_TYPE.getField(), OLD_GEN.toString(), MetricsDB.MAX);
+              .readDataFromSqlResult(heapMaxMetric.getData(), MEM_TYPE.getField(), HEAP.toString(), MetricsDB.MAX);
       if (Double.isNaN(ret)) {
         LOG.error("Failed to parse metric in FlowUnit from {}", heap_Max.getClass().getName());
       } else {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryActionRequestHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryActionRequestHandler.java
@@ -71,7 +71,7 @@ import org.apache.logging.log4j.util.Supplier;
  */
 
 public class QueryActionRequestHandler extends MetricsHandler implements HttpHandler {
-
+    public static final String ACTION_SET_JSON_NAME = "LastSuggestedActionSet";
     private static final Logger LOG = LogManager.getLogger(QueryActionRequestHandler.class);
     private Persistable persistable;
     private AppContext appContext;
@@ -149,12 +149,13 @@ public class QueryActionRequestHandler extends MetricsHandler implements HttpHan
                     for (PersistedAction action : actionSet) {
                         response.add(action.toJson());
                     }
-                    result.add("LastSuggestedActionSet", response);
+                    result.add(ACTION_SET_JSON_NAME, response);
                 } else {
-                    result.add("LastSuggestedActionSet", new JsonArray());
+                    result.add(ACTION_SET_JSON_NAME, new JsonArray());
                 }
             } catch (Exception e) {
-                result.add("error", new JsonParser().parse(e.getMessage()).getAsJsonObject());
+                LOG.error("Fail to query DB, message : {}", e.getMessage());
+                result.add("error", new JsonParser().parse("Fail to query db").getAsJsonObject());
             }
         }
         return result;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Cluster.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Cluster.java
@@ -277,8 +277,8 @@ public class Cluster {
     return tagToHostMapping.get(hostTag).constructObjectFromDB(className);
   }
 
-  public String getRcaRestResponse(final Map<String, String> params, HostTag hostByTag) {
-    return verifyTag(hostByTag).makeRestRequest(params);
+  public String getRcaRestResponse(final String queryUrl, final Map<String, String> params, HostTag hostByTag) {
+    return verifyTag(hostByTag).makeRestRequest(queryUrl, params);
   }
 
   public Map<String, Result<Record>> getRecordsForAllTablesOnHost(HostTag hostTag) {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Host.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Host.java
@@ -379,7 +379,7 @@ public class Host {
     return this.rcaController.getPersistenceProvider().getRecordsForAllTables();
   }
 
-  public String makeRestRequest(final Map<String, String> kvRequestParams) {
+  public String makeRestRequest(final String queryUrl, final Map<String, String> kvRequestParams) {
     StringBuilder queryString = new StringBuilder();
 
     String appender = "";
@@ -388,8 +388,10 @@ public class Host {
       appender = "&";
     }
     StringBuilder uri =
-        new StringBuilder("http://localhost:" + webServerPort + Util.RCA_QUERY_URL);
-    uri.append("?").append(queryString);
+        new StringBuilder("http://localhost:" + webServerPort + queryUrl);
+    if (!appender.isEmpty()) {
+      uri.append("?").append(queryString);
+    }
 
     URL url = null;
     try {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/api/TestApi.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/api/TestApi.java
@@ -5,6 +5,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.fr
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -43,10 +44,12 @@ public class TestApi {
    * @param hostByTag The host whose rest endpoint we will hit.
    * @return The response serialized as a String.
    */
-  public String getRcaRestResponse(@Nonnull final Map<String, String> params,
-                                   HostTag hostByTag) {
+  public JsonElement getRestResponse(@Nonnull final String queryUrl,
+                                @Nonnull final Map<String, String> params,
+                                HostTag hostByTag) {
     Objects.requireNonNull(params);
-    return cluster.getRcaRestResponse(params, hostByTag);
+    JsonElement json = JsonParser.parseString(cluster.getRcaRestResponse(queryUrl, params, hostByTag));
+    return json;
   }
 
   /**

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/runners/RcaItRunnerBase.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/runners/RcaItRunnerBase.java
@@ -1,5 +1,6 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.core.Util;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.Cluster;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.TestEnvironment;
@@ -10,13 +11,17 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.fr
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.api.TestApi;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.log.AppenderHelper;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rest.QueryRcaRequestHandler;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -262,7 +267,16 @@ public abstract class RcaItRunnerBase extends Runner implements IRcaItRunner, Fi
 
           switch (what) {
             case REST_API:
-              successful = validator.checkJsonResp(testApi.getRcaDataOnHost(expect.on(), rca.getSimpleName()));
+              Map<String, String> params = new HashMap<>();
+              if (rca == PersistedAction.class) {
+                successful = validator.checkJsonResp(
+                    testApi.getRestResponse(Util.ACTIONS_QUERY_URL, params, expect.on()));
+              }
+              else {
+                //TODO: we should read RCA output directly from rest endpoint if what = REST_API
+                // the current getRcaDataOnHost read data from sql DB file
+                successful = validator.checkJsonResp(testApi.getRcaDataOnHost(expect.on(), rca.getSimpleName()));
+              }
               break;
             case DB_QUERY:
               try {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/dedicated_master/LevelOneDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/dedicated_master/LevelOneDedicatedMasterITest.java
@@ -170,9 +170,6 @@ public class LevelOneDedicatedMasterITest {
   @AErrorPatternIgnored(
       pattern = "HighHeapUsageYoungGenRca:operate()",
       reason = "YoungGen metrics is expected to be missing.")
-  @AErrorPatternIgnored(
-      pattern = "PersistableSlidingWindow:<init>()",
-      reason = "Persistence base path can be null for integration test.")
   public void testActionBuilder() {
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/dedicated_master/LevelOneDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/dedicated_master/LevelOneDedicatedMasterITest.java
@@ -170,6 +170,12 @@ public class LevelOneDedicatedMasterITest {
   @AErrorPatternIgnored(
       pattern = "HighHeapUsageYoungGenRca:operate()",
       reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "OldGenRca:getMaxHeapSizeOrDefault()",
+      reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "OldGenRca:getMaxOldGenSizeOrDefault()",
+      reason = "YoungGen metrics is expected to be missing.")
   public void testActionBuilder() {
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/dedicated_master/LevelOneDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/dedicated_master/LevelOneDedicatedMasterITest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.dedicated_master;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.dedicated_master.LevelOneDedicatedMasterITest.FIELDDATA_CACHE_SIZE_IN_PERCENT;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.dedicated_master.LevelOneDedicatedMasterITest.HEAP_MAX_SIZE_IN_BYTE;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.dedicated_master.LevelOneDedicatedMasterITest.SHARD_REQUEST_CACHE_SIZE_IN_PERCENT;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cache.CacheUtil.GB_TO_BYTES;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.configs.QueueActionConfig;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolDimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Max_Size;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.GC_Collection_Event;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Max;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Used;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_QueueCapacity;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AErrorPatternIgnored;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AExpect;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AMetric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaGraph;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.validator.LevelOneValidator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.ElasticSearchAnalysisGraph;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(RcaItNotEncryptedRunner.class)
+
+@Category(RcaItMarker.class)
+@AClusterType(ClusterType.MULTI_NODE_DEDICATED_MASTER)
+@ARcaGraph(ElasticSearchAnalysisGraph.class)
+@AMetric(name = Heap_Used.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = {HostTag.DATA_0},
+            tuple = {
+                @ATuple(dimensionValues = AllMetrics.GCType.Constants.OLD_GEN_VALUE,
+                    sum = HEAP_MAX_SIZE_IN_BYTE * 0.7,
+                    avg = HEAP_MAX_SIZE_IN_BYTE * 0.7,
+                    min = HEAP_MAX_SIZE_IN_BYTE * 0.7,
+                    max = HEAP_MAX_SIZE_IN_BYTE * 0.7),
+            }
+        )
+    }
+)
+@AMetric(name = Heap_Max.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = {HostTag.DATA_0},
+            tuple = {
+                @ATuple(dimensionValues = AllMetrics.GCType.Constants.HEAP_VALUE,
+                    sum = HEAP_MAX_SIZE_IN_BYTE,
+                    avg = HEAP_MAX_SIZE_IN_BYTE,
+                    min = HEAP_MAX_SIZE_IN_BYTE,
+                    max = HEAP_MAX_SIZE_IN_BYTE),
+            }
+        )
+    }
+)
+@AMetric(name = GC_Collection_Event.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = {HostTag.DATA_0},
+            tuple = {
+                @ATuple(dimensionValues = AllMetrics.GCType.Constants.TOT_FULL_GC_VALUE,
+                    sum = 1, avg = 1, min = 1, max = 1),
+            }
+        )
+    }
+)
+@AMetric(
+    name = Cache_Max_Size.class,
+    dimensionNames = {AllMetrics.CacheConfigDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(
+            hostTag = HostTag.DATA_0,
+            tuple = {
+                @ATuple(
+                    dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
+                    sum = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT,
+                    avg = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT,
+                    min = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT,
+                    max = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT),
+                @ATuple(
+                    dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
+                    sum = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT,
+                    avg = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT,
+                    min = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT,
+                    max = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT)
+            }),
+    })
+@AMetric(name = ThreadPool_QueueCapacity.class,
+    dimensionNames = {ThreadPoolDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = HostTag.DATA_0,
+            tuple = {
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.WRITE_NAME},
+                    sum = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 200,
+                    avg = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 200,
+                    min = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 200,
+                    max = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 200),
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.SEARCH_NAME},
+                    sum = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 200,
+                    avg = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 200,
+                    min = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 200,
+                    max = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 200)
+            }
+        )
+    }
+)
+public class LevelOneDedicatedMasterITest {
+  public static final long HEAP_MAX_SIZE_IN_BYTE = 10 * GB_TO_BYTES;
+  public static final double FIELDDATA_CACHE_SIZE_IN_PERCENT = 0.3;
+  public static final double SHARD_REQUEST_CACHE_SIZE_IN_PERCENT = 0.04;
+
+  @Test
+  @AExpect(
+      what = AExpect.Type.REST_API,
+      on = HostTag.ELECTED_MASTER,
+      validator = LevelOneValidator.class,
+      forRca = PersistedAction.class,
+      timeoutSeconds = 1000)
+  @AErrorPatternIgnored(
+      pattern = "CacheUtil:getCacheMaxSize()",
+      reason = "Cache related configs are expected to be missing in this integ test")
+  @AErrorPatternIgnored(
+      pattern = "AggregateMetric:gather()",
+      reason = "Cache metrics are expected to be missing in this integ test")
+  @AErrorPatternIgnored(
+      pattern = "SubscribeResponseHandler:onError()",
+      reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+  @AErrorPatternIgnored(
+      pattern = "SQLParsingUtil:readDataFromSqlResult()",
+      reason = "Old gen metrics is expected to be missing in this integ test.")
+  @AErrorPatternIgnored(
+      pattern = "HighHeapUsageOldGenRca:operate()",
+      reason = "Old gen rca is expected to be missing in this integ test.")
+  @AErrorPatternIgnored(
+      pattern = "ModifyCacheMaxSizeAction:build()",
+      reason = "Node config cache is expected to be missing during shutdown")
+  @AErrorPatternIgnored(
+      pattern = "NodeConfigCollector:collectAndPublishMetric()",
+      reason = "Shard request cache metrics is expected to be missing")
+  @AErrorPatternIgnored(
+      pattern = "CacheUtil:getCacheMaxSize()",
+      reason = "Shard request cache metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "HighHeapUsageYoungGenRca:operate()",
+      reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "PersistableSlidingWindow:<init>()",
+      reason = "Persistence base path can be null for integration test.")
+  public void testActionBuilder() {
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/dedicated_master/LevelThreeDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/dedicated_master/LevelThreeDedicatedMasterITest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.dedicated_master;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.dedicated_master.LevelThreeDedicatedMasterITest.FIELDDATA_CACHE_SIZE_IN_PERCENT;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.dedicated_master.LevelThreeDedicatedMasterITest.HEAP_MAX_SIZE_IN_BYTE;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.dedicated_master.LevelThreeDedicatedMasterITest.SHARD_REQUEST_CACHE_SIZE_IN_PERCENT;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cache.CacheUtil.GB_TO_BYTES;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.configs.QueueActionConfig;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolDimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Max_Size;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.GC_Collection_Event;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Max;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Used;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_QueueCapacity;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AErrorPatternIgnored;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AExpect;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AMetric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaGraph;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.validator.LevelThreeValidator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.ElasticSearchAnalysisGraph;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(RcaItNotEncryptedRunner.class)
+
+@Category(RcaItMarker.class)
+@AClusterType(ClusterType.MULTI_NODE_DEDICATED_MASTER)
+@ARcaGraph(ElasticSearchAnalysisGraph.class)
+@AMetric(name = Heap_Used.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = {HostTag.DATA_0},
+            tuple = {
+                @ATuple(dimensionValues = AllMetrics.GCType.Constants.OLD_GEN_VALUE,
+                    sum = HEAP_MAX_SIZE_IN_BYTE * 0.96,
+                    avg = HEAP_MAX_SIZE_IN_BYTE * 0.96,
+                    min = HEAP_MAX_SIZE_IN_BYTE * 0.96,
+                    max = HEAP_MAX_SIZE_IN_BYTE * 0.96),
+            }
+        )
+    }
+)
+@AMetric(name = Heap_Max.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = {HostTag.DATA_0},
+            tuple = {
+                @ATuple(dimensionValues = AllMetrics.GCType.Constants.HEAP_VALUE,
+                    sum = HEAP_MAX_SIZE_IN_BYTE,
+                    avg = HEAP_MAX_SIZE_IN_BYTE,
+                    min = HEAP_MAX_SIZE_IN_BYTE,
+                    max = HEAP_MAX_SIZE_IN_BYTE),
+            }
+        )
+    }
+)
+@AMetric(name = GC_Collection_Event.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = {HostTag.DATA_0},
+            tuple = {
+                @ATuple(dimensionValues = AllMetrics.GCType.Constants.TOT_FULL_GC_VALUE,
+                    sum = 1, avg = 1, min = 1, max = 1),
+            }
+        )
+    }
+)
+@AMetric(
+    name = Cache_Max_Size.class,
+    dimensionNames = {AllMetrics.CacheConfigDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(
+            hostTag = HostTag.DATA_0,
+            tuple = {
+                @ATuple(
+                    dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
+                    sum = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT,
+                    avg = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT,
+                    min = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT,
+                    max = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT),
+                @ATuple(
+                    dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
+                    sum = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT,
+                    avg = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT,
+                    min = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT,
+                    max = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT)
+            }),
+    })
+@AMetric(name = ThreadPool_QueueCapacity.class,
+    dimensionNames = {ThreadPoolDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = HostTag.DATA_0,
+            tuple = {
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.WRITE_NAME},
+                    sum = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 200,
+                    avg = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 200,
+                    min = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 200,
+                    max = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 200),
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.SEARCH_NAME},
+                    sum = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 200,
+                    avg = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 200,
+                    min = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 200,
+                    max = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 200)
+            }
+        )
+    }
+)
+public class LevelThreeDedicatedMasterITest {
+  public static final long HEAP_MAX_SIZE_IN_BYTE = 10 * GB_TO_BYTES;
+  public static final double FIELDDATA_CACHE_SIZE_IN_PERCENT = 0.3;
+  public static final double SHARD_REQUEST_CACHE_SIZE_IN_PERCENT = 0.04;
+
+  @Test
+  @AExpect(
+      what = AExpect.Type.REST_API,
+      on = HostTag.ELECTED_MASTER,
+      validator = LevelThreeValidator.class,
+      forRca = PersistedAction.class,
+      timeoutSeconds = 1000)
+  @AErrorPatternIgnored(
+      pattern = "CacheUtil:getCacheMaxSize()",
+      reason = "Cache related configs are expected to be missing in this integ test")
+  @AErrorPatternIgnored(
+      pattern = "AggregateMetric:gather()",
+      reason = "Cache metrics are expected to be missing in this integ test")
+  @AErrorPatternIgnored(
+      pattern = "SubscribeResponseHandler:onError()",
+      reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+  @AErrorPatternIgnored(
+      pattern = "SQLParsingUtil:readDataFromSqlResult()",
+      reason = "Old gen metrics is expected to be missing in this integ test.")
+  @AErrorPatternIgnored(
+      pattern = "HighHeapUsageOldGenRca:operate()",
+      reason = "Old gen rca is expected to be missing in this integ test.")
+  @AErrorPatternIgnored(
+      pattern = "ModifyCacheMaxSizeAction:build()",
+      reason = "Node config cache is expected to be missing during shutdown")
+  @AErrorPatternIgnored(
+      pattern = "NodeConfigCollector:collectAndPublishMetric()",
+      reason = "Shard request cache metrics is expected to be missing")
+  @AErrorPatternIgnored(
+      pattern = "CacheUtil:getCacheMaxSize()",
+      reason = "Shard request cache metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "HighHeapUsageYoungGenRca:operate()",
+      reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "PersistableSlidingWindow:<init>()",
+      reason = "Persistence base path can be null for integration test.")
+  public void testActionBuilder() {
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/dedicated_master/LevelThreeDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/dedicated_master/LevelThreeDedicatedMasterITest.java
@@ -170,9 +170,6 @@ public class LevelThreeDedicatedMasterITest {
   @AErrorPatternIgnored(
       pattern = "HighHeapUsageYoungGenRca:operate()",
       reason = "YoungGen metrics is expected to be missing.")
-  @AErrorPatternIgnored(
-      pattern = "PersistableSlidingWindow:<init>()",
-      reason = "Persistence base path can be null for integration test.")
   public void testActionBuilder() {
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/dedicated_master/LevelThreeDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/dedicated_master/LevelThreeDedicatedMasterITest.java
@@ -170,6 +170,12 @@ public class LevelThreeDedicatedMasterITest {
   @AErrorPatternIgnored(
       pattern = "HighHeapUsageYoungGenRca:operate()",
       reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "OldGenRca:getMaxHeapSizeOrDefault()",
+      reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "OldGenRca:getMaxOldGenSizeOrDefault()",
+      reason = "YoungGen metrics is expected to be missing.")
   public void testActionBuilder() {
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/dedicated_master/LevelTwoDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/dedicated_master/LevelTwoDedicatedMasterITest.java
@@ -170,9 +170,6 @@ public class LevelTwoDedicatedMasterITest {
   @AErrorPatternIgnored(
       pattern = "HighHeapUsageYoungGenRca:operate()",
       reason = "YoungGen metrics is expected to be missing.")
-  @AErrorPatternIgnored(
-      pattern = "PersistableSlidingWindow:<init>()",
-      reason = "Persistence base path can be null for integration test.")
   public void testActionBuilder() {
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/dedicated_master/LevelTwoDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/dedicated_master/LevelTwoDedicatedMasterITest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.dedicated_master;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.dedicated_master.LevelTwoDedicatedMasterITest.FIELDDATA_CACHE_SIZE_IN_PERCENT;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.dedicated_master.LevelTwoDedicatedMasterITest.HEAP_MAX_SIZE_IN_BYTE;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.dedicated_master.LevelTwoDedicatedMasterITest.SHARD_REQUEST_CACHE_SIZE_IN_PERCENT;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cache.CacheUtil.GB_TO_BYTES;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.configs.QueueActionConfig;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolDimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Max_Size;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.GC_Collection_Event;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Max;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Used;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_QueueCapacity;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AErrorPatternIgnored;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AExpect;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AMetric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaGraph;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.validator.LevelTwoValidator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.ElasticSearchAnalysisGraph;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(RcaItNotEncryptedRunner.class)
+
+@Category(RcaItMarker.class)
+@AClusterType(ClusterType.MULTI_NODE_DEDICATED_MASTER)
+@ARcaGraph(ElasticSearchAnalysisGraph.class)
+@AMetric(name = Heap_Used.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = {HostTag.DATA_0},
+            tuple = {
+                @ATuple(dimensionValues = AllMetrics.GCType.Constants.OLD_GEN_VALUE,
+                    sum = HEAP_MAX_SIZE_IN_BYTE * 0.86,
+                    avg = HEAP_MAX_SIZE_IN_BYTE * 0.86,
+                    min = HEAP_MAX_SIZE_IN_BYTE * 0.86,
+                    max = HEAP_MAX_SIZE_IN_BYTE * 0.86),
+            }
+        )
+    }
+)
+@AMetric(name = Heap_Max.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = {HostTag.DATA_0},
+            tuple = {
+                @ATuple(dimensionValues = AllMetrics.GCType.Constants.HEAP_VALUE,
+                    sum = HEAP_MAX_SIZE_IN_BYTE,
+                    avg = HEAP_MAX_SIZE_IN_BYTE,
+                    min = HEAP_MAX_SIZE_IN_BYTE,
+                    max = HEAP_MAX_SIZE_IN_BYTE),
+            }
+        )
+    }
+)
+@AMetric(name = GC_Collection_Event.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = {HostTag.DATA_0},
+            tuple = {
+                @ATuple(dimensionValues = AllMetrics.GCType.Constants.TOT_FULL_GC_VALUE,
+                    sum = 1, avg = 1, min = 1, max = 1),
+            }
+        )
+    }
+)
+@AMetric(
+    name = Cache_Max_Size.class,
+    dimensionNames = {AllMetrics.CacheConfigDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(
+            hostTag = HostTag.DATA_0,
+            tuple = {
+                @ATuple(
+                    dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
+                    sum = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT,
+                    avg = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT,
+                    min = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT,
+                    max = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT),
+                @ATuple(
+                    dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
+                    sum = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT,
+                    avg = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT,
+                    min = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT,
+                    max = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT)
+            }),
+    })
+@AMetric(name = ThreadPool_QueueCapacity.class,
+    dimensionNames = {ThreadPoolDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = HostTag.DATA_0,
+            tuple = {
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.WRITE_NAME},
+                    sum = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 10,
+                    avg = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 10,
+                    min = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 10,
+                    max = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 10),
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.SEARCH_NAME},
+                    sum = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 10,
+                    avg = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 10,
+                    min = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 10,
+                    max = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 10)
+            }
+        )
+    }
+)
+public class LevelTwoDedicatedMasterITest {
+  public static final long HEAP_MAX_SIZE_IN_BYTE = 10 * GB_TO_BYTES;
+  public static final double FIELDDATA_CACHE_SIZE_IN_PERCENT = 0.3;
+  public static final double SHARD_REQUEST_CACHE_SIZE_IN_PERCENT = 0.04;
+
+  @Test
+  @AExpect(
+      what = AExpect.Type.REST_API,
+      on = HostTag.ELECTED_MASTER,
+      validator = LevelTwoValidator.class,
+      forRca = PersistedAction.class,
+      timeoutSeconds = 1000)
+  @AErrorPatternIgnored(
+      pattern = "CacheUtil:getCacheMaxSize()",
+      reason = "Cache related configs are expected to be missing in this integ test")
+  @AErrorPatternIgnored(
+      pattern = "AggregateMetric:gather()",
+      reason = "Cache metrics are expected to be missing in this integ test")
+  @AErrorPatternIgnored(
+      pattern = "SubscribeResponseHandler:onError()",
+      reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+  @AErrorPatternIgnored(
+      pattern = "SQLParsingUtil:readDataFromSqlResult()",
+      reason = "Old gen metrics is expected to be missing in this integ test.")
+  @AErrorPatternIgnored(
+      pattern = "HighHeapUsageOldGenRca:operate()",
+      reason = "Old gen rca is expected to be missing in this integ test.")
+  @AErrorPatternIgnored(
+      pattern = "ModifyCacheMaxSizeAction:build()",
+      reason = "Node config cache is expected to be missing during shutdown")
+  @AErrorPatternIgnored(
+      pattern = "NodeConfigCollector:collectAndPublishMetric()",
+      reason = "Shard request cache metrics is expected to be missing")
+  @AErrorPatternIgnored(
+      pattern = "CacheUtil:getCacheMaxSize()",
+      reason = "Shard request cache metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "HighHeapUsageYoungGenRca:operate()",
+      reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "PersistableSlidingWindow:<init>()",
+      reason = "Persistence base path can be null for integration test.")
+  public void testActionBuilder() {
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/dedicated_master/LevelTwoDedicatedMasterITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/dedicated_master/LevelTwoDedicatedMasterITest.java
@@ -170,6 +170,12 @@ public class LevelTwoDedicatedMasterITest {
   @AErrorPatternIgnored(
       pattern = "HighHeapUsageYoungGenRca:operate()",
       reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "OldGenRca:getMaxHeapSizeOrDefault()",
+      reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "OldGenRca:getMaxOldGenSizeOrDefault()",
+      reason = "YoungGen metrics is expected to be missing.")
   public void testActionBuilder() {
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/multi_node/LevelOneMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/multi_node/LevelOneMultiNodeITest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.multi_node;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.multi_node.LevelOneMultiNodeITest.FIELDDATA_CACHE_SIZE_IN_PERCENT;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.multi_node.LevelOneMultiNodeITest.HEAP_MAX_SIZE_IN_BYTE;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.multi_node.LevelOneMultiNodeITest.SHARD_REQUEST_CACHE_SIZE_IN_PERCENT;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cache.CacheUtil.GB_TO_BYTES;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.configs.QueueActionConfig;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolDimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Max_Size;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.GC_Collection_Event;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Max;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Used;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_QueueCapacity;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AErrorPatternIgnored;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AExpect;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AMetric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaGraph;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.validator.LevelOneValidator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.ElasticSearchAnalysisGraph;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(RcaItNotEncryptedRunner.class)
+
+@Category(RcaItMarker.class)
+@AClusterType(ClusterType.MULTI_NODE_CO_LOCATED_MASTER)
+@ARcaGraph(ElasticSearchAnalysisGraph.class)
+@AMetric(name = Heap_Used.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = {HostTag.DATA_0},
+            tuple = {
+                @ATuple(dimensionValues = AllMetrics.GCType.Constants.OLD_GEN_VALUE,
+                    sum = HEAP_MAX_SIZE_IN_BYTE * 0.7,
+                    avg = HEAP_MAX_SIZE_IN_BYTE * 0.7,
+                    min = HEAP_MAX_SIZE_IN_BYTE * 0.7,
+                    max = HEAP_MAX_SIZE_IN_BYTE * 0.7),
+            }
+        )
+    }
+)
+@AMetric(name = Heap_Max.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = {HostTag.DATA_0},
+            tuple = {
+                @ATuple(dimensionValues = AllMetrics.GCType.Constants.HEAP_VALUE,
+                    sum = HEAP_MAX_SIZE_IN_BYTE,
+                    avg = HEAP_MAX_SIZE_IN_BYTE,
+                    min = HEAP_MAX_SIZE_IN_BYTE,
+                    max = HEAP_MAX_SIZE_IN_BYTE),
+            }
+        )
+    }
+)
+@AMetric(name = GC_Collection_Event.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = {HostTag.DATA_0},
+            tuple = {
+                @ATuple(dimensionValues = AllMetrics.GCType.Constants.TOT_FULL_GC_VALUE,
+                    sum = 1, avg = 1, min = 1, max = 1),
+            }
+        )
+    }
+)
+@AMetric(
+    name = Cache_Max_Size.class,
+    dimensionNames = {AllMetrics.CacheConfigDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(
+            hostTag = HostTag.DATA_0,
+            tuple = {
+                @ATuple(
+                    dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
+                    sum = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT,
+                    avg = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT,
+                    min = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT,
+                    max = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT),
+                @ATuple(
+                    dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
+                    sum = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT,
+                    avg = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT,
+                    min = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT,
+                    max = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT)
+            }),
+    })
+@AMetric(name = ThreadPool_QueueCapacity.class,
+    dimensionNames = {ThreadPoolDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = HostTag.DATA_0,
+            tuple = {
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.WRITE_NAME},
+                    sum = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 200,
+                    avg = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 200,
+                    min = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 200,
+                    max = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 200),
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.SEARCH_NAME},
+                    sum = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 200,
+                    avg = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 200,
+                    min = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 200,
+                    max = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 200)
+            }
+        )
+    }
+)
+public class LevelOneMultiNodeITest {
+  public static final long HEAP_MAX_SIZE_IN_BYTE = 10 * GB_TO_BYTES;
+  public static final double FIELDDATA_CACHE_SIZE_IN_PERCENT = 0.3;
+  public static final double SHARD_REQUEST_CACHE_SIZE_IN_PERCENT = 0.04;
+
+  @Test
+  @AExpect(
+      what = AExpect.Type.REST_API,
+      on = HostTag.ELECTED_MASTER,
+      validator = LevelOneValidator.class,
+      forRca = PersistedAction.class,
+      timeoutSeconds = 1000)
+  @AErrorPatternIgnored(
+      pattern = "CacheUtil:getCacheMaxSize()",
+      reason = "Cache related configs are expected to be missing in this integ test")
+  @AErrorPatternIgnored(
+      pattern = "AggregateMetric:gather()",
+      reason = "Cache metrics are expected to be missing in this integ test")
+  @AErrorPatternIgnored(
+      pattern = "SubscribeResponseHandler:onError()",
+      reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+  @AErrorPatternIgnored(
+      pattern = "SQLParsingUtil:readDataFromSqlResult()",
+      reason = "Old gen metrics is expected to be missing in this integ test.")
+  @AErrorPatternIgnored(
+      pattern = "HighHeapUsageOldGenRca:operate()",
+      reason = "Old gen rca is expected to be missing in this integ test.")
+  @AErrorPatternIgnored(
+      pattern = "ModifyCacheMaxSizeAction:build()",
+      reason = "Node config cache is expected to be missing during shutdown")
+  @AErrorPatternIgnored(
+      pattern = "NodeConfigCollector:collectAndPublishMetric()",
+      reason = "Shard request cache metrics is expected to be missing")
+  @AErrorPatternIgnored(
+      pattern = "CacheUtil:getCacheMaxSize()",
+      reason = "Shard request cache metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "HighHeapUsageYoungGenRca:operate()",
+      reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "PersistableSlidingWindow:<init>()",
+      reason = "Persistence base path can be null for integration test.")
+  public void testActionBuilder() {
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/multi_node/LevelOneMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/multi_node/LevelOneMultiNodeITest.java
@@ -170,6 +170,12 @@ public class LevelOneMultiNodeITest {
   @AErrorPatternIgnored(
       pattern = "HighHeapUsageYoungGenRca:operate()",
       reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "OldGenRca:getMaxHeapSizeOrDefault()",
+      reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "OldGenRca:getMaxOldGenSizeOrDefault()",
+      reason = "YoungGen metrics is expected to be missing.")
   public void testActionBuilder() {
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/multi_node/LevelOneMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/multi_node/LevelOneMultiNodeITest.java
@@ -170,9 +170,6 @@ public class LevelOneMultiNodeITest {
   @AErrorPatternIgnored(
       pattern = "HighHeapUsageYoungGenRca:operate()",
       reason = "YoungGen metrics is expected to be missing.")
-  @AErrorPatternIgnored(
-      pattern = "PersistableSlidingWindow:<init>()",
-      reason = "Persistence base path can be null for integration test.")
   public void testActionBuilder() {
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/multi_node/LevelThreeMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/multi_node/LevelThreeMultiNodeITest.java
@@ -170,6 +170,12 @@ public class LevelThreeMultiNodeITest {
   @AErrorPatternIgnored(
       pattern = "HighHeapUsageYoungGenRca:operate()",
       reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "OldGenRca:getMaxHeapSizeOrDefault()",
+      reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "OldGenRca:getMaxOldGenSizeOrDefault()",
+      reason = "YoungGen metrics is expected to be missing.")
   public void testActionBuilder() {
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/multi_node/LevelThreeMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/multi_node/LevelThreeMultiNodeITest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.multi_node;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.multi_node.LevelThreeMultiNodeITest.FIELDDATA_CACHE_SIZE_IN_PERCENT;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.multi_node.LevelThreeMultiNodeITest.HEAP_MAX_SIZE_IN_BYTE;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.multi_node.LevelThreeMultiNodeITest.SHARD_REQUEST_CACHE_SIZE_IN_PERCENT;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cache.CacheUtil.GB_TO_BYTES;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.configs.QueueActionConfig;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolDimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Max_Size;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.GC_Collection_Event;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Max;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Used;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_QueueCapacity;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AErrorPatternIgnored;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AExpect;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AMetric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaGraph;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.validator.LevelThreeValidator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.ElasticSearchAnalysisGraph;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(RcaItNotEncryptedRunner.class)
+
+@Category(RcaItMarker.class)
+@AClusterType(ClusterType.MULTI_NODE_CO_LOCATED_MASTER)
+@ARcaGraph(ElasticSearchAnalysisGraph.class)
+@AMetric(name = Heap_Used.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = {HostTag.DATA_0},
+            tuple = {
+                @ATuple(dimensionValues = AllMetrics.GCType.Constants.OLD_GEN_VALUE,
+                    sum = HEAP_MAX_SIZE_IN_BYTE * 0.96,
+                    avg = HEAP_MAX_SIZE_IN_BYTE * 0.96,
+                    min = HEAP_MAX_SIZE_IN_BYTE * 0.96,
+                    max = HEAP_MAX_SIZE_IN_BYTE * 0.96),
+            }
+        )
+    }
+)
+@AMetric(name = Heap_Max.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = {HostTag.DATA_0},
+            tuple = {
+                @ATuple(dimensionValues = AllMetrics.GCType.Constants.HEAP_VALUE,
+                    sum = HEAP_MAX_SIZE_IN_BYTE,
+                    avg = HEAP_MAX_SIZE_IN_BYTE,
+                    min = HEAP_MAX_SIZE_IN_BYTE,
+                    max = HEAP_MAX_SIZE_IN_BYTE),
+            }
+        )
+    }
+)
+@AMetric(name = GC_Collection_Event.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = {HostTag.DATA_0},
+            tuple = {
+                @ATuple(dimensionValues = AllMetrics.GCType.Constants.TOT_FULL_GC_VALUE,
+                    sum = 1, avg = 1, min = 1, max = 1),
+            }
+        )
+    }
+)
+@AMetric(
+    name = Cache_Max_Size.class,
+    dimensionNames = {AllMetrics.CacheConfigDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(
+            hostTag = HostTag.DATA_0,
+            tuple = {
+                @ATuple(
+                    dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
+                    sum = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT,
+                    avg = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT,
+                    min = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT,
+                    max = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT),
+                @ATuple(
+                    dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
+                    sum = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT,
+                    avg = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT,
+                    min = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT,
+                    max = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT)
+            }),
+    })
+@AMetric(name = ThreadPool_QueueCapacity.class,
+    dimensionNames = {ThreadPoolDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = HostTag.DATA_0,
+            tuple = {
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.WRITE_NAME},
+                    sum = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 200,
+                    avg = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 200,
+                    min = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 200,
+                    max = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 200),
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.SEARCH_NAME},
+                    sum = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 200,
+                    avg = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 200,
+                    min = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 200,
+                    max = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 200)
+            }
+        )
+    }
+)
+public class LevelThreeMultiNodeITest {
+  public static final long HEAP_MAX_SIZE_IN_BYTE = 10 * GB_TO_BYTES;
+  public static final double FIELDDATA_CACHE_SIZE_IN_PERCENT = 0.3;
+  public static final double SHARD_REQUEST_CACHE_SIZE_IN_PERCENT = 0.04;
+
+  @Test
+  @AExpect(
+      what = AExpect.Type.REST_API,
+      on = HostTag.ELECTED_MASTER,
+      validator = LevelThreeValidator.class,
+      forRca = PersistedAction.class,
+      timeoutSeconds = 1000)
+  @AErrorPatternIgnored(
+      pattern = "CacheUtil:getCacheMaxSize()",
+      reason = "Cache related configs are expected to be missing in this integ test")
+  @AErrorPatternIgnored(
+      pattern = "AggregateMetric:gather()",
+      reason = "Cache metrics are expected to be missing in this integ test")
+  @AErrorPatternIgnored(
+      pattern = "SubscribeResponseHandler:onError()",
+      reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+  @AErrorPatternIgnored(
+      pattern = "SQLParsingUtil:readDataFromSqlResult()",
+      reason = "Old gen metrics is expected to be missing in this integ test.")
+  @AErrorPatternIgnored(
+      pattern = "HighHeapUsageOldGenRca:operate()",
+      reason = "Old gen rca is expected to be missing in this integ test.")
+  @AErrorPatternIgnored(
+      pattern = "ModifyCacheMaxSizeAction:build()",
+      reason = "Node config cache is expected to be missing during shutdown")
+  @AErrorPatternIgnored(
+      pattern = "NodeConfigCollector:collectAndPublishMetric()",
+      reason = "Shard request cache metrics is expected to be missing")
+  @AErrorPatternIgnored(
+      pattern = "CacheUtil:getCacheMaxSize()",
+      reason = "Shard request cache metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "HighHeapUsageYoungGenRca:operate()",
+      reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "PersistableSlidingWindow:<init>()",
+      reason = "Persistence base path can be null for integration test.")
+  public void testActionBuilder() {
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/multi_node/LevelThreeMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/multi_node/LevelThreeMultiNodeITest.java
@@ -170,9 +170,6 @@ public class LevelThreeMultiNodeITest {
   @AErrorPatternIgnored(
       pattern = "HighHeapUsageYoungGenRca:operate()",
       reason = "YoungGen metrics is expected to be missing.")
-  @AErrorPatternIgnored(
-      pattern = "PersistableSlidingWindow:<init>()",
-      reason = "Persistence base path can be null for integration test.")
   public void testActionBuilder() {
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/multi_node/LevelTwoMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/multi_node/LevelTwoMultiNodeITest.java
@@ -170,6 +170,12 @@ public class LevelTwoMultiNodeITest {
   @AErrorPatternIgnored(
       pattern = "HighHeapUsageYoungGenRca:operate()",
       reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "OldGenRca:getMaxHeapSizeOrDefault()",
+      reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "OldGenRca:getMaxOldGenSizeOrDefault()",
+      reason = "YoungGen metrics is expected to be missing.")
   public void testActionBuilder() {
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/multi_node/LevelTwoMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/multi_node/LevelTwoMultiNodeITest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.multi_node;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.multi_node.LevelTwoMultiNodeITest.FIELDDATA_CACHE_SIZE_IN_PERCENT;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.multi_node.LevelTwoMultiNodeITest.HEAP_MAX_SIZE_IN_BYTE;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.multi_node.LevelTwoMultiNodeITest.SHARD_REQUEST_CACHE_SIZE_IN_PERCENT;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cache.CacheUtil.GB_TO_BYTES;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.configs.QueueActionConfig;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolDimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Max_Size;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.GC_Collection_Event;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Max;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Used;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_QueueCapacity;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AErrorPatternIgnored;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AExpect;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AMetric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaGraph;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.validator.LevelTwoValidator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.ElasticSearchAnalysisGraph;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(RcaItNotEncryptedRunner.class)
+
+@Category(RcaItMarker.class)
+@AClusterType(ClusterType.MULTI_NODE_CO_LOCATED_MASTER)
+@ARcaGraph(ElasticSearchAnalysisGraph.class)
+@AMetric(name = Heap_Used.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = {HostTag.DATA_0},
+            tuple = {
+                @ATuple(dimensionValues = AllMetrics.GCType.Constants.OLD_GEN_VALUE,
+                    sum = HEAP_MAX_SIZE_IN_BYTE * 0.86,
+                    avg = HEAP_MAX_SIZE_IN_BYTE * 0.86,
+                    min = HEAP_MAX_SIZE_IN_BYTE * 0.86,
+                    max = HEAP_MAX_SIZE_IN_BYTE * 0.86),
+            }
+        )
+    }
+)
+@AMetric(name = Heap_Max.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = {HostTag.DATA_0},
+            tuple = {
+                @ATuple(dimensionValues = AllMetrics.GCType.Constants.HEAP_VALUE,
+                    sum = HEAP_MAX_SIZE_IN_BYTE,
+                    avg = HEAP_MAX_SIZE_IN_BYTE,
+                    min = HEAP_MAX_SIZE_IN_BYTE,
+                    max = HEAP_MAX_SIZE_IN_BYTE),
+            }
+        )
+    }
+)
+@AMetric(name = GC_Collection_Event.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = {HostTag.DATA_0},
+            tuple = {
+                @ATuple(dimensionValues = AllMetrics.GCType.Constants.TOT_FULL_GC_VALUE,
+                    sum = 1, avg = 1, min = 1, max = 1),
+            }
+        )
+    }
+)
+@AMetric(
+    name = Cache_Max_Size.class,
+    dimensionNames = {AllMetrics.CacheConfigDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(
+            hostTag = HostTag.DATA_0,
+            tuple = {
+                @ATuple(
+                    dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
+                    sum = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT,
+                    avg = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT,
+                    min = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT,
+                    max = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT),
+                @ATuple(
+                    dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
+                    sum = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT,
+                    avg = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT,
+                    min = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT,
+                    max = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT)
+            }),
+    })
+@AMetric(name = ThreadPool_QueueCapacity.class,
+    dimensionNames = {ThreadPoolDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = HostTag.DATA_0,
+            tuple = {
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.WRITE_NAME},
+                    sum = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 10,
+                    avg = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 10,
+                    min = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 10,
+                    max = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 10),
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.SEARCH_NAME},
+                    sum = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 10,
+                    avg = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 10,
+                    min = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 10,
+                    max = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 10)
+            }
+        )
+    }
+)
+public class LevelTwoMultiNodeITest {
+  public static final long HEAP_MAX_SIZE_IN_BYTE = 10 * GB_TO_BYTES;
+  public static final double FIELDDATA_CACHE_SIZE_IN_PERCENT = 0.3;
+  public static final double SHARD_REQUEST_CACHE_SIZE_IN_PERCENT = 0.04;
+
+  @Test
+  @AExpect(
+      what = AExpect.Type.REST_API,
+      on = HostTag.ELECTED_MASTER,
+      validator = LevelTwoValidator.class,
+      forRca = PersistedAction.class,
+      timeoutSeconds = 1000)
+  @AErrorPatternIgnored(
+      pattern = "CacheUtil:getCacheMaxSize()",
+      reason = "Cache related configs are expected to be missing in this integ test")
+  @AErrorPatternIgnored(
+      pattern = "AggregateMetric:gather()",
+      reason = "Cache metrics are expected to be missing in this integ test")
+  @AErrorPatternIgnored(
+      pattern = "SubscribeResponseHandler:onError()",
+      reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+  @AErrorPatternIgnored(
+      pattern = "SQLParsingUtil:readDataFromSqlResult()",
+      reason = "Old gen metrics is expected to be missing in this integ test.")
+  @AErrorPatternIgnored(
+      pattern = "HighHeapUsageOldGenRca:operate()",
+      reason = "Old gen rca is expected to be missing in this integ test.")
+  @AErrorPatternIgnored(
+      pattern = "ModifyCacheMaxSizeAction:build()",
+      reason = "Node config cache is expected to be missing during shutdown")
+  @AErrorPatternIgnored(
+      pattern = "NodeConfigCollector:collectAndPublishMetric()",
+      reason = "Shard request cache metrics is expected to be missing")
+  @AErrorPatternIgnored(
+      pattern = "CacheUtil:getCacheMaxSize()",
+      reason = "Shard request cache metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "HighHeapUsageYoungGenRca:operate()",
+      reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "PersistableSlidingWindow:<init>()",
+      reason = "Persistence base path can be null for integration test.")
+  public void testActionBuilder() {
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/multi_node/LevelTwoMultiNodeITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/multi_node/LevelTwoMultiNodeITest.java
@@ -170,9 +170,6 @@ public class LevelTwoMultiNodeITest {
   @AErrorPatternIgnored(
       pattern = "HighHeapUsageYoungGenRca:operate()",
       reason = "YoungGen metrics is expected to be missing.")
-  @AErrorPatternIgnored(
-      pattern = "PersistableSlidingWindow:<init>()",
-      reason = "Persistence base path can be null for integration test.")
   public void testActionBuilder() {
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/validator/LevelOneValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/validator/LevelOneValidator.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.validator;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum;
+import com.google.gson.JsonArray;
+
+public class LevelOneValidator extends OldGenPolicyBaseValidator {
+
+  @Override
+  public boolean checkPersistedActions(JsonArray actionJsonArray) {
+    return (checkModifyCacheAction(actionJsonArray, ResourceEnum.FIELD_DATA_CACHE)
+        && checkModifyCacheAction(actionJsonArray, ResourceEnum.SHARD_REQUEST_CACHE));
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/validator/LevelThreeValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/validator/LevelThreeValidator.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.validator;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum;
+import com.google.gson.JsonArray;
+
+public class LevelThreeValidator extends OldGenPolicyBaseValidator {
+
+  @Override
+  public boolean checkPersistedActions(JsonArray actionJsonArray) {
+    return (checkCacheClearAction(actionJsonArray)
+        && checkModifyQueueAction(actionJsonArray, ResourceEnum.WRITE_THREADPOOL)
+        && checkModifyQueueAction(actionJsonArray, ResourceEnum.SEARCH_THREADPOOL)
+        && checkModifyCacheAction(actionJsonArray, ResourceEnum.FIELD_DATA_CACHE)
+        && checkModifyCacheAction(actionJsonArray, ResourceEnum.SHARD_REQUEST_CACHE));
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/validator/LevelTwoValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/validator/LevelTwoValidator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.validator;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum;
+import com.google.gson.JsonArray;
+
+public class LevelTwoValidator extends OldGenPolicyBaseValidator {
+
+  /**
+   * the default rca.conf prefer ingest over search. So here we will
+   * only get three actions : search, fielddata, shard request.
+   */
+  @Override
+  public boolean checkPersistedActions(JsonArray actionJsonArray) {
+    return (
+        checkModifyQueueAction(actionJsonArray, ResourceEnum.SEARCH_THREADPOOL)
+        && checkModifyCacheAction(actionJsonArray, ResourceEnum.FIELD_DATA_CACHE)
+        && checkModifyCacheAction(actionJsonArray, ResourceEnum.SHARD_REQUEST_CACHE));
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/validator/OldGenPolicyBaseValidator.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/old_gen_policy/validator/OldGenPolicyBaseValidator.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.validator;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rest.QueryActionRequestHandler.ACTION_SET_JSON_NAME;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.CacheClearAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ModifyCacheMaxSizeAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.ModifyQueueCapacityAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.grpc.ResourceEnum;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.api.IValidator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction.SQL_SCHEMA_CONSTANTS;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public abstract class OldGenPolicyBaseValidator implements IValidator  {
+  private static final Logger LOG = LogManager.getLogger(OldGenPolicyBaseValidator.class);
+  private Gson gson;
+
+  public OldGenPolicyBaseValidator() {
+    gson = new Gson();
+  }
+
+  @Override
+  public boolean checkJsonResp(JsonElement response) {
+    JsonArray array = response.getAsJsonObject().get(ACTION_SET_JSON_NAME).getAsJsonArray();
+    if (array.size() == 0) {
+      return false;
+    }
+
+    return checkPersistedActions(array);
+  }
+
+  abstract boolean checkPersistedActions(JsonArray actionJsonArray);
+
+  protected boolean checkModifyQueueAction(JsonArray array, ResourceEnum threadpool) {
+    for (int i = 0; i < array.size(); i++) {
+      JsonObject object = array.get(i).getAsJsonObject();
+      if (!object.get(SQL_SCHEMA_CONSTANTS.ACTION_COL_NAME).getAsString().equals(
+          ModifyQueueCapacityAction.NAME)) {
+        continue;
+      }
+      if (!object.get(SQL_SCHEMA_CONSTANTS.ACTIONABLE_NAME).getAsBoolean()) {
+        continue;
+      }
+      JsonObject summaryObj = object.getAsJsonObject(SQL_SCHEMA_CONSTANTS.SUMMARY_NAME);
+      if (summaryObj != null) {
+        try {
+          ModifyQueueCapacityAction.Summary summary = gson.fromJson(summaryObj, ModifyQueueCapacityAction.Summary.class);
+          if (summary.getResource() == threadpool) {
+            return true;
+          }
+        }
+        catch (Exception e) {
+          LOG.warn("Json syntax error, parsing summary object : {}", summaryObj.toString());
+        }
+      }
+    }
+    return false;
+  }
+
+  protected boolean checkModifyCacheAction(JsonArray array, ResourceEnum cacheType) {
+    for (int i = 0; i < array.size(); i++) {
+      JsonObject object = array.get(i).getAsJsonObject();
+      if (!object.get(SQL_SCHEMA_CONSTANTS.ACTION_COL_NAME).getAsString().equals(
+          ModifyCacheMaxSizeAction.NAME)) {
+        continue;
+      }
+      if (!object.get(SQL_SCHEMA_CONSTANTS.ACTIONABLE_NAME).getAsBoolean()) {
+        continue;
+      }
+      JsonObject summaryObj = object.getAsJsonObject(SQL_SCHEMA_CONSTANTS.SUMMARY_NAME);
+      if (summaryObj != null) {
+        try {
+          ModifyCacheMaxSizeAction.Summary summary = gson.fromJson(summaryObj, ModifyCacheMaxSizeAction.Summary.class);
+          if (summary.getResource() == cacheType) {
+            return true;
+          }
+        }
+        catch (Exception e) {
+          LOG.warn("Json syntax error, parsing summary object : {}", summaryObj.toString());
+        }
+      }
+    }
+    return false;
+  }
+
+  protected boolean checkCacheClearAction(JsonArray array) {
+    for (int i = 0; i < array.size(); i++) {
+      JsonObject object = array.get(i).getAsJsonObject();
+      if (!object.get(SQL_SCHEMA_CONSTANTS.ACTION_COL_NAME).getAsString().equals(
+          CacheClearAction.NAME)) {
+        continue;
+      }
+      if (!object.get(SQL_SCHEMA_CONSTANTS.ACTIONABLE_NAME).getAsBoolean()) {
+        continue;
+      }
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/young_gen/YoungGenDeciderFullGCPauseIT.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvm/young_gen/YoungGenDeciderFullGCPauseIT.java
@@ -138,6 +138,9 @@ public class YoungGenDeciderFullGCPauseIT {
       pattern = "PersistableSlidingWindow:<init>()",
       reason = "Persistence base path can be null for integration test."
   )
+  @AErrorPatternIgnored(
+      pattern = "OldGenRca:getMaxHeapSizeOrDefault()",
+      reason = "YoungGen metrics is expected to be missing.")
   public void testShouldSuggestYoungGenIncrease() {
 
   }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvmsizing/HeapSizeIncreaseIT.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/jvmsizing/HeapSizeIncreaseIT.java
@@ -163,6 +163,9 @@ public class HeapSizeIncreaseIT {
       pattern = "PersistableSlidingWindow:<init>()",
       reason = "Persistence base path can be null for integration test."
   )
+  @AErrorPatternIgnored(
+      pattern = "OldGenRca:getMaxHeapSizeOrDefault()",
+      reason = "YoungGen metrics is expected to be missing.")
   public void testHeapSizeIncrease() {
 
   }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotheap/HighHeapUsageOldGenRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotheap/HighHeapUsageOldGenRcaTest.java
@@ -15,11 +15,13 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.store.rca.hotheap;
 
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCType.HEAP;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCType.OLD_GEN;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCType.TOT_FULL_GC;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.HeapDimension.MEM_TYPE;
 import static java.time.Instant.ofEpochMilli;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CommonDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca;
@@ -85,7 +87,7 @@ public class HighHeapUsageOldGenRcaTest {
     oldGenRcaX = new HighHeapUsageOldGenRcaX(1, heap_Used, gc_event, heap_Max, node_stats);
     columnName = Arrays.asList(MEM_TYPE.toString(), MetricsDB.MAX);
     // set max heap size to 100MB
-    heap_Max.createTestFlowUnits(columnName, Arrays.asList(OLD_GEN.toString(), String.valueOf(100 * CONVERT_MEGABYTES_TO_BYTES)));
+    heap_Max.createTestFlowUnits(columnName, Arrays.asList(HEAP.toString(), String.valueOf(100 * CONVERT_MEGABYTES_TO_BYTES)));
   }
 
   @Test


### PR DESCRIPTION
…Rest endpoint

*Fixes #:*

*Description of changes:*
Add ITs for JVM old gen policy. This PR fixes a few minor issues in IT framework to allow IT to retrieve persisted action list from rest endpoint. We also add six ITs to cover the happy scenario of old gen policy in JVM decider. 
Those ITs are :
ITs that triggers LevelOne/LevelTwo/LevelThree action builder (dedicated master / multinode)

*Tests:*

*If new tests are added, how long do the new ones take to complete*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
