### PR TITLE
Fixing Spotbugs issue 

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/CacheClearAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/CacheClearAction.java
@@ -22,13 +22,11 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.clu
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-
 import org.graalvm.compiler.options.SuppressFBWarnings;
 
 public class CacheClearAction extends SuppressibleAction {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/CacheClearAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/CacheClearAction.java
@@ -132,10 +132,10 @@ public class CacheClearAction extends SuppressibleAction {
     @SerializedName(value = IP)
     private String[] ip;
     @SerializedName(value = COOL_OFF_PERIOD)
-    @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "ahsda")
+    @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "Used in Summary Deserializing")
     private long coolOffPeriodInMillis;
     @SerializedName(value = CAN_UPDATE)
-    @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "ahsda")
+    @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "Used in Summary Deserializing")
     private boolean canUpdate;
 
     public Summary(final List<NodeKey> impactedNodes,

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/CacheClearAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/CacheClearAction.java
@@ -22,13 +22,14 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.clu
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
-import org.graalvm.compiler.options.SuppressFBWarnings;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
+import org.graalvm.compiler.options.SuppressFBWarnings;
 
 public class CacheClearAction extends SuppressibleAction {
   public static final String NAME = "CacheClear";

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/CacheClearAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/CacheClearAction.java
@@ -131,10 +131,10 @@ public class CacheClearAction extends SuppressibleAction {
     @SerializedName(value = IP)
     private String[] ip;
     @SerializedName(value = COOL_OFF_PERIOD)
-    @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "Used in Summary Deserializing")
+//    @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "Used in Summary Serializing")
     private long coolOffPeriodInMillis;
     @SerializedName(value = CAN_UPDATE)
-    @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "Used in Summary Deserializing")
+//    @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "Used in Summary Serializing")
     private boolean canUpdate;
 
     public Summary(final List<NodeKey> impactedNodes,

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/CacheClearAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/actions/CacheClearAction.java
@@ -22,6 +22,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.clu
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
+import org.graalvm.compiler.options.SuppressFBWarnings;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -130,8 +132,10 @@ public class CacheClearAction extends SuppressibleAction {
     @SerializedName(value = IP)
     private String[] ip;
     @SerializedName(value = COOL_OFF_PERIOD)
+    @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "ahsda")
     private long coolOffPeriodInMillis;
     @SerializedName(value = CAN_UPDATE)
+    @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "ahsda")
     private boolean canUpdate;
 
     public Summary(final List<NodeKey> impactedNodes,


### PR DESCRIPTION
*Fixes #:* Fixing Spotbugs issues which are blocking the build of the PA packages. 

*Description of changes:* Spotbugs Error thrown is 

```

Bug type URF_UNREAD_FIELD (click for details)In class 
com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.CacheClearAction$SummaryField 
com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.CacheClearAction$Summary.canUpdateAt 
CacheClearAction.java:[line 151]
--

```

But actually these variables are used to in Serializing to the Json. 
This is a false alarm by spotBugs. Therefore added the suppress of errors. 

*Tests:*

*If new tests are added, how long do the new ones take to complete*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
