### PR TITLE
Fix implementation of isCollectorCMS() in YoungGenRca

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotheap/HighHeapUsageYoungGenRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/hotheap/HighHeapUsageYoungGenRca.java
@@ -15,7 +15,6 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.hotheap;
 
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCType.EDEN;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCType.OLD_GEN;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCType.TOT_FULL_GC;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.GCType.TOT_YOUNG_GC;
@@ -278,7 +277,7 @@ public class HighHeapUsageYoungGenRca extends Rca<ResourceFlowUnit<HotResourceSu
       Result<Record> records = gcTypeFlowUnit.getData();
       for (final Record record : records) {
         final String memType = record.get(memTypeField);
-        if (EDEN.toString().equals(memType)) {
+        if (OLD_GEN.toString().equals(memType)) {
           return CMS_COLLECTOR.equals(record.get(collectorField));
         }
       }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotheap/HighHeapUsageYoungGenRcaTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/rca/hotheap/HighHeapUsageYoungGenRcaTest.java
@@ -71,7 +71,7 @@ public class HighHeapUsageYoungGenRcaTest {
     gc_Collection_Time.createTestFlowUnitsWithMultipleRows(columnName, Lists.newArrayList(youngGcRow, fullGcRow));
     gc_Collection_Event.createTestFlowUnits(columnName, Arrays.asList(OLD_GEN.toString(), String.valueOf(fullGcEvents)));
     gc_Type.createTestFlowUnits(Arrays.asList(GCInfoDimension.MEMORY_POOL.toString(),
-        GCInfoDimension.COLLECTOR_NAME.toString()), Arrays.asList(EDEN.toString(), CMS_COLLECTOR));
+        GCInfoDimension.COLLECTOR_NAME.toString()), Arrays.asList(OLD_GEN.toString(), CMS_COLLECTOR));
   }
 
   @Before


### PR DESCRIPTION
Eden uses the ParNew collector while the OldGen uses the CMS collector.
The code has been fixed to reflect this.

*Fixes #:*

*Description of changes:*

*Tests:*

*If new tests are added, how long do the new ones take to complete*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
