### PR TITLE
Fix actions not muting

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/AppContext.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/AppContext.java
@@ -22,9 +22,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDet
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCAScheduler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/RCAScheduler.java
@@ -21,18 +21,17 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Queryable;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.ThresholdMain;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.WireHopper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.Persistable;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
@@ -138,7 +137,8 @@ public class RCAScheduler {
         appContext);
 
     schedulerState = RcaSchedulerState.STATE_STARTED;
-    LOG.info("RCA scheduler thread started successfully on node: {}", appContext.getMyInstanceDetails().getInstanceId());
+    LOG.info("RCA scheduler thread started successfully on node: {}",
+        appContext.getMyInstanceDetails().getInstanceId());
     if (schedulerTrackingLatch != null) {
       schedulerTrackingLatch.countDown();
     }
@@ -206,6 +206,17 @@ public class RCAScheduler {
     rcaSchedulerPeriodicExecutor = Executors.newFixedThreadPool(2, taskThreadFactory);
   }
 
+  /**
+   * Updates the list of muted actions in the current instance of {@link AppContext}.
+   *
+   * @param mutedActions The set of actions names that need to be muted.
+   */
+  public void updateAppContextWithMutedActions(final Set<String> mutedActions) {
+    if (this.appContext != null) {
+      this.appContext.updateMutedActions(mutedActions);
+    }
+  }
+
   public NodeRole getRole() {
     return role;
   }
@@ -217,5 +228,10 @@ public class RCAScheduler {
   @VisibleForTesting
   public void setQueryable(Queryable queryable) {
     this.db = queryable;
+  }
+
+  @VisibleForTesting
+  public AppContext getAppContext() {
+    return this.appContext;
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaTestHelper.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaTestHelper.java
@@ -171,7 +171,8 @@ public class RcaTestHelper {
     }
   }
 
-  public static void updateConfFileForMutedRcas(String rcaConfPath, List<String> mutedRcas) throws Exception {
+  public static void updateConfFileForMutedComponents(String rcaConfPath,
+      List<String> mutedComponents, String componentKey) throws Exception {
 
     // create the config json Object from rca config file
     Scanner scanner = new Scanner(new FileInputStream(rcaConfPath), StandardCharsets.UTF_8.name());
@@ -182,8 +183,8 @@ public class RcaTestHelper {
     JsonNode configObject = mapper.readTree(jsonText);
 
     // update the `MUTED_RCAS_CONFIG` value in config Object
-    ArrayNode array = mapper.valueToTree(mutedRcas);
-    ((ObjectNode) configObject).putArray("muted-rcas").addAll(array);
+    ArrayNode array = mapper.valueToTree(mutedComponents);
+    ((ObjectNode) configObject).putArray(componentKey).addAll(array);
     mapper.writeValue(new FileOutputStream(rcaConfPath), configObject);
   }
 


### PR DESCRIPTION
*Fixes #:*
#505 

*Description of changes:*
This PR fixes the bug where actions that were overridden to be disabled do not end up being marked as muted. The reason for this behavior is because the RCA controller, while updating the list of muted components, updates the graph nodes directly for RCAs, and deciders, it updates the list of muted actions in the AppContext.

However, the AppContext updated by the RcaController and the AppContext used by the RcaScheduler are different. The Scheduler only gets a snapshot of the AppContext during its initialization as it uses that AppContext to determine staleness, and never gets an updated AppContext till the scheduler is restarted.

This causes the update to go missing in the AppContext used by the RcaScheduler which eventually manifests as an unmuted action(when muting an action is involved). The fix basically exposes a new method from the scheduler to get the updated list of muted actions that it should pass down to the Actions through its AppContext.

*Tests:*
Unit tests, tested on docker with HeapSizeIncreaseAction.

*If new tests are added, how long do the new ones take to complete*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
