### PR TITLE
Use aarch64 compatible version of SQLiteJDBC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -261,7 +261,7 @@ dependencies {
     compile 'org.jooq:jooq:3.10.8'
     compile 'org.bouncycastle:bcprov-jdk15on:1.66'
     compile 'org.bouncycastle:bcpkix-jdk15on:1.66'
-    compile 'org.xerial:sqlite-jdbc:3.8.11.2'
+    compile 'org.xerial:sqlite-jdbc:3.32.3.2'
     compile 'com.google.guava:guava:28.2-jre'
     compile 'com.fasterxml.jackson.core:jackson-annotations:2.10.4'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.10.4'


### PR DESCRIPTION
*Fixes #:*
#509 

*Description of changes:*
Use the aarch64 compatible version of SQLiteJDBC package.

*Tests:*
Tested on an ARM based ec2 instance.

*If new tests are added, how long do the new ones take to complete*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
