### PR TITLE
Add PersistableSlidingWindow UT for multiple writes

### DIFF
--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/PersistableSlidingWindowTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/PersistableSlidingWindowTest.java
@@ -84,7 +84,21 @@ public class PersistableSlidingWindowTest {
     Assert.assertEquals(1, slidingWindow.size());
   }
 
-
+  /**
+   * Tests that a PSW can call write() multiple times and still have its data read
+   */
+  @Test
+  public void testMultipleWrites() throws IOException {
+    PersistableSlidingWindow slidingWindow = new PersistableSlidingWindow(1, TimeUnit.SECONDS, persistFile);
+    long curTimestamp = Instant.now().toEpochMilli();
+    slidingWindow.next(new SlidingWindowData(curTimestamp, 10));
+    slidingWindow.write();
+    // This call to next removes the previous data from the window
+    slidingWindow.next(new SlidingWindowData(curTimestamp, 10));
+    slidingWindow.write();
+    PersistableSlidingWindow slidingWindow2 = new PersistableSlidingWindow(1, TimeUnit.SECONDS, persistFile);
+    Assert.assertEquals(20, slidingWindow2.readSum(), 0.0);
+  }
 
   @AfterClass
   public static void tearDown() {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/PersistableSlidingWindowTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/aggregators/PersistableSlidingWindowTest.java
@@ -93,7 +93,6 @@ public class PersistableSlidingWindowTest {
     long curTimestamp = Instant.now().toEpochMilli();
     slidingWindow.next(new SlidingWindowData(curTimestamp, 10));
     slidingWindow.write();
-    // This call to next removes the previous data from the window
     slidingWindow.next(new SlidingWindowData(curTimestamp, 10));
     slidingWindow.write();
     PersistableSlidingWindow slidingWindow2 = new PersistableSlidingWindow(1, TimeUnit.SECONDS, persistFile);


### PR DESCRIPTION
*Fixes #:* 
N/A

*Description of changes:* 
Adds a UT that makes sure a PSW can call write() multiple times and still maintain data integrity

*Tests:* 
PersistableSlidingWindowTest

*If new tests are added, how long do the new ones take to complete* 
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
