### PR TITLE
add new enum to log stale metrics count

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
@@ -33,7 +33,12 @@ public enum WriterMetrics implements MeasurementSet {
             Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
 
     FAULT_DETECTION_COLLECTOR_EXECUTION_TIME("FaultDetectionCollectorExecutionTime", "millis", Arrays.asList(
-    Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM));
+    Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
+
+    STALE_METRICS("StaleMetrics", "count", Arrays.asList(
+        Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
+
+    ;
 
     /** What we want to appear as the metric name. */
     private String name;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
@@ -35,9 +35,7 @@ public enum WriterMetrics implements MeasurementSet {
     FAULT_DETECTION_COLLECTOR_EXECUTION_TIME("FaultDetectionCollectorExecutionTime", "millis", Arrays.asList(
     Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
 
-    STALE_METRICS("StaleMetrics", "count", Arrays.asList(
-        Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
-
+    STALE_METRICS("StaleMetrics", "count", Arrays.asList( Statistics.COUNT)),
     ;
 
     /** What we want to appear as the metric name. */

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
@@ -35,7 +35,7 @@ public enum WriterMetrics implements MeasurementSet {
     FAULT_DETECTION_COLLECTOR_EXECUTION_TIME("FaultDetectionCollectorExecutionTime", "millis", Arrays.asList(
     Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
 
-    STALE_METRICS("StaleMetrics", "count", Arrays.asList( Statistics.COUNT)),
+    STALE_METRICS("StaleMetrics", "count", Arrays.asList(Statistics.COUNT)),
     ;
 
     /** What we want to appear as the metric name. */


### PR DESCRIPTION
*Fixes #:*

*Description of changes:*
1. Currently when the metrics PA collects arrive late, then it will be logged as info message. Instead we create a new metric `STALE_MERIC` and aggregate the count.

*Tests:*

*If new tests are added, how long do the new ones take to complete*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
