### PR TITLE
Upgrade dom4j to 2.1.3+ 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ plugins {
     id 'com.google.protobuf' version '0.8.8'
     id 'jacoco'
     id 'idea'
-    id 'com.github.spotbugs' version '4.0.0'
+    id 'com.github.spotbugs' version '4.6.0'
     id "de.undercouch.download" version "4.0.4"
     id 'com.adarshr.test-logger' version '2.1.0'
 }


### PR DESCRIPTION
*Fixes #:* https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/issues/521

*Description of changes:* Upgrade dom4j to 2.1.3+
Updating the com.github.spotbugs to latest 4.6.0 version, which will bring in 2.1.3 version of dom4j

*Tests:*
```
khushbr@3c22fb8556dd performance-analyzer-rca % ./gradlew :dependencyInsight --configuration spotbugs --dependency org.dom4j

> Configure project :
pa in dir: (../performance-analyzer) will be built.
PA repo located at '../performance-analyzer' will be used.

> Task :dependencyInsight
org.dom4j:dom4j:2.1.3
   variant "runtimeElements" [
      org.gradle.category            = library (not requested)
      org.gradle.dependency.bundling = external (not requested)
      org.gradle.jvm.version         = 8 (not requested)
      org.gradle.libraryelements     = jar (not requested)
      org.gradle.usage               = java-runtime (not requested)
      org.gradle.status              = release (not requested)
   ]

org.dom4j:dom4j:2.1.3
\--- com.github.spotbugs:spotbugs:4.1.1
     \--- spotbugs

A web-based, searchable dependency report is available by adding the --scan option.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.5/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 764ms
1 actionable task: 1 executed
```

*If new tests are added, how long do the new ones take to complete*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
