### PR TITLE
Add retries for failed tests. Upload gradle reports as artifacts

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,7 +10,6 @@ on:
     branches: 
       - master
       - dev
-  
 
 jobs:
   build_rca_pkg:
@@ -33,6 +32,11 @@ jobs:
     - name: Build RCA with Gradle
       working-directory:  ./tmp/performance-analyzer-rca
       run: ./gradlew build --stacktrace
+    - name: Upload reports
+      uses: actions/upload-artifact@v2
+      with:
+        name: gradle-reports
+        path: ./tmp/performance-analyzer-rca/build/reports
     - name: Generate Jacoco coverage report
       working-directory: ./tmp/performance-analyzer-rca
       run: ./gradlew jacocoTestReport

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ plugins {
     id 'com.github.spotbugs' version '4.6.0'
     id "de.undercouch.download" version "4.0.4"
     id 'com.adarshr.test-logger' version '2.1.0'
+    id 'org.gradle.test-retry' version '1.2.0'
 }
 
 application {
@@ -191,12 +192,17 @@ if (isSnapshot) {
 
 test {
     enabled = true
-
+    retry {
+        maxRetries = 2
+    }
 }
 
 task rcaTest(type: Test) {
     dependsOn checkstyleMain
     dependsOn checkstyleTest
+    retry {
+        maxRetries = 2
+    }
     useJUnit {
         includeCategories 'com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.GradleTaskForRca'
     }
@@ -207,6 +213,9 @@ task rcaIt(type: Test) {
     dependsOn checkstyleMain
     dependsOn checkstyleTest
     dependsOn spotbugsMain
+    retry {
+        maxRetries = 2
+    }
     useJUnit {
         includeCategories 'com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker'
     }


### PR DESCRIPTION
*Fixes #:*
#525 , #526 

*Description of changes:*
This patch adds the gradle test retry plugin which allows for retrying up to two times before declaring a test as a failure.
This patch also adds the ability to upload the generated test report as a workflow artifact. The artifact can be downloaded to easily look at per test case stdout and stderr logs which is currently absent in the workflow's stdout.

Note: The retry is a temporary solve to make sure that workflow completes and does not get blocked on unit tests if it doesn't need to.

*Tests:*

*If new tests are added, how long do the new ones take to complete*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
