### PR TITLE
Update the metricsDB instance for the gauntlet tests without a scheduler restart

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/RcaController.java
@@ -526,7 +526,8 @@ public class RcaController {
     return rcaConf;
   }
 
-  public void setDbProvider(Queryable dbProvider) {
+  @VisibleForTesting
+  public void setDbProvider(Queryable dbProvider) throws InterruptedException {
     this.dbProvider = dbProvider;
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/Tasklet.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/scheduler/Tasklet.java
@@ -21,6 +21,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.messages.Data
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.net.WireHopper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.NetPersistor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.Persistable;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -41,7 +42,10 @@ public class Tasklet {
   protected List<Tasklet> predecessors;
 
   private Node<?> node;
-  private final Queryable db;
+
+  // This member should be ideally final, but to be able to change it for the
+  // tests, we are making it non-final.
+  private Queryable db;
   private final Persistable persistable;
   private final Map<Node<?>, List<Node<?>>> remotelyDesirableNodeSet;
   private final WireHopper hopper;
@@ -138,5 +142,10 @@ public class Tasklet {
 
   public Node<?> getNode() {
     return node;
+  }
+
+  @VisibleForTesting
+  public void setDb(final Queryable db) {
+    this.db = db;
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/api/TestApi.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/api/TestApi.java
@@ -72,10 +72,6 @@ public class TestApi {
   public void updateMetrics(Class<?> clz) throws Exception {
     if (clz.isAnnotationPresent(AMetric.Metrics.class) || clz.isAnnotationPresent(AMetric.class)) {
       cluster.updateMetricsDB(clz.getAnnotationsByType(AMetric.class));
-
-      // The scheduler needs to be restarted to pick this change up.
-      cluster.stopRcaScheduler();
-      cluster.startRcaScheduler();
     }
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/overrides/RcaControllerIt.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/overrides/RcaControllerIt.java
@@ -25,6 +25,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.cor
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.Queryable;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaUtil;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.RCAScheduler;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.RcaSchedulerState;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.threads.ThreadProvider;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.util.WaitFor;
@@ -81,8 +82,16 @@ public class RcaControllerIt extends RcaController {
     return rcaConfIt;
   }
 
-  public void setDbProvider(final Queryable db) {
+  public void setDbProvider(final Queryable db) throws InterruptedException {
     dbProvider = db;
+    RCAScheduler sched = getRcaScheduler();
+
+    // The change is optional and only happens in the next line if the scheduler is already running.
+    // If the scheduler is not running at the moment, then it will pick up the new DB when it starts
+    // next.
+    if (sched != null) {
+      sched.setQueryable(db);
+    }
   }
 
   public void setRcaGraphComponents(Class rcaGraphClass)

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/poc/RcaItPocCoLocatedMaster.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/poc/RcaItPocCoLocatedMaster.java
@@ -13,11 +13,15 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.fr
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaGraph;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.api.IValidator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.api.TestApi;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.poc.validator.PocValidator;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/poc/RcaItPocCoLocatedMaster.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/poc/RcaItPocCoLocatedMaster.java
@@ -13,15 +13,11 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.fr
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaGraph;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.api.IValidator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.api.TestApi;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.poc.validator.PocValidator;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
*Fixes #:*

*Description of changes:*

Today the metricsDB instance serving the graph node can be updated but for the
update to take effect, it also restarts the Scheduler. The scheduler stores the
states of the RCA nodes in memory and therefore restarting it cases all transient
states to be lost. This change tries to make the chnage without causing a Scheduler
restart. In order to do this, we add a check in the SchedulerTask. Before every
run invokation, it checks if someone has asked for the metricsDB to be updated
if so, then it goes ahead and updates the reference for all Tasklets. This is only
for test purposes and should not happen in prod.

*Tests:*
It is tested by adding a placeholder test in the dev environment. The test is not checked in as it does not test a real feature and will add to the already painful build time. Very soon tests will be added that leverage this feature.

*If new tests are added, how long do the new ones take to complete*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
