### PR TITLE
Adding fix for concurrency issue for Reader

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessor.java
@@ -113,7 +113,8 @@ public class ReaderMetricsProcessor implements Runnable {
 
   private final boolean processNewFormat;
   private final EventLogFileHandler eventLogFileHandler;
-  private static ReaderMetricsProcessor current = null;
+  // This needs to be volatile to avoid failure caused by thread local cached values.
+  private static volatile ReaderMetricsProcessor current = null;
 
   public static void setCurrentInstance(ReaderMetricsProcessor currentInstance) {
     current = currentInstance;


### PR DESCRIPTION
*Fixes #:* https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/issues/532

*Description of changes:* When Reader Thread crashes the first time and is restarted, the [ReaderMetricsProcessor current instance is re-set](https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/blob/master/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerApp.java#L236). This value is not communicated to the MetricsServerHandler Thread, which uses the older thread-local cached value, causing the Process to crash with `java.lang.NullPointerException` when [ ReaderMetricsProcessor currentInstance attempts getMetricsDB()](https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/blob/master/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/handler/MetricsServerHandler.java#L39). This `java.lang.NullPointerException` behavior can be reproduced by :  
1. Force terminate the Reader thread on data node, wait for thread to be re-started. This can be verified by checking [ 'NumberOfPAThreadsStarted' and 'NumberOfPAThreadsEnded'](https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/blob/master/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/threads/ThreadProvider.java#L31) metrics.
2. Invoke the metrics API `metrics?metrics=CPU_Utilization&agg=avg&nodes=all` from the master node.
3. Reader process will fail with `java.lang.NullPointerException` at [this](https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/blob/master/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/handler/MetricsServerHandler.java#L39) line each time the metrics API is invoked. 

*Tests:* Performed the above test after adding the fix. The process did not ctash and the getMetrics API response for this node was empty (And not null, as was happening before).

```
for i in {1..2000}; do echo `curl -XGET "localhost:9200/_opendistro/_performanceanalyzer/_agent/metrics?metrics=CPU_Utilization&agg=avg&nodes=all"`; done

{"fTa04SdyRieljxvWSVDFPw": {"timestamp": 1607636775000, "data": {}}, "LSsMACufRKiFCtM-oJ81Rg" :{"timestamp": 1607636775000, "data": {}}}
```

*If new tests are added, how long do the new ones take to complete*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
