### PR TITLE
Upgrade jackson-databind to 2.12.0

### DIFF
--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -1,6 +1,6 @@
 ** GoogleGuava; version 27.0.1-jre -- https://github.com/google/guava
 ** Jackson-annotations; version 2.11.1 -- https://github.com/FasterXML/jackson-annotations/
-** Jackson-databind; version 2.11.1 -- https://github.com/FasterXML/jackson-databind
+** Jackson-databind; version 2.12.0 -- https://github.com/FasterXML/jackson-databind
 ** jooq; version 3.10.8 -- https://github.com/jOOQ/jOOQ
 ** org.xerial:sqlite-jdbc; version 3.8.11.2 -- https://bitbucket.org/xerial/sqlite-jdbc/src/8de652d3f54cdfd32d5a493130c995f36e16c652/LICENSE?at=default&fileviewer=file-view-default
 ** PowerMock; version 1.6.1 -- https://github.com/powermock/powermock

--- a/build.gradle
+++ b/build.gradle
@@ -273,7 +273,7 @@ dependencies {
     compile 'org.xerial:sqlite-jdbc:3.32.3.2'
     compile 'com.google.guava:guava:28.2-jre'
     compile 'com.fasterxml.jackson.core:jackson-annotations:2.10.4'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.10.4'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.0'
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.13.0'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.13.0'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'


### PR DESCRIPTION
*Fixes #:*

*Description of changes:*
Upgrade jackson-databind to 2.12.0 according to CVE-2020-25649
Update THIRD-PARTY

*Tests:*

*If new tests are added, how long do the new ones take to complete*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
