### PR TITLE
Gauntlet test - Add consolidate IT when JVM / queue rejection metrics are issued one after another 

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metricsdb/MetricsDB.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metricsdb/MetricsDB.java
@@ -22,6 +22,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.StatsC
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.Removable;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -181,6 +182,17 @@ public class MetricsDB implements Removable {
         .set(DSL.field(MAX, Double.class), metric.getMax())
         .set(dimensions.getFieldMap())
         .execute();
+  }
+
+  /**
+   * Drop a metric table. This is for IT framework to use only
+   * @param metricName metric table to be deleted
+   */
+  @VisibleForTesting
+  public void deleteMetric(String metricName) {
+    if (DBUtils.checkIfTableExists(create, metricName)) {
+      create.dropTable(metricName).execute();
+    }
   }
 
   // We have a table per metric. We do a group by/aggregate on

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Cluster.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Cluster.java
@@ -264,9 +264,9 @@ public class Cluster {
     }
   }
 
-  public void updateMetricsDB(AMetric[] metricAnnotations) throws Exception {
+  public void updateMetricsDB(AMetric[] metricAnnotations, boolean reloadDB) throws Exception {
     for (Host host : hostList) {
-      host.updateMetricsDB(metricAnnotations);
+      host.updateMetricsDB(metricAnnotations, reloadDB);
     }
   }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Host.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Host.java
@@ -320,7 +320,7 @@ public class Host {
    * refresh/update metric DB provider in integ test
    * @param metricAnnotations AMetric annotations
    * @param reloadDB whether to refresh entire DB or update tables in existing DB
-   * @throws Exception
+   * @throws Exception db related exceptions
    */
   public void updateMetricsDB(AMetric[] metricAnnotations, boolean reloadDB) throws Exception {
     RcaItMetricsDBProvider dbProvider;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Host.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/Host.java
@@ -316,9 +316,19 @@ public class Host {
     rcaController.setRcaGraphComponents(rcaGraphClass);
   }
 
-  public void updateMetricsDB(AMetric[] metricAnnotations) throws Exception {
-    RcaItMetricsDBProvider dbProvider =
-        new RcaItMetricsDBProvider(Paths.get(hostDir.getPath(), "metricsdb").toString());
+  /**
+   * refresh/update metric DB provider in integ test
+   * @param metricAnnotations AMetric annotations
+   * @param reloadDB whether to refresh entire DB or update tables in existing DB
+   * @throws Exception
+   */
+  public void updateMetricsDB(AMetric[] metricAnnotations, boolean reloadDB) throws Exception {
+    RcaItMetricsDBProvider dbProvider;
+    if (reloadDB) {
+      dbProvider = new RcaItMetricsDBProvider(Paths.get(hostDir.getPath(), "metricsdb").toString());
+    } else {
+      dbProvider = rcaController.getDbProvider();
+    }
     for (AMetric metric : metricAnnotations) {
       boolean foundDataForHost = false;
       // Each metric can have only one data table that can be associated to a host.
@@ -328,15 +338,18 @@ public class Host {
       for (ATable table : metric.tables()) {
         for (HostTag dataTag : table.hostTag()) {
           if (myTag == dataTag) {
+            String metricName;
+            try {
+              metricName = (String) metric.name().getField("NAME").get(null);
+            } catch (Exception ex) {
+              LOG.error("Error getting metric name.", ex);
+              throw ex;
+            }
+            if (!reloadDB) {
+              dbProvider.clearTable(metricName);
+            }
             // First data-tag to match the hostTags is considered to be a match
             for (ATuple tuple : table.tuple()) {
-              String metricName;
-              try {
-                metricName = (String) metric.name().getField("NAME").get(null);
-              } catch (Exception ex) {
-                LOG.error("Error getting metric name.", ex);
-                throw ex;
-              }
               dbProvider.insertRow(
                   metricName,
                   metric.dimensionNames(),

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/TestEnvironment.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/TestEnvironment.java
@@ -39,7 +39,7 @@ public class TestEnvironment {
 
       if (testClass.isAnnotationPresent(AMetric.Metrics.class)
           || testClass.isAnnotationPresent(AMetric.class)) {
-        updateMetricsDB((AMetric[]) testClass.getAnnotationsByType(AMetric.class), env);
+        updateMetricsDB((AMetric[]) testClass.getAnnotationsByType(AMetric.class), env, true);
       }
     }
     if (env.rcaConfMap.isEmpty()) {
@@ -64,7 +64,7 @@ public class TestEnvironment {
       }
 
       if (method.isAnnotationPresent(AMetric.Metrics.class)) {
-        updateMetricsDB(method.getAnnotationsByType(AMetric.class), currentEnv);
+        updateMetricsDB(method.getAnnotationsByType(AMetric.class), currentEnv, true);
       }
     }
   }
@@ -89,8 +89,8 @@ public class TestEnvironment {
     cluster.updateGraph(graphClass);
   }
 
-  private void updateMetricsDB(AMetric[] metrics, Env env) throws Exception {
-    cluster.updateMetricsDB(metrics);
+  private void updateMetricsDB(AMetric[] metrics, Env env, boolean reloadDB) throws Exception {
+    cluster.updateMetricsDB(metrics, reloadDB);
     env.isMetricsDBProviderSet = true;
   }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/api/TestApi.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/api/TestApi.java
@@ -67,11 +67,12 @@ public class TestApi {
    * This API let's a gauntlet test writer swap out the metricsDB for a new one.
    *
    * @param clz The class whose AMetric@ should be used to replace it
+   * @param reloadDB whether to refresh entire DB or update tables in existing DB
    * @throws Exception Throws Exception
    */
-  public void updateMetrics(Class<?> clz) throws Exception {
+  public void updateMetrics(Class<?> clz, boolean reloadDB) throws Exception {
     if (clz.isAnnotationPresent(AMetric.Metrics.class) || clz.isAnnotationPresent(AMetric.class)) {
-      cluster.updateMetricsDB(clz.getAnnotationsByType(AMetric.class));
+      cluster.updateMetricsDB(clz.getAnnotationsByType(AMetric.class), reloadDB);
     }
   }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/overrides/RcaControllerIt.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/overrides/RcaControllerIt.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 public class RcaControllerIt extends RcaController {
   private final String rcaPath;
   private List<ConnectedComponent> rcaGraphComponents;
+  private RcaItMetricsDBProvider rcaItMetricsDBProvider;
 
   public RcaControllerIt(ThreadProvider threadProvider,
                          ScheduledExecutorService netOpsExecutorService,
@@ -82,8 +83,9 @@ public class RcaControllerIt extends RcaController {
     return rcaConfIt;
   }
 
-  public void setDbProvider(final Queryable db) throws InterruptedException {
+  public void setDbProvider(final RcaItMetricsDBProvider db) throws InterruptedException {
     dbProvider = db;
+    rcaItMetricsDBProvider = db;
     RCAScheduler sched = getRcaScheduler();
 
     // The change is optional and only happens in the next line if the scheduler is already running.
@@ -92,6 +94,10 @@ public class RcaControllerIt extends RcaController {
     if (sched != null) {
       sched.setQueryable(db);
     }
+  }
+
+  public RcaItMetricsDBProvider getDbProvider() {
+    return rcaItMetricsDBProvider;
   }
 
   public void setRcaGraphComponents(Class rcaGraphClass)

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/overrides/RcaItMetricsDBProvider.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/framework/overrides/RcaItMetricsDBProvider.java
@@ -65,4 +65,8 @@ public class RcaItMetricsDBProvider extends MetricsDBProvider {
     db.createMetric(metric, Arrays.asList(dimensionNames));
     db.putMetric(metric, dimensions, 0);
   }
+
+  public void clearTable(String metricName) {
+    db.deleteMetric(metricName);
+  }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/consolidate_tuning/JvmFlipFlopITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/consolidate_tuning/JvmFlipFlopITest.java
@@ -1,0 +1,334 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.consolidate_tuning;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.consolidate_tuning.JvmFlipFlopITest.FIELDDATA_CACHE_SIZE_IN_PERCENT;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.consolidate_tuning.JvmFlipFlopITest.HEAP_MAX_SIZE_IN_BYTE;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.consolidate_tuning.JvmFlipFlopITest.SHARD_REQUEST_CACHE_SIZE_IN_PERCENT;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cache.CacheUtil.GB_TO_BYTES;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.actions.configs.QueueActionConfig;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolDimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Cache_Max_Size;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.GC_Collection_Event;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Max;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.Heap_Used;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_QueueCapacity;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics.ThreadPool_RejectedReqs;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.RcaItMarker;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AErrorPatternIgnored;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AExpect;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.AMetric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ARcaGraph;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATable;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.annotations.ATuple;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.api.TestApi;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.ClusterType;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.configs.HostTag;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.framework.runners.RcaItNotEncryptedRunner;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.integTests.tests.jvm.old_gen_policy.validator.LevelOneValidator;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.ElasticSearchAnalysisGraph;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(RcaItNotEncryptedRunner.class)
+
+@Category(RcaItMarker.class)
+@AClusterType(ClusterType.MULTI_NODE_DEDICATED_MASTER)
+@ARcaGraph(ElasticSearchAnalysisGraph.class)
+//initial metric table
+@AMetric(name = Heap_Used.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = {HostTag.DATA_0},
+            tuple = {
+                @ATuple(dimensionValues = AllMetrics.GCType.Constants.OLD_GEN_VALUE,
+                    sum = HEAP_MAX_SIZE_IN_BYTE * 0.8,
+                    avg = HEAP_MAX_SIZE_IN_BYTE * 0.8,
+                    min = HEAP_MAX_SIZE_IN_BYTE * 0.8,
+                    max = HEAP_MAX_SIZE_IN_BYTE * 0.8),
+            }
+        )
+    }
+)
+@AMetric(name = Heap_Max.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = {HostTag.DATA_0},
+            tuple = {
+                @ATuple(dimensionValues = AllMetrics.GCType.Constants.HEAP_VALUE,
+                    sum = HEAP_MAX_SIZE_IN_BYTE,
+                    avg = HEAP_MAX_SIZE_IN_BYTE,
+                    min = HEAP_MAX_SIZE_IN_BYTE,
+                    max = HEAP_MAX_SIZE_IN_BYTE),
+            }
+        )
+    }
+)
+@AMetric(name = GC_Collection_Event.class,
+    dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = {HostTag.DATA_0},
+            tuple = {
+                @ATuple(dimensionValues = AllMetrics.GCType.Constants.TOT_FULL_GC_VALUE,
+                    sum = 0, avg = 0, min = 0, max = 0),
+            }
+        )
+    }
+)
+@AMetric(
+    name = Cache_Max_Size.class,
+    dimensionNames = {AllMetrics.CacheConfigDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(
+            hostTag = HostTag.DATA_0,
+            tuple = {
+                @ATuple(
+                    dimensionValues = {AllMetrics.CacheType.Constants.FIELD_DATA_CACHE_NAME},
+                    sum = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT,
+                    avg = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT,
+                    min = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT,
+                    max = HEAP_MAX_SIZE_IN_BYTE * FIELDDATA_CACHE_SIZE_IN_PERCENT),
+                @ATuple(
+                    dimensionValues = {AllMetrics.CacheType.Constants.SHARD_REQUEST_CACHE_NAME},
+                    sum = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT,
+                    avg = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT,
+                    min = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT,
+                    max = HEAP_MAX_SIZE_IN_BYTE * SHARD_REQUEST_CACHE_SIZE_IN_PERCENT)
+            }),
+    })
+@AMetric(name = ThreadPool_QueueCapacity.class,
+    dimensionNames = {ThreadPoolDimension.Constants.TYPE_VALUE},
+    tables = {
+        @ATable(hostTag = HostTag.DATA_0,
+            tuple = {
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.WRITE_NAME},
+                    sum = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 200,
+                    avg = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 200,
+                    min = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 200,
+                    max = QueueActionConfig.DEFAULT_WRITE_QUEUE_UPPER_BOUND - 200),
+                @ATuple(dimensionValues = {ThreadPoolType.Constants.SEARCH_NAME},
+                    sum = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 200,
+                    avg = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 200,
+                    min = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 200,
+                    max = QueueActionConfig.DEFAULT_SEARCH_QUEUE_UPPER_BOUND - 200)
+            }
+        )
+    }
+)
+
+public class JvmFlipFlopITest {
+  public static final long HEAP_MAX_SIZE_IN_BYTE = 10 * GB_TO_BYTES;
+  public static final double FIELDDATA_CACHE_SIZE_IN_PERCENT = 0.3;
+  public static final double SHARD_REQUEST_CACHE_SIZE_IN_PERCENT = 0.04;
+  private TestApi api;
+
+  public void setTestApi(final TestApi api) {
+    this.api = api;
+  }
+
+  @Test
+  @AExpect(
+      what = AExpect.Type.REST_API,
+      on = HostTag.ELECTED_MASTER,
+      validator = LevelOneValidator.class,
+      forRca = PersistedAction.class,
+      timeoutSeconds = 10000)
+  @AErrorPatternIgnored(
+      pattern = "CacheUtil:getCacheMaxSize()",
+      reason = "Cache related configs are expected to be missing in this integ test")
+  @AErrorPatternIgnored(
+      pattern = "AggregateMetric:gather()",
+      reason = "Cache metrics are expected to be missing in this integ test")
+  @AErrorPatternIgnored(
+      pattern = "SubscribeResponseHandler:onError()",
+      reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+  @AErrorPatternIgnored(
+      pattern = "SQLParsingUtil:readDataFromSqlResult()",
+      reason = "Old gen metrics is expected to be missing in this integ test.")
+  @AErrorPatternIgnored(
+      pattern = "HighHeapUsageOldGenRca:operate()",
+      reason = "Old gen rca is expected to be missing in this integ test.")
+  @AErrorPatternIgnored(
+      pattern = "ModifyCacheMaxSizeAction:build()",
+      reason = "Node config cache is expected to be missing during shutdown")
+  @AErrorPatternIgnored(
+      pattern = "NodeConfigCollector:collectAndPublishMetric()",
+      reason = "Shard request cache metrics is expected to be missing")
+  @AErrorPatternIgnored(
+      pattern = "CacheUtil:getCacheMaxSize()",
+      reason = "Shard request cache metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "HighHeapUsageYoungGenRca:operate()",
+      reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "OldGenRca:getMaxHeapSizeOrDefault()",
+      reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "OldGenRca:getMaxOldGenSizeOrDefault()",
+      reason = "YoungGen metrics is expected to be missing.")
+  /**
+   * in this IT, we start with low JVM usage and then increase the JVM after 10 seconds.
+   * JVM RCA is expected to be triggered and we should be able to observe JVM actions to lower
+   * heap usage in about 3-4 mins
+   */
+  public void testJvmActions() throws Exception {
+    try {
+      Thread.sleep(TimeUnit.SECONDS.toMillis(10));
+    } catch (InterruptedException e) {
+      throw new RuntimeException("Sleep was interrupted. Underlying exception: ", e);
+    }
+    api.updateMetrics(MetricsForUnhealthyOldGenUsage.class, false);
+  }
+
+  @Test
+  @AExpect(
+      what = AExpect.Type.REST_API,
+      on = HostTag.ELECTED_MASTER,
+      validator = LevelOneValidator.class,
+      forRca = PersistedAction.class,
+      timeoutSeconds = 10000)
+  @AErrorPatternIgnored(
+      pattern = "CacheUtil:getCacheMaxSize()",
+      reason = "Cache related configs are expected to be missing in this integ test")
+  @AErrorPatternIgnored(
+      pattern = "AggregateMetric:gather()",
+      reason = "Cache metrics are expected to be missing in this integ test")
+  @AErrorPatternIgnored(
+      pattern = "SubscribeResponseHandler:onError()",
+      reason = "A unit test expressly calls SubscribeResponseHandler#onError, which writes an error log")
+  @AErrorPatternIgnored(
+      pattern = "SQLParsingUtil:readDataFromSqlResult()",
+      reason = "Old gen metrics is expected to be missing in this integ test.")
+  @AErrorPatternIgnored(
+      pattern = "HighHeapUsageOldGenRca:operate()",
+      reason = "Old gen rca is expected to be missing in this integ test.")
+  @AErrorPatternIgnored(
+      pattern = "ModifyCacheMaxSizeAction:build()",
+      reason = "Node config cache is expected to be missing during shutdown")
+  @AErrorPatternIgnored(
+      pattern = "NodeConfigCollector:collectAndPublishMetric()",
+      reason = "Shard request cache metrics is expected to be missing")
+  @AErrorPatternIgnored(
+      pattern = "CacheUtil:getCacheMaxSize()",
+      reason = "Shard request cache metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "HighHeapUsageYoungGenRca:operate()",
+      reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "OldGenRca:getMaxHeapSizeOrDefault()",
+      reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "OldGenRca:getMaxOldGenSizeOrDefault()",
+      reason = "YoungGen metrics is expected to be missing.")
+  @AErrorPatternIgnored(
+      pattern = "BucketizedSlidingWindow:next()",
+      reason = "BucketizedSlidingWindow is expected to be missing.")
+  /**
+   * Once JVM decisions are published, we lower the JVM usage to bring JVM RCA back to normal and
+   * immediately inject queue rejection metrics. Flip Flop detector should capture this and suppress
+   * queue rejection actions because increasing queue capacity will change JVM vector into a different direction.
+   */
+  public void testFlipFlop() throws Exception {
+    api.updateMetrics(MetricsForHealthyOldGenUsage.class, false);
+    api.updateMetrics(MetricsForQueueRejection.class, false);
+    //queue decisions can be observed in about 2 mins if flip flop detector is not involved. Let's
+    //keep the test thread to sleep for 140s and persisted actions should remain unchanged.
+    try {
+      Thread.sleep(TimeUnit.SECONDS.toMillis(140));
+    } catch (InterruptedException e) {
+      throw new RuntimeException("Sleep was interrupted. Underlying exception: ", e);
+    }
+  }
+
+
+  @AMetric(name = Heap_Used.class,
+      dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+      tables = {
+          @ATable(hostTag = {HostTag.DATA_0},
+              tuple = {
+                  @ATuple(dimensionValues = AllMetrics.GCType.Constants.OLD_GEN_VALUE,
+                      sum = HEAP_MAX_SIZE_IN_BYTE * 0.7,
+                      avg = HEAP_MAX_SIZE_IN_BYTE * 0.7,
+                      min = HEAP_MAX_SIZE_IN_BYTE * 0.7,
+                      max = HEAP_MAX_SIZE_IN_BYTE * 0.7),
+              }
+          )
+      }
+  )
+  @AMetric(name = GC_Collection_Event.class,
+      dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+      tables = {
+          @ATable(hostTag = {HostTag.DATA_0},
+              tuple = {
+                  @ATuple(dimensionValues = AllMetrics.GCType.Constants.TOT_FULL_GC_VALUE,
+                      sum = 1, avg = 1, min = 1, max = 1),
+              }
+          )
+      }
+  )
+  public static class MetricsForUnhealthyOldGenUsage {
+  }
+
+  @AMetric(name = Heap_Used.class,
+      dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+      tables = {
+          @ATable(hostTag = {HostTag.DATA_0},
+              tuple = {
+                  @ATuple(dimensionValues = AllMetrics.GCType.Constants.OLD_GEN_VALUE,
+                      sum = HEAP_MAX_SIZE_IN_BYTE * 0.2,
+                      avg = HEAP_MAX_SIZE_IN_BYTE * 0.2,
+                      min = HEAP_MAX_SIZE_IN_BYTE * 0.2,
+                      max = HEAP_MAX_SIZE_IN_BYTE * 0.2),
+              }
+          )
+      }
+  )
+  @AMetric(name = GC_Collection_Event.class,
+      dimensionNames = {AllMetrics.HeapDimension.Constants.TYPE_VALUE},
+      tables = {
+          @ATable(hostTag = {HostTag.DATA_0},
+              tuple = {
+                  @ATuple(dimensionValues = AllMetrics.GCType.Constants.TOT_FULL_GC_VALUE,
+                      sum = 1, avg = 1, min = 1, max = 1),
+              }
+          )
+      }
+  )
+  public static class MetricsForHealthyOldGenUsage {
+  }
+
+
+  @AMetric(name = ThreadPool_RejectedReqs.class,
+      dimensionNames = {ThreadPoolDimension.Constants.TYPE_VALUE},
+      tables = {
+          @ATable(hostTag = HostTag.DATA_0,
+              tuple = {
+                  @ATuple(dimensionValues = {ThreadPoolType.Constants.WRITE_NAME},
+                      sum = 1.0, avg = 1.0, min = 1.0, max = 1.0),
+                  @ATuple(dimensionValues = {ThreadPoolType.Constants.SEARCH_NAME},
+                      sum = 0.0, avg = 0.0, min = 0.0, max = 0.0)
+              }
+          )
+      }
+  )
+  @AMetric(name = ThreadPool_QueueCapacity.class,
+      dimensionNames = {ThreadPoolDimension.Constants.TYPE_VALUE},
+      tables = {
+          @ATable(hostTag = HostTag.DATA_0,
+              tuple = {
+                  @ATuple(dimensionValues = {ThreadPoolType.Constants.WRITE_NAME},
+                      sum = 500, avg = 500, min = 500, max = 500),
+                  @ATuple(dimensionValues = {ThreadPoolType.Constants.SEARCH_NAME},
+                      sum = 1500, avg = 1500, min = 1500, max = 1500)
+              }
+          )
+      }
+  )
+  public static class MetricsForQueueRejection {
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/consolidate_tuning/JvmFlipFlopITest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/integTests/tests/consolidate_tuning/JvmFlipFlopITest.java
@@ -131,6 +131,11 @@ public class JvmFlipFlopITest {
     this.api = api;
   }
 
+  /**
+   * in this IT, we start with low JVM usage and then increase the JVM after 10 seconds.
+   * JVM RCA is expected to be triggered and we should be able to observe JVM actions to lower
+   * heap usage in about 3-4 mins
+   */
   @Test
   @AExpect(
       what = AExpect.Type.REST_API,
@@ -171,11 +176,6 @@ public class JvmFlipFlopITest {
   @AErrorPatternIgnored(
       pattern = "OldGenRca:getMaxOldGenSizeOrDefault()",
       reason = "YoungGen metrics is expected to be missing.")
-  /**
-   * in this IT, we start with low JVM usage and then increase the JVM after 10 seconds.
-   * JVM RCA is expected to be triggered and we should be able to observe JVM actions to lower
-   * heap usage in about 3-4 mins
-   */
   public void testJvmActions() throws Exception {
     try {
       Thread.sleep(TimeUnit.SECONDS.toMillis(10));
@@ -185,6 +185,11 @@ public class JvmFlipFlopITest {
     api.updateMetrics(MetricsForUnhealthyOldGenUsage.class, false);
   }
 
+  /**
+   * Once JVM decisions are published, we lower the JVM usage to bring JVM RCA back to normal and
+   * immediately inject queue rejection metrics. Flip Flop detector should capture this and suppress
+   * queue rejection actions because increasing queue capacity will change JVM vector into a different direction.
+   */
   @Test
   @AExpect(
       what = AExpect.Type.REST_API,
@@ -228,11 +233,6 @@ public class JvmFlipFlopITest {
   @AErrorPatternIgnored(
       pattern = "BucketizedSlidingWindow:next()",
       reason = "BucketizedSlidingWindow is expected to be missing.")
-  /**
-   * Once JVM decisions are published, we lower the JVM usage to bring JVM RCA back to normal and
-   * immediately inject queue rejection metrics. Flip Flop detector should capture this and suppress
-   * queue rejection actions because increasing queue capacity will change JVM vector into a different direction.
-   */
   public void testFlipFlop() throws Exception {
     api.updateMetrics(MetricsForHealthyOldGenUsage.class, false);
     api.updateMetrics(MetricsForQueueRejection.class, false);


### PR DESCRIPTION
*Fixes #:*

*Description of changes:*
Add consolidate IT to cover the scenario two deciders are trying to issue two set of actions in different direction. As a result, Flip flop detector will jump in to suppress one set of actions. 

1. we start with low JVM usage and then increase the JVM after 10 seconds. JVM RCA is expected to be triggered and we should be able to observe JVM actions to lower heap usage in about 3-4 mins

2. Once JVM decisions are published, we lower the JVM usage to bring JVM RCA back to normal and immediately inject queue rejection metrics. Flip Flop detector should capture this and suppress queue rejection actions because increasing queue capacity will change JVM vector into a different direction.

*Tests:*
n/a

*If new tests are added, how long do the new ones take to complete*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
