### PR TITLE
Changes the Naming Convention as per ODFE Conventions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -106,7 +106,7 @@ You can use the packaged Dockerfile and docker-compose.yml files [here](./docker
 4. Copy the RCA framework artifact and the Performance Analyzer plugin JAR into this folder
  
     `cp <RCA framework root>/build/distributions/performance-analyzer-rca.zip ./`  
-    `cp <Performance Analyzer plugin root>/build/distributions/opendistro_performance_analyzer-1.12.0.0-SNAPSHOT.zip ./`
+    `cp <Performance Analyzer plugin root>/build/distributions/opendistro-performance-analyzer-1.12.0.0-SNAPSHOT.zip ./`
  
  ### Installation
  

--- a/build.gradle
+++ b/build.gradle
@@ -375,7 +375,7 @@ task copyAllArtifacts(type: Copy) {
     def projectPathStr = getProjectDir().toPath().toString()
     def dockerArtifacts = Paths.get(projectPathStr, 'docker').toString()
     def rcaArtifacts = Paths.get(projectPathStr, 'build', 'distributions', 'performance-analyzer-rca.zip')
-    def paArtifacts = Paths.get(paDir, 'build', 'distributions', 'opendistro_performance_analyzer-1.12.0.0-SNAPSHOT.zip')
+    def paArtifacts = Paths.get(paDir, 'build', 'distributions', 'opendistro-performance-analyzer-1.12.0.0-SNAPSHOT.zip')
 
     dockerArtifactsDir = Paths.get(dockerBuildDir, 'rca-docker')
     from(dockerArtifacts)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,10 +49,10 @@ COPY --chown=1000:0 elasticsearch.yml log4j2.properties config/
 
 COPY --chown=1000:0 performance-analyzer-rca.zip config/
 
-COPY --chown=1000:0 opendistro_performance_analyzer-1.12.0.0-SNAPSHOT.zip /tmp/
+COPY --chown=1000:0 opendistro-performance-analyzer-1.12.0.0-SNAPSHOT.zip /tmp/
 
-RUN elasticsearch-plugin install --batch file:///tmp/opendistro_performance_analyzer-1.12.0.0-SNAPSHOT.zip; \
-        rm /tmp/opendistro_performance_analyzer-1.12.0.0-SNAPSHOT.zip
+RUN elasticsearch-plugin install --batch file:///tmp/opendistro-performance-analyzer-1.12.0.0-SNAPSHOT.zip; \
+        rm /tmp/opendistro-performance-analyzer-1.12.0.0-SNAPSHOT.zip
 
 USER 0
 
@@ -62,8 +62,8 @@ RUN chown -R elasticsearch:0 . && \
 
 RUN unzip config/performance-analyzer-rca.zip
 
-RUN cp -r performance-analyzer-rca/* plugins/opendistro_performance_analyzer/
-RUN chmod 755 /usr/share/elasticsearch/plugins/opendistro_performance_analyzer/pa_bin/performance-analyzer-agent
+RUN cp -r performance-analyzer-rca/* plugins/opendistro-performance-analyzer/
+RUN chmod 755 /usr/share/elasticsearch/plugins/opendistro-performance-analyzer/pa_bin/performance-analyzer-agent
 RUN chmod -R 755 /dev/shm
 ################################################################################
 # Build stage 1 (the actual opendistroforelasticsearch image):
@@ -126,7 +126,7 @@ RUN chgrp 0 /usr/local/bin/docker-entrypoint.sh && \
     chmod 0775 /usr/local/bin/docker-entrypoint.sh
 
 # Bind to all interfaces so that the docker container is accessible from the host machine
-RUN sed -i "s|#webservice-bind-host =|webservice-bind-host = 0.0.0.0|g" /usr/share/elasticsearch/plugins/opendistro_performance_analyzer/pa_config/performance-analyzer.properties
+RUN sed -i "s|#webservice-bind-host =|webservice-bind-host = 0.0.0.0|g" /usr/share/elasticsearch/plugins/opendistro-performance-analyzer/pa_config/performance-analyzer.properties
 
 EXPOSE 9200 9300 9600 9650
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -88,7 +88,7 @@ if [[ -d "/usr/share/elasticsearch/plugins/opendistro_security" ]]; then
     /usr/share/elasticsearch/plugins/opendistro_security/tools/install_demo_configuration.sh -y -i -s
 fi
 
-if [[ -d "/usr/share/elasticsearch/plugins/opendistro_performance_analyzer" ]]; then
+if [[ -d "/usr/share/elasticsearch/plugins/opendistro-performance-analyzer" ]]; then
     CLK_TCK=`/usr/bin/getconf CLK_TCK`
     DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n"
     ES_JAVA_OPTS="-Djava.security.policy=file:///usr/share/elasticsearch/performance-analyzer-rca/pa_config/es_security.policy -Dclk.tck=$CLK_TCK -Djdk.attach.allowAttachSelf=true $ES_JAVA_OPTS"

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/core/Util.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/core/Util.java
@@ -34,7 +34,7 @@ public class Util {
           + File.separator
           + "plugins"
           + File.separator
-          + "opendistro_performance_analyzer"
+          + "opendistro-performance-analyzer"
           + File.separator;
   public static final String READER_LOCATION =
           ES_HOME


### PR DESCRIPTION
*Fixes #:*

*Description of changes:*

*Tests:* Smoke testing using local Docker build. 

Plugin and the path renamed from `opendistro_performance_analyzer` to `opendistro-performance-analyzer`. 

```
[root@bd43959e2073 opendistro-performance-analyzer]# pwd
/usr/share/elasticsearch/plugins/opendistro-performance-analyzer
[root@bd43959e2073 opendistro-performance-analyzer]# 

[root@bd43959e2073 elasticsearch]# 
[root@bd43959e2073 elasticsearch]# curl --url "localhost:9600/_opendistro/_performanceanalyzer/actions" -XGET
{"LastSuggestedActionSet":[]}[root@bd43959e2073 elasticsearch]# 

```

*If new tests are added, how long do the new ones take to complete*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
