### PR TITLE
Added Election Term Metric

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/AllMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/AllMetrics.java
@@ -41,6 +41,7 @@ public class AllMetrics {
     THREAD_POOL,
     SHARD_STATS,
     MASTER_PENDING,
+    ELECTION_TERM,
     MOUNTED_PARTITION_METRICS
   }
 
@@ -818,6 +819,25 @@ public class AllMetrics {
 
     public static class Constants {
       public static final String PENDING_TASKS_COUNT_VALUE = "Master_PendingQueueSize";
+    }
+  }
+
+  public enum ElectionTermValue implements MetricValue {
+    ELECTION_TERM(Constants.ELECTION_TERM_VALUE);
+
+    private final String value;
+
+    ElectionTermValue(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return this.value;
+    }
+
+    public static class Constants {
+      public static final String ELECTION_TERM_VALUE = "Election_Term";
     }
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
@@ -44,6 +44,7 @@ public class PerformanceAnalyzerMetrics {
   public static final String sShardQueryPath = "shardquery";
   public static final String sMasterTaskPath = "master_task";
   public static final String sFaultDetection = "fault_detection";
+  public static final String sElectionTermPath = "election_term";
   public static final String sHttpPath = "http";
   public static final String sOSPath = "os_metrics";
   public static final String sHeapPath = "heap_metrics";

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/model/MetricsModel.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/model/MetricsModel.java
@@ -24,6 +24,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetric
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CommonMetric;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.DiskDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.DiskValue;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ElectionTermValue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.EmptyDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.HeapDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.HeapValue;
@@ -329,6 +330,10 @@ public class MetricsModel {
     allMetricsInitializer.put(
         MasterPendingValue.MASTER_PENDING_QUEUE_SIZE.toString(),
         new MetricAttributes(MetricUnits.COUNT.toString(), EmptyDimension.values()));
+
+    allMetricsInitializer.put(
+            ElectionTermValue.ELECTION_TERM.toString(),
+            new MetricAttributes(MetricUnits.COUNT.toString(), EmptyDimension.values()));
 
     allMetricsInitializer.put(
         AllMetrics.MasterMetricValues.MASTER_TASK_QUEUE_TIME.toString(),

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/ElectionTerm.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/ElectionTerm.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
+
+public class ElectionTerm extends Metric {
+    public ElectionTerm(long evaluationIntervalSeconds) {
+        super(
+            AllMetrics.ElectionTermValue.ELECTION_TERM.name(), evaluationIntervalSeconds);
+    }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
@@ -53,7 +53,9 @@ public enum ExceptionsAndErrors implements MeasurementSet {
 
   MASTER_THROTTLING_COLLECTOR_ERROR("MasterThrottlingMetricsCollector"),
 
-  FAULT_DETECTION_COLLECTOR_ERROR("FaultDetectionMetricsCollector");
+  FAULT_DETECTION_COLLECTOR_ERROR("FaultDetectionMetricsCollector"),
+
+  ELECTION_TERM_COLLECTOR_ERROR("ElectionTermCollectorError");
 
   /** What we want to appear as the metric name. */
   private String name;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
@@ -35,6 +35,9 @@ public enum WriterMetrics implements MeasurementSet {
     FAULT_DETECTION_COLLECTOR_EXECUTION_TIME("FaultDetectionCollectorExecutionTime", "millis", Arrays.asList(
     Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
 
+    ELECTION_TERM_COLLECTOR_EXECUTION_TIME("ElectionTermCollectorExecutionTime", "millis", Arrays.asList(
+            Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
+
     STALE_METRICS("StaleMetrics", "count", Arrays.asList(Statistics.COUNT)),
     ;
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MetricPropertiesConfig.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MetricPropertiesConfig.java
@@ -24,6 +24,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetric
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.DevicePartitionValue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.DiskDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.DiskValue;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ElectionTermValue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.HeapDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.HeapValue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.IPDimension;
@@ -166,6 +167,7 @@ public final class MetricPropertiesConfig {
     metricPathMap.put(MetricName.THREAD_POOL, PerformanceAnalyzerMetrics.sThreadPoolPath);
     metricPathMap.put(MetricName.SHARD_STATS, PerformanceAnalyzerMetrics.sIndicesPath);
     metricPathMap.put(MetricName.MASTER_PENDING, PerformanceAnalyzerMetrics.sPendingTasksPath);
+    metricPathMap.put(MetricName.ELECTION_TERM, PerformanceAnalyzerMetrics.sElectionTermPath);
     metricPathMap.put(MetricName.MOUNTED_PARTITION_METRICS,
         PerformanceAnalyzerMetrics.sMountedPartitionMetricsPath);
 
@@ -181,6 +183,8 @@ public final class MetricPropertiesConfig {
     eventKeyToMetricNameMap.put(PerformanceAnalyzerMetrics.sIndicesPath, MetricName.SHARD_STATS);
     eventKeyToMetricNameMap.put(
         PerformanceAnalyzerMetrics.sPendingTasksPath, MetricName.MASTER_PENDING);
+    eventKeyToMetricNameMap.put(
+            PerformanceAnalyzerMetrics.sElectionTermPath, MetricName.ELECTION_TERM);
     eventKeyToMetricNameMap.put(PerformanceAnalyzerMetrics.sMountedPartitionMetricsPath,
         MetricName.MOUNTED_PARTITION_METRICS);
 
@@ -244,6 +248,12 @@ public final class MetricPropertiesConfig {
                 metricPathMap.get(MetricName.MASTER_PENDING),
                 PerformanceAnalyzerMetrics.MASTER_CURRENT,
                 PerformanceAnalyzerMetrics.MASTER_META_DATA)));
+    metricName2Property.put(
+            MetricName.ELECTION_TERM,
+            new MetricProperties(
+                    MetricProperties.EMPTY_DIMENSION,
+                    ElectionTermValue.values(),
+                    createFileHandler(metricPathMap.get(MetricName.ELECTION_TERM))));
     metricName2Property.put(MetricName.MOUNTED_PARTITION_METRICS,
         new MetricProperties(
             DevicePartitionDimension.values(),


### PR DESCRIPTION
This Metric will Publish the Only Election term number

*Tests:*
Docker Container Testing

*1. Schema of Election term*
```
sqlite> .schema Election_Term
CREATE TABLE Election_Term(sum double null, avg double null, min double null, max double null);
```
*2. Entry in Election term table*
```
sqlite> select * from Election_Term;
18.0|18.0|18.0|18.0
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
