### PR TITLE
Configure spotless plugin and enable code formatting

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -3,12 +3,12 @@ name: Java CI
 on: 
   push: 
     branches: 
-      - master
+      - main
       - dev
 
   pull_request:
     branches: 
-      - master
+      - main
       - dev
 
 jobs:
@@ -20,6 +20,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: ./tmp/performance-analyzer-rca
+    # fetch the main branch to make it available for spotless ratcheting
+    - name: Fetch 'main' branch
+      working-directory:  ./tmp/performance-analyzer-rca
+      run: git fetch --depth=1 origin main
     - name: Checkout Performance Analyzer package
       uses: actions/checkout@v2
       with:

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ buildscript {
 
 plugins {
     id 'java'
-    id 'checkstyle'
     id 'application'
     id 'maven-publish'
     id 'com.google.protobuf' version '0.8.8'
@@ -32,7 +31,7 @@ plugins {
     id "de.undercouch.download" version "4.0.4"
     id 'com.adarshr.test-logger' version '2.1.0'
     id 'org.gradle.test-retry' version '1.2.0'
-    id 'com.diffplug.spotless' version '5.8.2'
+    id 'com.diffplug.spotless' version '5.11.0'
 }
 
 application {
@@ -81,30 +80,23 @@ publishing {
 ext {
     opendistroVersion = '1.13'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
+    gitDefaultBranch = 'main'
 }
-
-checkstyle {
-    toolVersion '8.24'
-    configFile file("configs/checkstyle/checkstyle.xml")
-}
-
-apply plugin: 'com.diffplug.spotless'
 
 spotless {
     java {
-        licenseHeaderFile(file('license-header'))
-
         // only apply formatting rules to updated files
-        // ratchetFrom 'origin/master'
+        ratchetFrom "origin/${gitDefaultBranch}"
 
-        // googleJavaFormat()
-        // importOrder()
-        // removeUnusedImports()
-        // trimTrailingWhitespace()
-        // endWithNewLine()
+        licenseHeaderFile(file('license-header'))
+        googleJavaFormat().aosp()
+        importOrder()
+        removeUnusedImports()
+        trimTrailingWhitespace()
+        endWithNewline()
 
         // add support for spotless:off and spotless:on tags to exclude sections of code
-        // toggleOffOn()
+        toggleOffOn()
     }
 }
 
@@ -219,8 +211,6 @@ test {
 }
 
 task rcaTest(type: Test) {
-    dependsOn checkstyleMain
-    dependsOn checkstyleTest
     retry {
         maxRetries = 2
     }
@@ -231,8 +221,6 @@ task rcaTest(type: Test) {
 }
 
 task rcaIt(type: Test) {
-    dependsOn checkstyleMain
-    dependsOn checkstyleTest
     dependsOn spotbugsMain
     retry {
         maxRetries = 2
@@ -367,6 +355,7 @@ task cloneGitRepo(type: GitClone) {
 
     def destination = file(paDir)
     uri = "https://github.com/opendistro-for-elasticsearch/performance-analyzer.git"
+    branch = gitDefaultBranch
     destinationPath = destination
     bare = false
     enabled = !destination.exists() //to clone only once

--- a/checkstyle/findbugs-exclude.xml
+++ b/checkstyle/findbugs-exclude.xml
@@ -74,9 +74,13 @@
         <Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.FileRotate"/>
         <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
     </Match>
-        <Match>
+    <Match>
         <Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.samplers.MetricsDBFileSampler"/>
         <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+    </Match>
+    <Match>
+        <Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.AdmissionControlProcessor"/>
+        <Bug pattern="URF_UNREAD_FIELD"/>
     </Match>
     <!--Exclude gRPC generated classes-->
     <Match>

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/AppContext.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/AppContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer;
 
+
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.collector.NodeConfigCache;
@@ -28,113 +29,117 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * The PA agent process is composed of multiple components. The PA Reader and RCA are two such components that are
- * independent in a way they process information but also share some information such as the node and the cluster
- * details. Today, some of these information is accessed by calling static methods and members. This is a bad idea.
- * This class encapsulates such information and is created right at the start in the {@code PerformanceAnalyzerApp}.
+ * The PA agent process is composed of multiple components. The PA Reader and RCA are two such
+ * components that are independent in a way they process information but also share some information
+ * such as the node and the cluster details. Today, some of these information is accessed by calling
+ * static methods and members. This is a bad idea. This class encapsulates such information and is
+ * created right at the start in the {@code PerformanceAnalyzerApp}.
  */
 public class AppContext {
-  private volatile ClusterDetailsEventProcessor clusterDetailsEventProcessor;
-  // initiate a node config cache within each AppContext space
-  // to store node config settings from ES
-  private final NodeConfigCache nodeConfigCache;
-  private volatile Set<String> mutedActions;
+    private volatile ClusterDetailsEventProcessor clusterDetailsEventProcessor;
+    // initiate a node config cache within each AppContext space
+    // to store node config settings from ES
+    private final NodeConfigCache nodeConfigCache;
+    private volatile Set<String> mutedActions;
 
-  public AppContext() {
-    this.clusterDetailsEventProcessor = null;
-    this.nodeConfigCache = new NodeConfigCache();
-    this.mutedActions = ImmutableSet.of();
-  }
-
-  public AppContext(AppContext other) {
-    this.clusterDetailsEventProcessor = new ClusterDetailsEventProcessor(other.clusterDetailsEventProcessor);
-
-    // Initializing this as we don't want to copy the entire cache.
-    this.nodeConfigCache = new NodeConfigCache();
-    this.mutedActions = ImmutableSet.copyOf(other.getMutedActions());
-  }
-
-  public void setClusterDetailsEventProcessor(final ClusterDetailsEventProcessor clusterDetailsEventProcessor) {
-    this.clusterDetailsEventProcessor = clusterDetailsEventProcessor;
-  }
-
-  public InstanceDetails getMyInstanceDetails() {
-    InstanceDetails ret = new InstanceDetails(AllMetrics.NodeRole.UNKNOWN);
-
-    if (clusterDetailsEventProcessor != null && clusterDetailsEventProcessor.getCurrentNodeDetails() != null) {
-      ClusterDetailsEventProcessor.NodeDetails nodeDetails = clusterDetailsEventProcessor.getCurrentNodeDetails();
-      ret = new InstanceDetails(nodeDetails);
+    public AppContext() {
+        this.clusterDetailsEventProcessor = null;
+        this.nodeConfigCache = new NodeConfigCache();
+        this.mutedActions = ImmutableSet.of();
     }
-    return ret;
-  }
 
-  /**
-   * Can be used to get all the nodes in the cluster.
-   *
-   * @return Returns an empty list of the details are not available or else it provides the immutable list of nodes in
-   *     the cluster.
-   */
-  public List<InstanceDetails> getAllClusterInstances() {
-    List<InstanceDetails> ret = Collections.EMPTY_LIST;
+    public AppContext(AppContext other) {
+        this.clusterDetailsEventProcessor =
+                new ClusterDetailsEventProcessor(other.clusterDetailsEventProcessor);
 
-    if (clusterDetailsEventProcessor != null) {
-      ret = getInstanceDetailsFromNodeDetails(clusterDetailsEventProcessor.getNodesDetails());
+        // Initializing this as we don't want to copy the entire cache.
+        this.nodeConfigCache = new NodeConfigCache();
+        this.mutedActions = ImmutableSet.copyOf(other.getMutedActions());
     }
-    return ret;
-  }
 
-  public List<InstanceDetails> getDataNodeInstances() {
-    List<InstanceDetails> ret = Collections.EMPTY_LIST;
-    if (clusterDetailsEventProcessor != null) {
-      ret = getInstanceDetailsFromNodeDetails(clusterDetailsEventProcessor.getDataNodesDetails());
+    public void setClusterDetailsEventProcessor(
+            final ClusterDetailsEventProcessor clusterDetailsEventProcessor) {
+        this.clusterDetailsEventProcessor = clusterDetailsEventProcessor;
     }
-    return ret;
-  }
 
-  private static List<InstanceDetails> getInstanceDetailsFromNodeDetails(
-      final List<ClusterDetailsEventProcessor.NodeDetails> nodeDetails) {
-    ImmutableList.Builder<InstanceDetails> instanceDetails = ImmutableList.builder();
-    for (ClusterDetailsEventProcessor.NodeDetails node : nodeDetails) {
-      instanceDetails.add(new InstanceDetails(node));
+    public InstanceDetails getMyInstanceDetails() {
+        InstanceDetails ret = new InstanceDetails(AllMetrics.NodeRole.UNKNOWN);
+
+        if (clusterDetailsEventProcessor != null
+                && clusterDetailsEventProcessor.getCurrentNodeDetails() != null) {
+            ClusterDetailsEventProcessor.NodeDetails nodeDetails =
+                    clusterDetailsEventProcessor.getCurrentNodeDetails();
+            ret = new InstanceDetails(nodeDetails);
+        }
+        return ret;
     }
-    return instanceDetails.build();
-  }
 
-  @VisibleForTesting
-  public ClusterDetailsEventProcessor getClusterDetailsEventProcessor() {
-    return clusterDetailsEventProcessor;
-  }
+    /**
+     * Can be used to get all the nodes in the cluster.
+     *
+     * @return Returns an empty list of the details are not available or else it provides the
+     *     immutable list of nodes in the cluster.
+     */
+    public List<InstanceDetails> getAllClusterInstances() {
+        List<InstanceDetails> ret = Collections.EMPTY_LIST;
 
-  public Set<InstanceDetails> getPeerInstances() {
-    return ImmutableSet.copyOf(
-            getAllClusterInstances()
-                    .stream()
-                    .skip(1)  // Skipping the first instance as it is self.
-                    .collect(Collectors.toSet()));
-  }
+        if (clusterDetailsEventProcessor != null) {
+            ret = getInstanceDetailsFromNodeDetails(clusterDetailsEventProcessor.getNodesDetails());
+        }
+        return ret;
+    }
 
-  public NodeConfigCache getNodeConfigCache() {
-    return this.nodeConfigCache;
-  }
+    public List<InstanceDetails> getDataNodeInstances() {
+        List<InstanceDetails> ret = Collections.EMPTY_LIST;
+        if (clusterDetailsEventProcessor != null) {
+            ret =
+                    getInstanceDetailsFromNodeDetails(
+                            clusterDetailsEventProcessor.getDataNodesDetails());
+        }
+        return ret;
+    }
 
-  public InstanceDetails getInstanceById(InstanceDetails.Id instanceIdKey) {
-    return getPeerInstances()
-            .stream()
-            .filter(
-                    x -> x.getInstanceId().equals(instanceIdKey))
-            .findFirst()
-            .orElse(new InstanceDetails(AllMetrics.NodeRole.UNKNOWN));
-  }
+    private static List<InstanceDetails> getInstanceDetailsFromNodeDetails(
+            final List<ClusterDetailsEventProcessor.NodeDetails> nodeDetails) {
+        ImmutableList.Builder<InstanceDetails> instanceDetails = ImmutableList.builder();
+        for (ClusterDetailsEventProcessor.NodeDetails node : nodeDetails) {
+            instanceDetails.add(new InstanceDetails(node));
+        }
+        return instanceDetails.build();
+    }
 
-  public boolean isActionMuted(final String action) {
-    return this.mutedActions.contains(action);
-  }
+    @VisibleForTesting
+    public ClusterDetailsEventProcessor getClusterDetailsEventProcessor() {
+        return clusterDetailsEventProcessor;
+    }
 
-  public void updateMutedActions(final Set<String> mutedActions) {
-    this.mutedActions = ImmutableSet.copyOf(mutedActions);
-  }
+    public Set<InstanceDetails> getPeerInstances() {
+        return ImmutableSet.copyOf(
+                getAllClusterInstances().stream()
+                        .skip(1) // Skipping the first instance as it is self.
+                        .collect(Collectors.toSet()));
+    }
 
-  public Set<String> getMutedActions() {
-    return this.mutedActions;
-  }
+    public NodeConfigCache getNodeConfigCache() {
+        return this.nodeConfigCache;
+    }
+
+    public InstanceDetails getInstanceById(InstanceDetails.Id instanceIdKey) {
+        return getPeerInstances().stream()
+                .filter(x -> x.getInstanceId().equals(instanceIdKey))
+                .findFirst()
+                .orElse(new InstanceDetails(AllMetrics.NodeRole.UNKNOWN));
+    }
+
+    public boolean isActionMuted(final String action) {
+        return this.mutedActions.contains(action);
+    }
+
+    public void updateMutedActions(final Set<String> mutedActions) {
+        this.mutedActions = ImmutableSet.copyOf(mutedActions);
+    }
+
+    public Set<String> getMutedActions() {
+        return this.mutedActions;
+    }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/spec/RcaSpecTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/spec/RcaSpecTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -46,222 +46,220 @@ import org.junit.experimental.categories.Category;
 @Category(GradleTaskForRca.class)
 public class RcaSpecTests {
 
-  @Before
-  public void cleanup() {
-    Stats.getInstance().reset();
-    Stats.clear();
-  }
-
-  @Test
-  public void testCreation() {
-
-    class SymptomX extends Symptom {
-      SymptomX(long evaluationIntervalMins) {
-        super(evaluationIntervalMins);
-      }
-
-      @Override
-      public SymptomFlowUnit operate() {
-        return SymptomFlowUnit.generic();
-      }
+    @Before
+    public void cleanup() {
+        Stats.getInstance().reset();
+        Stats.clear();
     }
 
-    class RcaX extends Rca {
-      RcaX() {
-        super(5);
-      }
+    @Test
+    public void testCreation() {
 
-      @Override
-      public ResourceFlowUnit operate() {
-        return ResourceFlowUnit.generic();
-      }
+        class SymptomX extends Symptom {
+            SymptomX(long evaluationIntervalMins) {
+                super(evaluationIntervalMins);
+            }
 
-      @Override
-      public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {
-      }
+            @Override
+            public SymptomFlowUnit operate() {
+                return SymptomFlowUnit.generic();
+            }
+        }
+
+        class RcaX extends Rca {
+            RcaX() {
+                super(5);
+            }
+
+            @Override
+            public ResourceFlowUnit operate() {
+                return ResourceFlowUnit.generic();
+            }
+
+            @Override
+            public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {}
+        }
+
+        class AnalysisGraphX extends AnalysisGraph {
+            @Override
+            public void construct() {
+                Metric metric1 = new CPU_Utilization(5);
+                addLeaf(metric1);
+
+                SymptomX symptom = new SymptomX(5);
+
+                List<Node<?>> lsym = new ArrayList<>();
+                lsym.add(metric1);
+                symptom.addAllUpstreams(lsym);
+
+                RcaX rca = new RcaX();
+                lsym = new ArrayList<>();
+                lsym.add(symptom);
+                rca.addAllUpstreams(lsym);
+            }
+        }
+
+        AnalysisGraphX fieldx = new AnalysisGraphX();
+        fieldx.construct();
     }
 
-    class AnalysisGraphX extends AnalysisGraph {
-      @Override
-      public void construct() {
-        Metric metric1 = new CPU_Utilization(5);
-        addLeaf(metric1);
-
-        SymptomX symptom = new SymptomX(5);
-
-        List<Node<?>> lsym = new ArrayList<>();
-        lsym.add(metric1);
-        symptom.addAllUpstreams(lsym);
-
-        RcaX rca = new RcaX();
-        lsym = new ArrayList<>();
-        lsym.add(symptom);
-        rca.addAllUpstreams(lsym);
-      }
+    @Test
+    public void testElastiSearchAnalysisFlowField() {
+        ElasticSearchAnalysisGraph field = new ElasticSearchAnalysisGraph();
+        field.construct();
     }
 
-    AnalysisGraphX fieldx = new AnalysisGraphX();
-    fieldx.construct();
-  }
-
-  @Test
-  public void testElastiSearchAnalysisFlowField() {
-    ElasticSearchAnalysisGraph field = new ElasticSearchAnalysisGraph();
-    field.construct();
-  }
-
-  // @Test(expected = RuntimeException.class)
-  public void testAddToFlowFieldBeforeAddingAsDependency() {
-    Metric heapUsed = new Heap_Used(5);
-    HighHeapUsageOldGenRca highHeapUsageOldGenRca = new HighHeapUsageOldGenRca(1, heapUsed, null, null, null);
-    highHeapUsageOldGenRca.addAllUpstreams(Collections.singletonList(heapUsed));
-  }
-
-  @Test
-  public void testGraphId() {
-    class TestMetric1 extends Metric {
-
-      TestMetric1() {
-        super("test-metric1", 5);
-      }
+    // @Test(expected = RuntimeException.class)
+    public void testAddToFlowFieldBeforeAddingAsDependency() {
+        Metric heapUsed = new Heap_Used(5);
+        HighHeapUsageOldGenRca highHeapUsageOldGenRca =
+                new HighHeapUsageOldGenRca(1, heapUsed, null, null, null);
+        highHeapUsageOldGenRca.addAllUpstreams(Collections.singletonList(heapUsed));
     }
 
-    class TestMetric2 extends Metric {
+    @Test
+    public void testGraphId() {
+        class TestMetric1 extends Metric {
 
-      TestMetric2() {
-        super("test-metric2", 5);
-      }
-    }
+            TestMetric1() {
+                super("test-metric1", 5);
+            }
+        }
 
-    class TestMetric3 extends Metric {
+        class TestMetric2 extends Metric {
 
-      TestMetric3() {
-        super("test-metric3", 5);
-      }
-    }
+            TestMetric2() {
+                super("test-metric2", 5);
+            }
+        }
 
-    class TestMetric4 extends Metric {
+        class TestMetric3 extends Metric {
 
-      TestMetric4() {
-        super("test-metric4", 5);
-      }
-    }
+            TestMetric3() {
+                super("test-metric3", 5);
+            }
+        }
 
-    class TestMetric5 extends Metric {
+        class TestMetric4 extends Metric {
 
-      TestMetric5() {
-        super("test-metric5", 5);
-      }
-    }
+            TestMetric4() {
+                super("test-metric4", 5);
+            }
+        }
 
-    class TestSymptom1 extends Symptom {
+        class TestMetric5 extends Metric {
 
-      TestSymptom1() {
-        super(1);
-      }
+            TestMetric5() {
+                super("test-metric5", 5);
+            }
+        }
 
-      @Override
-      public SymptomFlowUnit operate() {
-        return null;
-      }
-    }
+        class TestSymptom1 extends Symptom {
 
-    class TestSymptom2 extends Symptom {
+            TestSymptom1() {
+                super(1);
+            }
 
-      TestSymptom2() {
-        super(1);
-      }
+            @Override
+            public SymptomFlowUnit operate() {
+                return null;
+            }
+        }
 
-      @Override
-      public SymptomFlowUnit operate() {
-        return null;
-      }
-    }
+        class TestSymptom2 extends Symptom {
 
-    class TestSymptom3 extends Symptom {
+            TestSymptom2() {
+                super(1);
+            }
 
-      TestSymptom3() {
-        super(1);
-      }
+            @Override
+            public SymptomFlowUnit operate() {
+                return null;
+            }
+        }
 
-      @Override
-      public SymptomFlowUnit operate() {
-        return null;
-      }
-    }
+        class TestSymptom3 extends Symptom {
 
-    class TestRCA1 extends Rca {
+            TestSymptom3() {
+                super(1);
+            }
 
-      TestRCA1() {
-        super(5);
-      }
+            @Override
+            public SymptomFlowUnit operate() {
+                return null;
+            }
+        }
 
-      @Override
-      public ResourceFlowUnit operate() {
-        return null;
-      }
+        class TestRCA1 extends Rca {
 
-      @Override
-      public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {
-      }
-    }
+            TestRCA1() {
+                super(5);
+            }
 
-    class TestRCA2 extends Rca {
+            @Override
+            public ResourceFlowUnit operate() {
+                return null;
+            }
 
-      TestRCA2() {
-        super(5);
-      }
+            @Override
+            public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {}
+        }
 
-      @Override
-      public ResourceFlowUnit operate() {
-        return null;
-      }
+        class TestRCA2 extends Rca {
 
-      @Override
-      public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {
-      }
-    }
+            TestRCA2() {
+                super(5);
+            }
 
-    class TestRCA3 extends Rca {
+            @Override
+            public ResourceFlowUnit operate() {
+                return null;
+            }
 
-      TestRCA3() {
-        super(2);
-      }
+            @Override
+            public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {}
+        }
 
-      @Override
-      public ResourceFlowUnit operate() {
-        return null;
-      }
+        class TestRCA3 extends Rca {
 
-      @Override
-      public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {
-      }
-    }
+            TestRCA3() {
+                super(2);
+            }
 
-    class TestGraph extends AnalysisGraph {
+            @Override
+            public ResourceFlowUnit operate() {
+                return null;
+            }
 
-      @Override
-      public void construct() {
-        Metric m1 = new TestMetric1();
-        Metric m2 = new TestMetric2();
-        Metric m3 = new TestMetric3();
-        Metric m4 = new TestMetric4();
-        Metric m5 = new TestMetric5();
+            @Override
+            public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {}
+        }
 
-        Symptom s1 = new TestSymptom1();
-        Symptom s2 = new TestSymptom2();
-        Symptom s3 = new TestSymptom3();
+        class TestGraph extends AnalysisGraph {
 
-        Rca r1 = new TestRCA1();
-        Rca r2 = new TestRCA2();
-        Rca r3 = new TestRCA3();
+            @Override
+            public void construct() {
+                Metric m1 = new TestMetric1();
+                Metric m2 = new TestMetric2();
+                Metric m3 = new TestMetric3();
+                Metric m4 = new TestMetric4();
+                Metric m5 = new TestMetric5();
 
-        addLeaf(m1);
-        addLeaf(m2);
-        addLeaf(m3);
-        addLeaf(m4);
-        addLeaf(m5);
+                Symptom s1 = new TestSymptom1();
+                Symptom s2 = new TestSymptom2();
+                Symptom s3 = new TestSymptom3();
 
+                Rca r1 = new TestRCA1();
+                Rca r2 = new TestRCA2();
+                Rca r3 = new TestRCA3();
+
+                addLeaf(m1);
+                addLeaf(m2);
+                addLeaf(m3);
+                addLeaf(m4);
+                addLeaf(m5);
+
+                // spotless:off
         /*
            m1      m2      m3    m4      m5
             \     /       /      /        |
@@ -275,62 +273,66 @@ public class RcaSpecTests {
                      \   /
                       r2
         */
+        // spotless:on
 
-        s1.addAllUpstreams(Arrays.asList(m1, m2));
-        s2.addAllUpstreams(Arrays.asList(s1, m3));
-        r1.addAllUpstreams(Collections.singletonList(s2));
-        r2.addAllUpstreams(Arrays.asList(r1, m4));
+                s1.addAllUpstreams(Arrays.asList(m1, m2));
+                s2.addAllUpstreams(Arrays.asList(s1, m3));
+                r1.addAllUpstreams(Collections.singletonList(s2));
+                r2.addAllUpstreams(Arrays.asList(r1, m4));
 
-        s3.addAllUpstreams(Collections.singletonList(m5));
-        r3.addAllUpstreams(Collections.singletonList(s3));
-      }
+                s3.addAllUpstreams(Collections.singletonList(m5));
+                r3.addAllUpstreams(Collections.singletonList(s3));
+            }
+        }
+
+        AnalysisGraph field = new TestGraph();
+        field.construct();
+        field.validateAndProcess();
+
+        Stats stats = Stats.getInstance();
+
+        assertEquals(2, stats.getGraphsCount());
+        assertEquals(11, stats.getTotalNodesCount());
+        assertEquals(5, stats.getLeafNodesCount());
+        assertEquals(5, stats.getLeavesAddedToAnalysisFlowField());
+
+        List<List<String>> expectedG1 =
+                Arrays.asList(
+                        Arrays.asList("TestMetric1", "TestMetric2", "TestMetric3", "TestMetric4"),
+                        Collections.singletonList("TestSymptom1"),
+                        Collections.singletonList("TestSymptom2"),
+                        Collections.singletonList("TestRCA1"),
+                        Collections.singletonList("TestRCA2"));
+
+        List<List<String>> expectedG2 =
+                Arrays.asList(
+                        Collections.singletonList("TestMetric5"),
+                        Collections.singletonList("TestSymptom3"),
+                        Collections.singletonList("TestRCA3"));
+
+        int idx1 = 0;
+        for (ConnectedComponent g : stats.getConnectedComponents()) {
+            List<List<String>> expected;
+            if (0 == idx1) {
+                expected = expectedG1;
+            } else {
+                expected = expectedG2;
+            }
+            int idx2 = 0;
+            for (List<Node<?>> parallelExecutables : g.getAllNodesByDependencyOrder()) {
+                parallelExecutables.sort(
+                        (o1, o2) ->
+                                o1.getClass()
+                                        .getSimpleName()
+                                        .compareTo(o2.getClass().getSimpleName()));
+                List<String> actual =
+                        parallelExecutables.stream()
+                                .map(n -> n.getClass().getSimpleName())
+                                .collect(Collectors.toList());
+                assertThat(actual, is(expected.get(idx2)));
+                ++idx2;
+            }
+            ++idx1;
+        }
     }
-
-    AnalysisGraph field = new TestGraph();
-    field.construct();
-    field.validateAndProcess();
-
-    Stats stats = Stats.getInstance();
-
-    assertEquals(2, stats.getGraphsCount());
-    assertEquals(11, stats.getTotalNodesCount());
-    assertEquals(5, stats.getLeafNodesCount());
-    assertEquals(5, stats.getLeavesAddedToAnalysisFlowField());
-
-    List<List<String>> expectedG1 =
-        Arrays.asList(
-            Arrays.asList("TestMetric1", "TestMetric2", "TestMetric3", "TestMetric4"),
-            Collections.singletonList("TestSymptom1"),
-            Collections.singletonList("TestSymptom2"),
-            Collections.singletonList("TestRCA1"),
-            Collections.singletonList("TestRCA2"));
-
-    List<List<String>> expectedG2 =
-        Arrays.asList(
-            Collections.singletonList("TestMetric5"),
-            Collections.singletonList("TestSymptom3"),
-            Collections.singletonList("TestRCA3"));
-
-    int idx1 = 0;
-    for (ConnectedComponent g : stats.getConnectedComponents()) {
-      List<List<String>> expected;
-      if (0 == idx1) {
-        expected = expectedG1;
-      } else {
-        expected = expectedG2;
-      }
-      int idx2 = 0;
-      for (List<Node<?>> parallelExecutables : g.getAllNodesByDependencyOrder()) {
-        parallelExecutables.sort(
-            (o1, o2) -> o1.getClass().getSimpleName().compareTo(o2.getClass().getSimpleName()));
-        List<String> actual =
-            parallelExecutables.stream()
-                .map(n -> n.getClass().getSimpleName())
-                .collect(Collectors.toList());
-        assertThat(actual, is(expected.get(idx2)));
-        ++idx2;
-      }
-      ++idx1;
-    }
-  }
 }


### PR DESCRIPTION
This PR adds code formatting rules to the spotless plugin configuration and adds the `spotlessApply` target as a dependency of the `compileJava` target. This means that source files will be automatically formatted during the compilation step.

The plugin is configured to "ratchet from" the main github branch. This means that code formatting will only be applied to source files that are touched in a given PR. This is to avoid creating a huge PR by reformatting every Java file at once. In order to demonstrate the plugin in this PR I triggered formatting for two source files only.

In addition to configuring spotless, this PR updates the github action to track the 'main' branch, and adds a new spotbugs violation to our filter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
