### PR TITLE
Code changes to read shard indexing pressure metrics and put in metricsDb

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/AllMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/AllMetrics.java
@@ -41,7 +41,8 @@ public class AllMetrics {
     THREAD_POOL,
     SHARD_STATS,
     MASTER_PENDING,
-    MOUNTED_PARTITION_METRICS
+    MOUNTED_PARTITION_METRICS,
+    SHARD_INDEXING_PRESSURE
   }
 
   // we don't store node details as a metric on reader side database.  We
@@ -1313,6 +1314,81 @@ public class AllMetrics {
 
     public static class Constants {
       public static final String SHARD_STATE = "Shard_State";
+    }
+  }
+
+  public enum ShardIndexingPressureNodeRoleType {
+    COORDINATING(Constants.COORDINATING_VALUE),
+    PRIMARY(Constants.PRIMARY_VALUE),
+    REPLICA(Constants.REPLICA_VALUE);
+
+    private final String value;
+
+    ShardIndexingPressureNodeRoleType(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return value;
+    }
+
+    public static class Constants {
+      public static final String COORDINATING_VALUE = "Coordinating";
+      public static final String PRIMARY_VALUE = "Primary";
+      public static final String REPLICA_VALUE = "Replica";
+    }
+  }
+
+  public enum ShardIndexingPressureDimension implements  MetricDimension {
+    NODE_ROLE(Constants.NODE_ROLE_VALUE),
+    INDEX_NAME(Constants.INDEX_NAME_VALUE),
+    SHARD_ID(Constants.SHARD_ID_VALUE);
+
+    private final String value;
+
+    ShardIndexingPressureDimension(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return value;
+    }
+
+    public static class Constants {
+      public static final String NODE_ROLE_VALUE = "NodeRole";
+      public static final String INDEX_NAME_VALUE = "IndexName";
+      public static final String SHARD_ID_VALUE = "ShardId";
+    }
+  }
+
+  public enum ShardIndexingPressureValue implements MetricValue {
+    IS_ACTIVE_SHARD(Constants.IS_ACTIVE_SHARD),
+    REJECTION_COUNT(Constants.REJECTION_COUNT_VALUE),
+    CURRENT_BYTES(Constants.CURRENT_BYTES),
+    CURRENT_LIMITS(Constants.CURRENT_LIMITS),
+    AVERAGE_WINDOW_THROUGHPUT(Constants.AVERAGE_WINDOW_THROUGHPUT),
+    LAST_SUCCESSFUL_TIMESTAMP(Constants.LAST_SUCCESSFUL_TIMESTAMP);
+
+    private final String value;
+
+    ShardIndexingPressureValue(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return value;
+    }
+
+    public static class Constants {
+      public static final String IS_ACTIVE_SHARD = "IsActiveShard";
+      public static final String REJECTION_COUNT_VALUE = "Rejection_Count";
+      public static final String CURRENT_BYTES = "Current_Bytes";
+      public static final String CURRENT_LIMITS = "Current_Limits";
+      public static final String AVERAGE_WINDOW_THROUGHPUT = "Average_Window_Throughput";
+      public static final String LAST_SUCCESSFUL_TIMESTAMP = "Last_Successful_Timestamp";
     }
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/AllMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/AllMetrics.java
@@ -1317,14 +1317,15 @@ public class AllMetrics {
     }
   }
 
-  public enum ShardIndexingPressureNodeRoleType {
+  /** Enumeration of the indexing stages. */
+  public enum IndexingStage {
     COORDINATING(Constants.COORDINATING_VALUE),
     PRIMARY(Constants.PRIMARY_VALUE),
     REPLICA(Constants.REPLICA_VALUE);
 
     private final String value;
 
-    ShardIndexingPressureNodeRoleType(String value) {
+    IndexingStage(String value) {
       this.value = value;
     }
 
@@ -1340,8 +1341,9 @@ public class AllMetrics {
     }
   }
 
+  /** Enumeration of the Shard Indexing Pressure Dimension*/
   public enum ShardIndexingPressureDimension implements  MetricDimension {
-    NODE_ROLE(Constants.NODE_ROLE_VALUE),
+    INDEXING_STAGE(Constants.INDEXING_STAGE),
     INDEX_NAME(Constants.INDEX_NAME_VALUE),
     SHARD_ID(Constants.SHARD_ID_VALUE);
 
@@ -1357,14 +1359,29 @@ public class AllMetrics {
     }
 
     public static class Constants {
-      public static final String NODE_ROLE_VALUE = "NodeRole";
+      public static final String INDEXING_STAGE = "IndexingStage";
       public static final String INDEX_NAME_VALUE = "IndexName";
       public static final String SHARD_ID_VALUE = "ShardId";
     }
   }
 
+  /**
+   * Column names of Rejection_Count table
+   * NodeRole | IndexName | ShardID | sum | avg | min |max
+   * Column names of Current_Bytes table
+   * NodeRole | IndexName | ShardID | sum | avg | min |max
+   * Column names of Current_Limits table
+   * NodeRole | IndexName | ShardID | sum | avg | min |max
+   * Column names of Average_Window_Throughput table
+   * NodeRole | IndexName | ShardID | sum | avg | min |max
+   * Column names of Last_Successful_Timestamp table
+   * NodeRole | IndexName | ShardID | sum | avg | min |max
+   *
+   * <p>Example:
+   * Coordinating|pmc|4|1.0|1.0|1.0|1.0
+   * Primary|pmc|2|1.0|1.0|1.0|1.0
+   */
   public enum ShardIndexingPressureValue implements MetricValue {
-    IS_ACTIVE_SHARD(Constants.IS_ACTIVE_SHARD),
     REJECTION_COUNT(Constants.REJECTION_COUNT_VALUE),
     CURRENT_BYTES(Constants.CURRENT_BYTES),
     CURRENT_LIMITS(Constants.CURRENT_LIMITS),
@@ -1383,12 +1400,11 @@ public class AllMetrics {
     }
 
     public static class Constants {
-      public static final String IS_ACTIVE_SHARD = "IsActiveShard";
-      public static final String REJECTION_COUNT_VALUE = "Rejection_Count";
-      public static final String CURRENT_BYTES = "Current_Bytes";
-      public static final String CURRENT_LIMITS = "Current_Limits";
-      public static final String AVERAGE_WINDOW_THROUGHPUT = "Average_Window_Throughput";
-      public static final String LAST_SUCCESSFUL_TIMESTAMP = "Last_Successful_Timestamp";
+      public static final String REJECTION_COUNT_VALUE = "Indexing_Pressure_Rejection_Count";
+      public static final String CURRENT_BYTES = "Indexing_Pressure_Current_Bytes";
+      public static final String CURRENT_LIMITS = "Indexing_Pressure_Current_Limits";
+      public static final String AVERAGE_WINDOW_THROUGHPUT = "Indexing_Pressure_Average_Window_Throughput";
+      public static final String LAST_SUCCESSFUL_TIMESTAMP = "Indexing_Pressure_Last_Successful_Timestamp";
     }
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
@@ -56,6 +56,7 @@ public class PerformanceAnalyzerMetrics {
   public static final String sIPPath = "ip_metrics";
   public static final String sGcInfoPath = "gc_info";
   public static final String sMountedPartitionMetricsPath = "mounted_part_space";
+  public static final String sShardIndexingPressurePath = "shard_indexing_pressure_metrics";
   public static final String sKeyValueDelimitor = ":";
   public static final String sMetricNewLineDelimitor = System.getProperty("line.separator");
   public static final String START_FILE_NAME = "start";

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/model/MetricsModel.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/model/MetricsModel.java
@@ -374,6 +374,24 @@ public class MetricsModel {
         new MetricAttributes(
             MetricUnits.COUNT.toString(), AllMetrics.ShardStateDimension.values()));
 
+    // Shard Indexing Pressure Metrics
+    allMetricsInitializer.put(
+        AllMetrics.ShardIndexingPressureValue.REJECTION_COUNT.toString(),
+        new MetricAttributes(MetricUnits.COUNT.toString(), AllMetrics.ShardIndexingPressureDimension.values()));
+    allMetricsInitializer.put(
+        AllMetrics.ShardIndexingPressureValue.CURRENT_BYTES.toString(),
+        new MetricAttributes(MetricUnits.BYTE.toString(), AllMetrics.ShardIndexingPressureDimension.values()));
+    allMetricsInitializer.put(
+        AllMetrics.ShardIndexingPressureValue.CURRENT_LIMITS.toString(),
+        new MetricAttributes(MetricUnits.BYTE.toString(), AllMetrics.ShardIndexingPressureDimension.values()));
+    allMetricsInitializer.put(
+        AllMetrics.ShardIndexingPressureValue.AVERAGE_WINDOW_THROUGHPUT.toString(),
+        new MetricAttributes(MetricUnits.COUNT_PER_SEC.toString(), AllMetrics.ShardIndexingPressureDimension.values()));
+    allMetricsInitializer.put(
+        AllMetrics.ShardIndexingPressureValue.LAST_SUCCESSFUL_TIMESTAMP.toString(),
+        new MetricAttributes(MetricUnits.MILLISECOND.toString(), AllMetrics.ShardIndexingPressureDimension.values()));
+
+
     ALL_METRICS = Collections.unmodifiableMap(allMetricsInitializer);
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MetricPropertiesConfig.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MetricPropertiesConfig.java
@@ -168,6 +168,7 @@ public final class MetricPropertiesConfig {
     metricPathMap.put(MetricName.MASTER_PENDING, PerformanceAnalyzerMetrics.sPendingTasksPath);
     metricPathMap.put(MetricName.MOUNTED_PARTITION_METRICS,
         PerformanceAnalyzerMetrics.sMountedPartitionMetricsPath);
+    metricPathMap.put(MetricName.SHARD_INDEXING_PRESSURE, PerformanceAnalyzerMetrics.sShardIndexingPressurePath);
 
     eventKeyToMetricNameMap = new HashMap<>();
     eventKeyToMetricNameMap.put(PerformanceAnalyzerMetrics.sCacheConfigPath, MetricName.CACHE_CONFIG);
@@ -183,6 +184,7 @@ public final class MetricPropertiesConfig {
         PerformanceAnalyzerMetrics.sPendingTasksPath, MetricName.MASTER_PENDING);
     eventKeyToMetricNameMap.put(PerformanceAnalyzerMetrics.sMountedPartitionMetricsPath,
         MetricName.MOUNTED_PARTITION_METRICS);
+    eventKeyToMetricNameMap.put(PerformanceAnalyzerMetrics.sShardIndexingPressurePath, MetricName.SHARD_INDEXING_PRESSURE);
 
     metricName2Property = new HashMap<>();
 
@@ -250,6 +252,12 @@ public final class MetricPropertiesConfig {
             DevicePartitionValue.values(),
             createFileHandler(metricPathMap.get(MetricName.MOUNTED_PARTITION_METRICS))
         ));
+    metricName2Property.put(
+        MetricName.SHARD_INDEXING_PRESSURE,
+        new MetricProperties(
+            AllMetrics.ShardIndexingPressureDimension.values(),
+            AllMetrics.ShardIndexingPressureValue.values(),
+            createFileHandler(metricPathMap.get(MetricName.SHARD_INDEXING_PRESSURE))));
   }
 
   public static MetricPropertiesConfig getInstance() {


### PR DESCRIPTION
*Fixes #:* #561

*Related PR:* [PR 278](https://github.com/opendistro-for-elasticsearch/performance-analyzer/pull/278)

*Description of changes:*
Code changes to read the metrics from shared location and put it in metrics db.

*Tests:*
Shared location
```
^shard_indexing_pressure_metrics
{"current_time":1614085632612}
{"NodeRole":"Coordinating","IndexName":"index_name","ShardId":"3","Rejection_Count":0,"Current_Bytes":0,"Current_Limits":427753,"Average_Window_Throughput":85.99631367388736,"Last_Successful_Timestamp":1614085514350}
{"NodeRole":"Primary","IndexName":"index_name","ShardId":"3","Rejection_Count":0,"Current_Bytes":0,"Current_Limits":427753,"Average_Window_Throughput":0.0,"Last_Successful_Timestamp":0}
{"NodeRole":"Replica","IndexName":"index_name","ShardId":"3","Rejection_Count":0,"Current_Bytes":0,"Current_Limits":641629,"Average_Window_Throughput":0.0,"Last_Successful_Timestamp":0}
{"current_time":1614085632612}
{"NodeRole":"Coordinating","IndexName":"index_name","ShardId":"4","Rejection_Count":0,"Current_Bytes":0,"Current_Limits":427753,"Average_Window_Throughput":76.3751761482247,"Last_Successful_Timestamp":1614085514942}
{"NodeRole":"Primary","IndexName":"index_name","ShardId":"4","Rejection_Count":0,"Current_Bytes":0,"Current_Limits":427753,"Average_Window_Throughput":0.0,"Last_Successful_Timestamp":0}
{"NodeRole":"Replica","IndexName":"index_name","ShardId":"4","Rejection_Count":0,"Current_Bytes":0,"Current_Limits":641629,"Average_Window_Throughput":0.0,"Last_Successful_Timestamp":0}
{"current_time":1614085632612}
{"NodeRole":"Coordinating","IndexName":".kibana_1","ShardId":"0","Rejection_Count":0,"Current_Bytes":0,"Current_Limits":427753,"Average_Window_Throughput":0.0,"Last_Successful_Timestamp":0}
{"NodeRole":"Primary","IndexName":".kibana_1","ShardId":"0","Rejection_Count":0,"Current_Bytes":0,"Current_Limits":427753,"Average_Window_Throughput":0.1838103756708408,"Last_Successful_Timestamp":1614085024645}
{"NodeRole":"Replica","IndexName":".kibana_1","ShardId":"0","Rejection_Count":0,"Current_Bytes":0,"Current_Limits":641629,"Average_Window_Throughput":0.0,"Last_Successful_Timestamp":0}
{"current_time":1614085632612}
{"NodeRole":"Coordinating","IndexName":"index_name","ShardId":"0","Rejection_Count":0,"Current_Bytes":0,"Current_Limits":427753,"Average_Window_Throughput":57.36497399955767,"Last_Successful_Timestamp":1614085514339}
{"NodeRole":"Primary","IndexName":"index_name","ShardId":"0","Rejection_Count":0,"Current_Bytes":0,"Current_Limits":427753,"Average_Window_Throughput":0.0,"Last_Successful_Timestamp":0}
{"NodeRole":"Replica","IndexName":"index_name","ShardId":"0","Rejection_Count":0,"Current_Bytes":0,"Current_Limits":641629,"Average_Window_Throughput":0.0,"Last_Successful_Timestamp":0}
{"current_time":1614085632612}
{"NodeRole":"Coordinating","IndexName":"index_name","ShardId":"1","Rejection_Count":0,"Current_Bytes":0,"Current_Limits":427753,"Average_Window_Throughput":42.35938401845564,"Last_Successful_Timestamp":1614085514920}
{"NodeRole":"Primary","IndexName":"index_name","ShardId":"1","Rejection_Count":0,"Current_Bytes":0,"Current_Limits":427753,"Average_Window_Throughput":0.0,"Last_Successful_Timestamp":0}
{"NodeRole":"Replica","IndexName":"index_name","ShardId":"1","Rejection_Count":0,"Current_Bytes":0,"Current_Limits":641629,"Average_Window_Throughput":0.0,"Last_Successful_Timestamp":0}
{"current_time":1614085632612}
{"NodeRole":"Coordinating","IndexName":"index_name","ShardId":"2","Rejection_Count":0,"Current_Bytes":0,"Current_Limits":427753,"Average_Window_Throughput":51.93470687300152,"Last_Successful_Timestamp":1614085514936}
{"NodeRole":"Primary","IndexName":"index_name","ShardId":"2","Rejection_Count":0,"Current_Bytes":0,"Current_Limits":427753,"Average_Window_Throughput":0.0,"Last_Successful_Timestamp":0}
{"NodeRole":"Replica","IndexName":"index_name","ShardId":"2","Rejection_Count":0,"Current_Bytes":0,"Current_Limits":641629,"Average_Window_Throughput":0.48856209150326796,"Last_Successful_Timestamp":1614085514935}
```

New Tables
```
% sqlite3 metricsdb_1614072880000
SQLite version 3.7.17 2013-05-20 00:56:22
Enter ".help" for instructions
Enter SQL statements terminated with a ";"
sqlite> .tables              
Indexing_Pressure_Average_Window_Throughput          Indexing_Pressure_Last_Successful_Timestamp                                              
Indexing_Pressure_Current_Bytes                      Indexing_Pressure_Current_Limits                     
Indexing_Pressure_Rejection_Count                   
```

Sample information persisted in one of the table
```
sqlite> select * from Indexing_Pressure_Last_Successful_Timestamp;
Coordinating|.kibana_1|0|0.0|0.0|0.0|0.0
Coordinating|index_name|0|1614085366310.0|1614085366310.0|1614085366310.0|1614085366310.0
Coordinating|index_name|1|1614085309874.0|1614085309874.0|1614085309874.0|1614085309874.0
Coordinating|index_name|2|1614085309897.0|1614085309897.0|1614085309897.0|1614085309897.0
Coordinating|index_name|3|1614085366322.0|1614085366322.0|1614085366322.0|1614085366322.0
Coordinating|index_name|4|1614085309868.0|1614085309868.0|1614085309868.0|1614085309868.0
Primary|.kibana_1|0|1614085024645.0|1614085024645.0|1614085024645.0|1614085024645.0
Primary|index_name|0|0.0|0.0|0.0|0.0
Primary|index_name|1|0.0|0.0|0.0|0.0
Primary|index_name|2|0.0|0.0|0.0|0.0
Primary|index_name|3|0.0|0.0|0.0|0.0
Primary|index_name|4|0.0|0.0|0.0|0.0
Replica|.kibana_1|0|0.0|0.0|0.0|0.0
Replica|index_name|0|0.0|0.0|0.0|0.0
Replica|index_name|1|0.0|0.0|0.0|0.0
Replica|index_name|2|1614085309895.0|1614085309895.0|1614085309895.0|1614085309895.0
Replica|index_name|3|0.0|0.0|0.0|0.0
Replica|index_name|4|0.0|0.0|0.0|0.0
```


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
