### PR TITLE
Only emit modify cache actions if the cache actual usage is above lower bound

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/persist/SQLParsingUtil.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/persist/SQLParsingUtil.java
@@ -83,4 +83,23 @@ public class SQLParsingUtil {
     }
     return ret;
   }
+
+  /**
+   * Sums up the SUM field of all tuples in the SQL result
+   * @param records the record result from SQL query
+   * @return sum value
+   */
+  public static Double readSumFromSqlResult(final Result<Record> records) {
+    if (records == null) {
+      LOG.error("sql result is null");
+      return Double.NaN;
+    }
+    double size = 0;
+    // since the flow unit data is aggregated by index, summing the size across indices
+    if (records.size() > 0) {
+      size = records.stream().mapToDouble(
+          record -> record.getValue(MetricsDB.SUM, Double.class)).sum();
+    }
+    return size;
+  }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/ResourceUtil.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/summaries/ResourceUtil.java
@@ -89,6 +89,9 @@ public class ResourceUtil {
   public static final Resource FIELD_DATA_CACHE_MAX_SIZE = Resource.newBuilder()
           .setResourceEnum(ResourceEnum.FIELD_DATA_CACHE)
           .setMetricEnum(MetricEnum.CACHE_MAX_SIZE).build();
+  public static final Resource FIELD_DATA_CACHE_ACTUAL_SIZE = Resource.newBuilder()
+          .setResourceEnum(ResourceEnum.FIELD_DATA_CACHE)
+          .setMetricEnum(MetricEnum.CACHE_ACTUAL_SIZE).build();
   public static final Resource SHARD_REQUEST_CACHE_EVICTION = Resource.newBuilder()
           .setResourceEnum(ResourceEnum.SHARD_REQUEST_CACHE)
           .setMetricEnum(MetricEnum.CACHE_EVICTION).build();
@@ -98,6 +101,9 @@ public class ResourceUtil {
   public static final Resource SHARD_REQUEST_CACHE_MAX_SIZE = Resource.newBuilder()
           .setResourceEnum(ResourceEnum.SHARD_REQUEST_CACHE)
           .setMetricEnum(MetricEnum.CACHE_MAX_SIZE).build();
+  public static final Resource SHARD_REQUEST_CACHE_ACTUAL_SIZE = Resource.newBuilder()
+          .setResourceEnum(ResourceEnum.SHARD_REQUEST_CACHE)
+          .setMetricEnum(MetricEnum.CACHE_ACTUAL_SIZE).build();
 
   /**
    * Read the resourceType name from the ResourceType object

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/util/NodeConfigCacheReaderUtil.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/util/NodeConfigCacheReaderUtil.java
@@ -55,6 +55,19 @@ public class NodeConfigCacheReaderUtil {
     return null;
   }
 
+  public static Long readCacheActualSizeInBytes(
+      final NodeConfigCache nodeConfigCache, final NodeKey esNode, final ResourceEnum cacheType) {
+    try {
+      if (cacheType.equals(ResourceEnum.FIELD_DATA_CACHE)) {
+        return (long) nodeConfigCache.get(esNode, ResourceUtil.FIELD_DATA_CACHE_ACTUAL_SIZE);
+      }
+      return (long) nodeConfigCache.get(esNode, ResourceUtil.SHARD_REQUEST_CACHE_ACTUAL_SIZE);
+    } catch (final IllegalArgumentException e) {
+      LOG.error("Exception while reading cache actual size from Node Config Cache", e);
+    }
+    return null;
+  }
+
   public static Long readHeapMaxSizeInBytes(
       final NodeConfigCache nodeConfigCache, final NodeKey esNode) {
     try {

--- a/src/main/proto/inter_node_rpc_service.proto
+++ b/src/main/proto/inter_node_rpc_service.proto
@@ -98,6 +98,7 @@ enum MetricEnum {
   CACHE_EVICTION = 10 [(additional_fields).name = "cache eviction", (additional_fields).description = "cache eviction count"];
   CACHE_HIT = 11 [(additional_fields).name = "cache hit", (additional_fields).description = "cache hit count"];
   CACHE_MAX_SIZE = 12 [(additional_fields).name = "cache max size", (additional_fields).description = "max cache size in bytes"];
+  CACHE_ACTUAL_SIZE = 13 [(additional_fields).name = "cache actual size", (additional_fields).description = "cache actual size in bytes"];
 
   // Heap
   HEAP_MAX = 16 [(additional_fields).name = "heap max", (additional_fields).description = "max heap size in bytes"];

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/collector/NodeConfigClusterCollectorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/store/collector/NodeConfigClusterCollectorTest.java
@@ -39,7 +39,7 @@ public class NodeConfigClusterCollectorTest {
 
   @Before
   public void init() {
-    collector = new NodeConfigCollector(1, null, null, null);
+    collector = new NodeConfigCollector(1, null, null, null, null, null);
     clusterCollector = new NodeConfigClusterCollector(collector);
     observer = new RcaTestHelper<>();
     AppContext appContext = new AppContext();


### PR DESCRIPTION
*Fixes #:*

*Description of changes:*
Modify cache actions nowadays will reduce cache max capacity regardless of the actual usage of each cache. This will make users confused if they receive notices on cache actions being published but does not use i.e. fielddata cache at all. 
So this PR will Take cache actual size into consideration and only emit modify cache actions if the cache actual usage is above lower bound

*Tests:*
testing in progress

*If new tests are added, how long do the new ones take to complete*

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
