### PR TITLE
Threads blocked trying to attach to the JVM

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/PerformanceAnalyzerMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/PerformanceAnalyzerMetricsCollector.java
@@ -22,16 +22,30 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public abstract class PerformanceAnalyzerMetricsCollector implements Runnable {
+  enum State {
+    HEALTHY,
+
+    // This collector could not complete between two runs of
+    // ScheduledMetricCollectorsExecutor. First occurrence of
+    // this is considered a warning.
+    SLOW,
+
+    // A collector is muted if it failed to complete between two runs of
+    // ScheduledMetricCollectorsExecutor. A muted collector is skipped.
+    MUTED
+  }
   private static final Logger LOG = LogManager.getLogger(PerformanceAnalyzerMetricsCollector.class);
   private int timeInterval;
   private long startTime;
   private String collectorName;
   protected StringBuilder value;
+  protected State state;
 
   protected PerformanceAnalyzerMetricsCollector(int timeInterval, String collectorName) {
     this.timeInterval = timeInterval;
     this.collectorName = collectorName;
     this.value = new StringBuilder();
+    this.state = State.HEALTHY;
   }
 
   private AtomicBoolean bInProgress = new AtomicBoolean(false);
@@ -75,5 +89,13 @@ public abstract class PerformanceAnalyzerMetricsCollector implements Runnable {
   @VisibleForTesting
   public StringBuilder getValue() {
     return value;
+  }
+
+  public State getState() {
+    return state;
+  }
+
+  public void setState(State state) {
+    this.state = state;
   }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
@@ -21,6 +21,8 @@ public enum StatExceptionCode {
   METRICS_REMOVE_ERROR("MetricsRemoveError"),
   // Tracks the number of VM attach/dataDump or detach failures.
   JVM_ATTACH_ERROR("JvmAttachErrror"),
+  // This error is thrown if the java_pid file is missing.
+  JVM_ATTACH_ERROR_JAVA_PID_FILE_MISSING("JvmAttachErrorJavaPidFileMissing"),
   // The lock could not be acquired within the timeout.
   JVM_ATTACH_LOCK_ACQUISITION_FAILED("JvmAttachLockAcquisitionFailed"),
   // ThreadState could not be found for an ES thread in the critical ES path.
@@ -28,6 +30,7 @@ public enum StatExceptionCode {
   // This metric indicates that we successfully completed a thread-dump. Likewise,
   // an omission of this should indicate that the thread taking the dump got stuck.
   JVM_THREAD_DUMP_SUCCESSFUL("JvmThreadDumpSuccessful"),
+  COLLECTORS_MUTED("CollectorsMutedCount"),
   MASTER_METRICS_ERROR("MasterMetricsError"),
   DISK_METRICS_ERROR("DiskMetricsError"),
   THREAD_IO_ERROR("ThreadIOError"),

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
@@ -19,8 +19,12 @@ public enum StatExceptionCode {
   TOTAL_ERROR("TotalError"),
   METRICS_WRITE_ERROR("MetricsWriteError"),
   METRICS_REMOVE_ERROR("MetricsRemoveError"),
+  // Tracks the number of VM attach/dataDump or detach failures.
   JVM_ATTACH_ERROR("JvmAttachErrror"),
+  // The lock could not be acquired within the timeout.
   JVM_ATTACH_LOCK_ACQUISITION_FAILED("JvmAttachLockAcquisitionFailed"),
+  // ThreadState could not be found for an ES thread in the critical ES path.
+  NO_THREAD_STATE_INFO("NoThreadStateInfo"),
   MASTER_METRICS_ERROR("MasterMetricsError"),
   DISK_METRICS_ERROR("DiskMetricsError"),
   THREAD_IO_ERROR("ThreadIOError"),

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
@@ -30,6 +30,7 @@ public enum StatExceptionCode {
   // This metric indicates that we successfully completed a thread-dump. Likewise,
   // an omission of this should indicate that the thread taking the dump got stuck.
   JVM_THREAD_DUMP_SUCCESSFUL("JvmThreadDumpSuccessful"),
+  THREAD_DUMP_FROM_NON_COLLECTOR_THREAD("ThreadDumpFromNonCollectorThread"),
   COLLECTORS_MUTED("CollectorsMutedCount"),
   MASTER_METRICS_ERROR("MasterMetricsError"),
   DISK_METRICS_ERROR("DiskMetricsError"),

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
@@ -20,6 +20,7 @@ public enum StatExceptionCode {
   METRICS_WRITE_ERROR("MetricsWriteError"),
   METRICS_REMOVE_ERROR("MetricsRemoveError"),
   JVM_ATTACH_ERROR("JvmAttachErrror"),
+  JVM_ATTACH_LOCK_ACQUISITION_FAILED("JvmAttachLockAcquisitionFailed"),
   MASTER_METRICS_ERROR("MasterMetricsError"),
   DISK_METRICS_ERROR("DiskMetricsError"),
   THREAD_IO_ERROR("ThreadIOError"),

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
@@ -30,7 +30,6 @@ public enum StatExceptionCode {
   // This metric indicates that we successfully completed a thread-dump. Likewise,
   // an omission of this should indicate that the thread taking the dump got stuck.
   JVM_THREAD_DUMP_SUCCESSFUL("JvmThreadDumpSuccessful"),
-  THREAD_DUMP_FROM_NON_COLLECTOR_THREAD("ThreadDumpFromNonCollectorThread"),
   COLLECTORS_MUTED("CollectorsMutedCount"),
   MASTER_METRICS_ERROR("MasterMetricsError"),
   DISK_METRICS_ERROR("DiskMetricsError"),

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/StatExceptionCode.java
@@ -25,6 +25,9 @@ public enum StatExceptionCode {
   JVM_ATTACH_LOCK_ACQUISITION_FAILED("JvmAttachLockAcquisitionFailed"),
   // ThreadState could not be found for an ES thread in the critical ES path.
   NO_THREAD_STATE_INFO("NoThreadStateInfo"),
+  // This metric indicates that we successfully completed a thread-dump. Likewise,
+  // an omission of this should indicate that the thread taking the dump got stuck.
+  JVM_THREAD_DUMP_SUCCESSFUL("JvmThreadDumpSuccessful"),
   MASTER_METRICS_ERROR("MasterMetricsError"),
   DISK_METRICS_ERROR("DiskMetricsError"),
   THREAD_IO_ERROR("ThreadIOError"),

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/jvm/ThreadList.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/jvm/ThreadList.java
@@ -271,6 +271,8 @@ public class ThreadList {
     Util.invokePrivileged(() -> runAttachDump(pid, args));
     runMXDump();
 
+    StatsCollector.instance()
+        .logException(StatExceptionCode.JVM_THREAD_DUMP_SUCCESSFUL);
     lastRunTime = System.currentTimeMillis();
   }
 


### PR DESCRIPTION
*Fixes #:* #565

*Description of changes:*

In [this code](https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/blob/b33c502d55b954782129b8f61b2c67b07e8477d5/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/jvm/ThreadList.java#L127) all threads might be blocked behind one thread trying to
fill the jTidMap from a threaddump that contains all the thread related details that performanceAnalyzer uses. The thread dump is requires a JVM attach which has a [default timeout of 10 seconds](https://github.com/openjdk/jdk/blob/353416ffcaa12d79013e6f9d03371bf86d0f671b/src/jdk.attach/share/classes/sun/tools/attach/HotSpotVirtualMachine.java#L368) which is quite long. While one thread is busy attaching, all threads running ES operations might be stuck waiting for the same lock. Therefore, this change replaces a mandatory lock with a try-lock, so that the threads which cannot acquire the lock, moves past this and carry on. We will loose the metrics for this run, but that is better than stalling all ES operations.

*Tests:*

PA metrics is returning the metrics:
```
curl "localhost:9600/_opendistro/_performanceanalyzer/metrics?metrics=Latency,CPU_Utilization&agg=avg,max&dim=ShardID&nodes=all"
{"iAHcZIXUQMaOBPzRNsC-JA": {"timestamp": 1614637105000, "data": {"fields":[{"name":"ShardID","type":"VARCHAR"},{"name":"Latency","type":"DOUBLE"},{"name":"CPU_Utilization","type":"DOUBLE"}],"records":[[null,null,0.005394726328405913]]}}, "jLtljYrfQAuTVwUBgGtHNQ" :{"timestamp": 1614637105000, "data": {"fields":[{"name":"ShardID","type":"VARCHAR"},{"name":"Latency","type":"DOUBLE"},{"name":"CPU_Utilization","type":"DOUBLE"}],"records":[[null,null,0.002798561151079137]]}}}```

The writer metrics are being emitted in the /dev/shm file

```[root@7b746ade07bd performanceanalyzer]# cat 1614636875000
^heap_metrics
{"current_time":1614636875493}
{"MemType":"totYoungGC","GC_Collection_Event":0,"GC_Collection_Time":0,"Heap_Committed":-2,"Heap_Init":-2,"Heap_Max":-2,"Heap_Used":-2}
{"MemType":"totFullGC","GC_Collection_Event":0,"GC_Collection_Time":0,"Heap_Committed":-2,"Heap_Init":-2,"Heap_Max":-2,"Heap_Used":-2}
{"MemType":"PermGen","GC_Collection_Event":-2,"GC_Collection_Time":-2,"Heap_Committed":85696512,"Heap_Init":0,"Heap_Max":-1,"Heap_Used":80593424}
{"MemType":"Survivor","GC_Collection_Event":-2,"GC_Collection_Time":-2,"Heap_Committed":17891328,"Heap_Init":17891328,"Heap_Max":17891328,"Heap_Used":9578944}
{"MemType":"OldGen","GC_Collection_Event":-2,"GC_Collection_Time":-2,"Heap_Committed":357957632,"Heap_Init":357957632,"Heap_Max":357957632,"Heap_Used":55396840}
{"MemType":"Eden","GC_Collection_Event":-2,"GC_Collection_Time":-2,"Heap_Committed":143130624,"Heap_Init":143130624,"Heap_Max":143130624,"Heap_Used":37667024}
{"MemType":"NonHeap","GC_Collection_Event":-2,"GC_Collection_Time":-2,"Heap_Committed":118042624,"Heap_Init":7667712,"Heap_Max":-1,"Heap_Used":109184376}
{"MemType":"Heap","GC_Collection_Event":-2,"GC_Collection_Time":-2,"Heap_Committed":518979584,"Heap_Init":536870912,"Heap_Max":518979584,"Heap_Used":102642808}
```

*If new tests are added, how long do the new ones take to complete*

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
