### PR TITLE
Track admission control metrics

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/AdmissionControlDecider.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/AdmissionControlDecider.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotClusterSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.admission_control.AdmissionControlClusterRca;
+
+import java.time.Instant;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class AdmissionControlDecider extends Decider {
+
+    private static final Logger LOG = LogManager.getLogger(AdmissionControlDecider.class);
+    private static final String NAME = "AdmissionControlDecider";
+
+    private int counter = 0;
+    private AdmissionControlClusterRca admissionControlClusterRca;
+
+    public AdmissionControlDecider(long evalIntervalSeconds, int decisionFrequency, AdmissionControlClusterRca admissionControlClusterRca) {
+        super(evalIntervalSeconds, decisionFrequency);
+        this.admissionControlClusterRca = admissionControlClusterRca;
+    }
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public Decision operate() {
+        Decision decision = new Decision(Instant.now().toEpochMilli(), NAME);
+        counter += 1;
+        if (counter < decisionFrequency) {
+            return decision;
+        }
+        counter = 0;
+        for (ResourceFlowUnit<HotClusterSummary> flowUnit : admissionControlClusterRca.getFlowUnits()) {
+            if (flowUnit.hasResourceSummary()) {
+                LOG.warn("encountered an unhealthy admissionControlClusterRca flowUnit");
+                return decision;
+            }
+        }
+        LOG.warn("no unhealthy admissionControlClusterRca flowUnits");
+        return decision;
+    }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/AllMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/AllMetrics.java
@@ -42,6 +42,7 @@ public class AllMetrics {
     SHARD_STATS,
     MASTER_PENDING,
     MOUNTED_PARTITION_METRICS,
+    ADMISSION_CONTROL_METRICS,
     SHARD_INDEXING_PRESSURE
   }
 
@@ -1405,6 +1406,72 @@ public class AllMetrics {
       public static final String CURRENT_LIMITS = "Indexing_Pressure_Current_Limits";
       public static final String AVERAGE_WINDOW_THROUGHPUT = "Indexing_Pressure_Average_Window_Throughput";
       public static final String LAST_SUCCESSFUL_TIMESTAMP = "Indexing_Pressure_Last_Successful_Timestamp";
+    }
+  }
+
+  /*
+   * Column names of AdmissionControl_RejectionCount table
+   * ControllerName | sum | avg | min | max
+   *
+   * Column names of AdmissionControl_ThresholdValue table
+   * ControllerName | sum | avg | min | max
+   *
+   * Column names of AdmissionControl_CurrentValue table
+   * ControllerName | sum | avg | min | max
+   *
+   * Example:
+   * Global_JVMMP|41.0|8.2|8.0|9.0
+   * Request_Size|0.0|0.0|0.0|0.0
+   */
+  public enum AdmissionControlDimension implements MetricDimension, JooqFieldValue {
+    CONTROLLER_NAME(Constants.CONTROLLER_NAME);
+
+    private final String value;
+
+    AdmissionControlDimension(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return value;
+    }
+
+    @Override
+    public Field<String> getField() {
+      return DSL.field(DSL.name(this.value), String.class);
+    }
+
+    @Override
+    public String getName() {
+      return value;
+    }
+
+    public static class Constants {
+      public static final String CONTROLLER_NAME = "ControllerName";
+    }
+  }
+
+  public enum AdmissionControlValue implements MetricValue {
+    CURRENT_VALUE(Constants.CURRENT_VALUE),
+    THRESHOLD_VALUE(Constants.THRESHOLD_VALUE),
+    REJECTION_COUNT(Constants.REJECTION_COUNT);
+
+    private final String value;
+
+    AdmissionControlValue(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return value;
+    }
+
+    public static class Constants {
+      public static final String CURRENT_VALUE = "AdmissionControl_CurrentValue";
+      public static final String THRESHOLD_VALUE = "AdmissionControl_ThresholdValue";
+      public static final String REJECTION_COUNT = "AdmissionControl_RejectionCount";
     }
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
@@ -56,6 +56,7 @@ public class PerformanceAnalyzerMetrics {
   public static final String sIPPath = "ip_metrics";
   public static final String sGcInfoPath = "gc_info";
   public static final String sMountedPartitionMetricsPath = "mounted_part_space";
+  public static final String sAdmissionControlMetricsPath = "admission_control_metrics";
   public static final String sShardIndexingPressurePath = "shard_indexing_pressure_metrics";
   public static final String sKeyValueDelimitor = ":";
   public static final String sMetricNewLineDelimitor = System.getProperty("line.separator");

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/model/MetricsModel.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/model/MetricsModel.java
@@ -16,6 +16,8 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.model;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.AdmissionControlDimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.AdmissionControlValue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.AggregatedOSDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CacheConfigDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CacheConfigValue;
@@ -374,6 +376,19 @@ public class MetricsModel {
         new MetricAttributes(
             MetricUnits.COUNT.toString(), AllMetrics.ShardStateDimension.values()));
 
+    allMetricsInitializer.put(
+            AdmissionControlValue.REJECTION_COUNT.toString(),
+            new MetricAttributes(MetricUnits.COUNT.toString(), AdmissionControlDimension.values())
+    );
+    allMetricsInitializer.put(
+            AdmissionControlValue.THRESHOLD_VALUE.toString(),
+            new MetricAttributes(MetricUnits.COUNT.toString(), AdmissionControlDimension.values())
+    );
+    allMetricsInitializer.put(
+            AdmissionControlValue.CURRENT_VALUE.toString(),
+            new MetricAttributes(MetricUnits.COUNT.toString(), AdmissionControlDimension.values())
+    );
+
     // Shard Indexing Pressure Metrics
     allMetricsInitializer.put(
         AllMetrics.ShardIndexingPressureValue.REJECTION_COUNT.toString(),
@@ -390,7 +405,6 @@ public class MetricsModel {
     allMetricsInitializer.put(
         AllMetrics.ShardIndexingPressureValue.LAST_SUCCESSFUL_TIMESTAMP.toString(),
         new MetricAttributes(MetricUnits.MILLISECOND.toString(), AllMetrics.ShardIndexingPressureDimension.values()));
-
 
     ALL_METRICS = Collections.unmodifiableMap(allMetricsInitializer);
   }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/AdmissionControl_CurrentValue.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/AdmissionControl_CurrentValue.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
+
+public class AdmissionControl_CurrentValue extends Metric {
+    public AdmissionControl_CurrentValue(long evaluationIntervalSeconds) {
+        super(AllMetrics.AdmissionControlValue.CURRENT_VALUE.toString(), evaluationIntervalSeconds);
+    }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/AdmissionControl_RejectionCount.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/AdmissionControl_RejectionCount.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
+
+public class AdmissionControl_RejectionCount extends Metric {
+    public AdmissionControl_RejectionCount(long evaluationIntervalSeconds) {
+        super(AllMetrics.AdmissionControlValue.REJECTION_COUNT.toString(), evaluationIntervalSeconds);
+    }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/AdmissionControl_ThresholdValue.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/AdmissionControl_ThresholdValue.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
+
+public class AdmissionControl_ThresholdValue extends Metric {
+    public AdmissionControl_ThresholdValue(long evaluationIntervalSeconds) {
+        super(AllMetrics.AdmissionControlValue.THRESHOLD_VALUE.toString(), evaluationIntervalSeconds);
+    }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
@@ -51,6 +51,8 @@ public enum ExceptionsAndErrors implements MeasurementSet {
 
   SHARD_STATE_COLLECTOR_ERROR("ShardStateCollectorError"),
 
+  ADMISSION_CONTROL_COLLECTOR_ERROR("AdmissionControlCollectorError"),
+
   MASTER_THROTTLING_COLLECTOR_ERROR("MasterThrottlingMetricsCollector"),
 
   FAULT_DETECTION_COLLECTOR_ERROR("FaultDetectionMetricsCollector"),

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/admission_control/AdmissionControlClusterRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/admission_control/AdmissionControlClusterRca.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.admission_control;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Rca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotClusterSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.BaseClusterRca;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class AdmissionControlClusterRca extends BaseClusterRca {
+
+    public static final String RCA_TABLE_NAME = AdmissionControlClusterRca.class.getSimpleName();
+    private static final Logger LOG = LogManager.getLogger(AdmissionControlClusterRca.class);
+
+    public <R extends Rca<ResourceFlowUnit<HotNodeSummary>>> AdmissionControlClusterRca(final int rcaPeriod, final R nodeRca) {
+        super(rcaPeriod, nodeRca);
+    }
+
+    @Override
+    public ResourceFlowUnit<HotClusterSummary> operate() {
+        LOG.info("[AdmissionControl] {}", System.currentTimeMillis());
+        return new ResourceFlowUnit<>(System.currentTimeMillis());
+    }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/admission_control/AdmissionControllerRca.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/store/rca/admission_control/AdmissionControllerRca.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.admission_control;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Metric;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Rca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.MetricFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.persist.SQLParsingUtil;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class AdmissionControllerRca extends Rca<ResourceFlowUnit<HotNodeSummary>> {
+
+    private static final Logger LOG = LogManager.getLogger(AdmissionControllerRca.class);
+
+    // Global JVM Memory Pressure Metric
+    private static final String GLOBAL_JVMMP = "Global_JVMMP";
+
+    // Request Size Metric
+    private static final String REQUEST_SIZE = "Request_Size";
+
+    private final Metric admissionControlCurrentValue;
+    private final Metric admissionControlThresholdValue;
+    private final Metric admissionControlRejectionCount;
+
+    public <M extends Metric> AdmissionControllerRca(final int rcaPeriod,
+                                                     final M admissionControlCurrentValue,
+                                                     final M admissionControlThresholdValue,
+                                                     final M admissionControlRejectionCount) {
+        super(rcaPeriod);
+
+        this.admissionControlCurrentValue = admissionControlCurrentValue;
+        this.admissionControlThresholdValue = admissionControlThresholdValue;
+        this.admissionControlRejectionCount = admissionControlRejectionCount;
+    }
+
+    private <M extends Metric> double getMaxMetricValue(String controllerName, M metric) {
+        double metricValue = 0;
+        for (MetricFlowUnit metricFU : metric.getFlowUnits()) {
+            if (metricFU.isEmpty()) {
+                continue;
+            }
+            if (metricFU.getData().isEmpty()) {
+                continue;
+            }
+            try {
+                metricValue = SQLParsingUtil.readDataFromSqlResult(
+                        metricFU.getData(),
+                        AllMetrics.AdmissionControlDimension.CONTROLLER_NAME.getField(),
+                        controllerName,
+                        MetricsDB.MAX);
+                if (Double.isNaN(metricValue)) {
+                    metricValue = 0;
+                    LOG.warn("[AdmissionControl] Failed to parse metric from {}", metric.name());
+                } else {
+                    LOG.debug("[AdmissionControl] Metric value {} is {}", metric.name(), metricValue);
+                }
+            } catch (Exception ex) {
+                LOG.warn("[AdmissionControl] Failed to parse metric from {}. [{}]", metric.name(), ex.toString());
+            }
+        }
+        return metricValue;
+    }
+
+    private AdmissionControlMetrics getMetricModel(String controllerName) {
+        AdmissionControlMetrics metricValue = new AdmissionControlMetrics();
+        metricValue.controllerName = controllerName;
+        metricValue.rejectionCount = (long)getMaxMetricValue(controllerName, admissionControlRejectionCount);
+        metricValue.thresholdValue = (long)getMaxMetricValue(controllerName, admissionControlThresholdValue);
+        metricValue.currentValue = (long)getMaxMetricValue(controllerName, admissionControlCurrentValue);
+        return metricValue;
+    }
+
+    @Override
+    public ResourceFlowUnit<HotNodeSummary> operate() {
+        long currentTimeMillis = System.currentTimeMillis();
+
+        AdmissionControlMetrics globalJVMMP = getMetricModel(GLOBAL_JVMMP);
+        AdmissionControlMetrics requestSize = getMetricModel(REQUEST_SIZE);
+
+        LOG.info("[AdmissionControl] Time:{} Controller:{} CurrentValue:{} ThresholdValue:{} RejectionCount:{}",
+                currentTimeMillis, GLOBAL_JVMMP, globalJVMMP.currentValue, globalJVMMP.thresholdValue, globalJVMMP.rejectionCount);
+
+        LOG.info("[AdmissionControl] Time:{} Controller:{} CurrentValue:{} ThresholdValue:{} RejectionCount:{}",
+                currentTimeMillis, REQUEST_SIZE, requestSize.currentValue, requestSize.thresholdValue, requestSize.rejectionCount);
+
+        // TODO: Add the RCA logic here
+        return new ResourceFlowUnit<>(currentTimeMillis);
+    }
+
+    @Override
+    public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {
+        throw new IllegalArgumentException(name() + ": not expected to be called over the wire");
+    }
+
+    public static class AdmissionControlMetrics {
+
+        private String controllerName;
+        private long currentValue;
+        private long thresholdValue;
+        private long rejectionCount;
+
+        public AdmissionControlMetrics() {
+            super();
+        }
+
+        public AdmissionControlMetrics(String controllerName, long currentValue, long thresholdValue, long rejectionCount) {
+            super();
+            this.controllerName = controllerName;
+            this.currentValue = currentValue;
+            this.thresholdValue = thresholdValue;
+            this.rejectionCount = rejectionCount;
+        }
+
+        public String getControllerName() {
+            return controllerName;
+        }
+
+        public long getCurrentValue() {
+            return currentValue;
+        }
+
+        public long getThresholdValue() {
+            return thresholdValue;
+        }
+
+        public long getRejectionCount() {
+            return rejectionCount;
+        }
+    }
+
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/AdmissionControlProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/AdmissionControlProcessor.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.AdmissionControlDimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.AdmissionControlValue;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.util.JsonConverter;
+import org.jooq.BatchBindStep;
+
+import java.sql.Connection;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.NavigableMap;
+
+public class AdmissionControlProcessor implements EventProcessor {
+
+    private AdmissionControlSnapshot admissionControlSnapshot;
+    private BatchBindStep handle;
+    private long startTime;
+    private long endTime;
+
+    private AdmissionControlProcessor(AdmissionControlSnapshot admissionControlSnapshot) {
+        this.admissionControlSnapshot = admissionControlSnapshot;
+    }
+
+    static AdmissionControlProcessor build(
+            long currentWindowStartTime,
+            Connection connection,
+            NavigableMap<Long, AdmissionControlSnapshot> admissionControlSnapshotNavigableMap
+    ) {
+
+        if (admissionControlSnapshotNavigableMap.get(currentWindowStartTime) == null) {
+            AdmissionControlSnapshot admissionControlSnapshot = new AdmissionControlSnapshot(
+                    connection,
+                    currentWindowStartTime
+            );
+            admissionControlSnapshotNavigableMap.put(currentWindowStartTime, admissionControlSnapshot);
+            return new AdmissionControlProcessor(admissionControlSnapshot);
+        }
+
+        return new AdmissionControlProcessor(admissionControlSnapshotNavigableMap.get(currentWindowStartTime));
+    }
+
+    @Override
+    public void initializeProcessing(long startTime, long endTime) {
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.handle = admissionControlSnapshot.startBatchPut();
+    }
+
+    @Override
+    public void finalizeProcessing() {
+        if (handle.size() > 0) {
+            handle.execute();
+        }
+    }
+
+    @Override
+    public void processEvent(Event event) {
+        processEvent(event.value);
+        if (handle.size() == 500) {
+            handle.execute();
+            handle = admissionControlSnapshot.startBatchPut();
+        }
+    }
+
+    private void processEvent(String eventValue) {
+        String[] lines = eventValue.split(System.lineSeparator());
+        Arrays.stream(lines).forEach(line -> {
+            Map<String, Object> map = JsonConverter.createMapFrom(line);
+            String controller = (String) map.get(AdmissionControlDimension.Constants.CONTROLLER_NAME);
+            long rejectionCount = getRejectionCount(map);
+            handle.bind(controller, rejectionCount);
+        });
+    }
+
+    private long getRejectionCount(Map<String, Object> map) {
+        Object rejectionCountObject = map.get(AdmissionControlValue.Constants.REJECTION_COUNT);
+        return rejectionCountObject instanceof String
+                ? Long.parseLong((String)rejectionCountObject)
+                : ((Number)rejectionCountObject).longValue();
+    }
+
+    @Override
+    public boolean shouldProcessEvent(Event event) {
+        return event.key.contains(PerformanceAnalyzerMetrics.sAdmissionControlMetricsPath);
+    }
+
+    @Override
+    public void commitBatchIfRequired() {
+        if (handle.size() >= BATCH_LIMIT) {
+            handle.execute();
+            handle = admissionControlSnapshot.startBatchPut();
+        }
+    }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/AdmissionControlSnapshot.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/AdmissionControlSnapshot.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.AdmissionControlDimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.AdmissionControlValue;
+import org.jooq.BatchBindStep;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AdmissionControlSnapshot implements Removable {
+
+    private final DSLContext create;
+    private final String tableName;
+    private List<Field<?>> columns;
+
+    public AdmissionControlSnapshot(Connection conn, Long windowStartTime) {
+        this.create = DSL.using(conn, SQLDialect.SQLITE);
+        this.tableName = "admission_control_" + windowStartTime;
+        this.columns = new ArrayList<Field<?>>() {
+            {
+                this.add(DSL.field(DSL.name(Fields.CONTROLLER_NAME.toString()), String.class));
+                this.add(DSL.field(DSL.name(Fields.REJECTION_COUNT.toString()), Long.class));
+            }
+        };
+        create.createTable(tableName).columns(columns).execute();
+    }
+
+    public DSLContext getDSLContext() {
+        return create;
+    }
+
+    public BatchBindStep startBatchPut() {
+        List<Object> dummyValues = new ArrayList<>();
+        for (int i = 0; i < columns.size(); i++) {
+            dummyValues.add(null);
+        }
+        return create.batch(create.insertInto(DSL.table(this.tableName)).values(dummyValues));
+    }
+
+    public Result<Record> fetchAll() {
+        return create.select().from(DSL.table(tableName)).fetch();
+    }
+
+    @Override
+    public void remove() throws Exception {
+        create.dropTable(DSL.table(tableName)).execute();
+    }
+
+    public enum Fields {
+        CONTROLLER_NAME(AdmissionControlDimension.CONTROLLER_NAME.toString()),
+        REJECTION_COUNT(AdmissionControlValue.REJECTION_COUNT.toString());
+
+        private final String fieldValue;
+
+        Fields(String fieldValue) {
+            this.fieldValue = fieldValue;
+        }
+
+        @Override
+        public String toString() {
+            return fieldValue;
+        }
+    }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MetricPropertiesConfig.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MetricPropertiesConfig.java
@@ -16,6 +16,8 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.AdmissionControlDimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.AdmissionControlValue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CacheConfigDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CacheConfigValue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CircuitBreakerDimension;
@@ -168,6 +170,7 @@ public final class MetricPropertiesConfig {
     metricPathMap.put(MetricName.MASTER_PENDING, PerformanceAnalyzerMetrics.sPendingTasksPath);
     metricPathMap.put(MetricName.MOUNTED_PARTITION_METRICS,
         PerformanceAnalyzerMetrics.sMountedPartitionMetricsPath);
+    metricPathMap.put(MetricName.ADMISSION_CONTROL_METRICS, PerformanceAnalyzerMetrics.sAdmissionControlMetricsPath);
     metricPathMap.put(MetricName.SHARD_INDEXING_PRESSURE, PerformanceAnalyzerMetrics.sShardIndexingPressurePath);
 
     eventKeyToMetricNameMap = new HashMap<>();
@@ -184,6 +187,7 @@ public final class MetricPropertiesConfig {
         PerformanceAnalyzerMetrics.sPendingTasksPath, MetricName.MASTER_PENDING);
     eventKeyToMetricNameMap.put(PerformanceAnalyzerMetrics.sMountedPartitionMetricsPath,
         MetricName.MOUNTED_PARTITION_METRICS);
+    eventKeyToMetricNameMap.put(PerformanceAnalyzerMetrics.sAdmissionControlMetricsPath, MetricName.ADMISSION_CONTROL_METRICS);
     eventKeyToMetricNameMap.put(PerformanceAnalyzerMetrics.sShardIndexingPressurePath, MetricName.SHARD_INDEXING_PRESSURE);
 
     metricName2Property = new HashMap<>();
@@ -251,6 +255,12 @@ public final class MetricPropertiesConfig {
             DevicePartitionDimension.values(),
             DevicePartitionValue.values(),
             createFileHandler(metricPathMap.get(MetricName.MOUNTED_PARTITION_METRICS))
+        ));
+    metricName2Property.put(MetricName.ADMISSION_CONTROL_METRICS,
+        new MetricProperties(
+            AdmissionControlDimension.values(),
+            AdmissionControlValue.values(),
+            createFileHandler(metricPathMap.get(MetricName.ADMISSION_CONTROL_METRICS))
         ));
     metricName2Property.put(
         MetricName.SHARD_INDEXING_PRESSURE,

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/AdmissionControlDeciderTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/AdmissionControlDeciderTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.AdmissionControlDecider;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.decisionmaker.deciders.Decision;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.RcaTestHelper;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.Resources;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.contexts.ResourceContext;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotClusterSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.core.RcaConf;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.InstanceDetails;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.util.RcaConsts;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.admission_control.AdmissionControlClusterRca;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
+import org.apache.logging.log4j.core.util.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AdmissionControlDeciderTest {
+
+    AppContext appContext;
+    RcaConf rcaConf;
+
+    @Before
+    public void setupCluster() {
+        ClusterDetailsEventProcessor clusterDetailsEventProcessor = new ClusterDetailsEventProcessor();
+
+        ClusterDetailsEventProcessor.NodeDetails node1 =
+                new ClusterDetailsEventProcessor.NodeDetails(AllMetrics.NodeRole.DATA, "node1", "127.0.0.1", false);
+        ClusterDetailsEventProcessor.NodeDetails node2 =
+                new ClusterDetailsEventProcessor.NodeDetails(AllMetrics.NodeRole.DATA, "node2", "127.0.0.2", false);
+        ClusterDetailsEventProcessor.NodeDetails node3 =
+                new ClusterDetailsEventProcessor.NodeDetails(AllMetrics.NodeRole.DATA, "node3", "127.0.0.3", false);
+        ClusterDetailsEventProcessor.NodeDetails node4 =
+                new ClusterDetailsEventProcessor.NodeDetails(AllMetrics.NodeRole.DATA, "node3", "127.0.0.4", false);
+        ClusterDetailsEventProcessor.NodeDetails master =
+                new ClusterDetailsEventProcessor.NodeDetails(AllMetrics.NodeRole.ELECTED_MASTER, "master", "127.0.0.9", true);
+
+        List<ClusterDetailsEventProcessor.NodeDetails> nodes = new ArrayList<>();
+        nodes.add(node1);
+        nodes.add(node2);
+        nodes.add(node3);
+        nodes.add(node4);
+        nodes.add(master);
+        clusterDetailsEventProcessor.setNodesDetails(nodes);
+
+        appContext = new AppContext();
+        appContext.setClusterDetailsEventProcessor(clusterDetailsEventProcessor);
+
+        String rcaConfPath = Paths.get(RcaConsts.TEST_CONFIG_PATH, "rca.conf").toString();
+        rcaConf = new RcaConf(rcaConfPath);
+    }
+
+    @Test
+    public void testAdmissionControl() {
+        RcaTestHelper<HotNodeSummary> admissionControlNodeRca = new RcaTestHelper<>("AdmissionControlNodeRca");
+        admissionControlNodeRca.setAppContext(this.appContext);
+
+        AdmissionControlClusterRca admissionControlClusterRca =
+                new AdmissionControlClusterRca(1, admissionControlNodeRca);
+        admissionControlClusterRca.setAppContext(this.appContext);
+
+        AdmissionControlDecider admissionControlDecider =
+                new AdmissionControlDecider(1, 1, admissionControlClusterRca);
+
+        ResourceContext resourceContext = new ResourceContext(Resources.State.UNHEALTHY);
+        NodeKey nodeKey = new NodeKey(new InstanceDetails.Id("node1"), new InstanceDetails.Ip("127.0.0.1"));
+        HotNodeSummary nodeSummary = new HotNodeSummary(nodeKey.getNodeId(), nodeKey.getHostAddress());
+        HotClusterSummary clusterSummary = new HotClusterSummary(5, 0);
+        clusterSummary.appendNestedSummary(nodeSummary);
+
+        admissionControlClusterRca.setLocalFlowUnit(new ResourceFlowUnit<>(
+                System.currentTimeMillis(),
+                resourceContext,
+                clusterSummary,
+                true)
+        );
+
+        Decision decision = admissionControlDecider.operate();
+        Assert.isNonEmpty(decision);
+    }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/AdmissionControlProcessorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/AdmissionControlProcessorTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MetricStatus;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.AdmissionControlSnapshot.Fields;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class AdmissionControlProcessorTest {
+
+    private static final String DB_URL = "jdbc:sqlite:";
+    private static final String TEST_CONTROLLER = "testController";
+    private static final String TEST_REJECTION_COUNT = "1";
+
+    private AdmissionControlProcessor admissionControlProcessor;
+    private long currentTimestamp;
+    private NavigableMap<Long, AdmissionControlSnapshot> snapshotMap;
+    Connection connection;
+
+    @Before
+    public void setup() throws Exception {
+        Class.forName("org.sqlite.JDBC");
+        System.setProperty("java.io.tmpdir", "/tmp");
+        connection = DriverManager.getConnection(DB_URL);
+        this.currentTimestamp = System.currentTimeMillis();
+        this.snapshotMap = new TreeMap<>();
+        this.admissionControlProcessor = AdmissionControlProcessor.build(currentTimestamp, connection, snapshotMap);
+    }
+
+    @Test
+    public void testHandleEvent() throws Exception {
+        Event testEvent = buildTestAdmissionControlEvent();
+
+        admissionControlProcessor.initializeProcessing(currentTimestamp, System.currentTimeMillis());
+
+        assertTrue(admissionControlProcessor.shouldProcessEvent(testEvent));
+
+        admissionControlProcessor.processEvent(testEvent);
+        admissionControlProcessor.finalizeProcessing();
+
+        AdmissionControlSnapshot snap = snapshotMap.get(currentTimestamp);
+        Result<Record> result = snap.fetchAll();
+        assertEquals(1, result.size());
+        assertEquals(TEST_CONTROLLER, result.get(0).get(Fields.CONTROLLER_NAME.toString()));
+        assertEquals(Long.parseLong(TEST_REJECTION_COUNT), result.get(0).get(Fields.REJECTION_COUNT.toString()));
+    }
+
+    private Event buildTestAdmissionControlEvent() {
+        long currentTimeMillis = System.currentTimeMillis();
+        String admissionControlEvent =
+                new AdmissionControlMetrics(
+                        TEST_CONTROLLER, 0L, 0L, Long.parseLong(TEST_REJECTION_COUNT))
+                        .serialize();
+        return new Event(PerformanceAnalyzerMetrics.sAdmissionControlMetricsPath, admissionControlEvent, currentTimeMillis);
+    }
+
+    static class AdmissionControlMetrics extends MetricStatus {
+
+        private String controllerName;
+        private long currentValue;
+        private long thresholdValue;
+        private long rejectionCount;
+
+        public AdmissionControlMetrics() {
+            super();
+        }
+
+        public AdmissionControlMetrics(String controllerName, long currentValue, long thresholdValue, long rejectionCount) {
+            super();
+            this.controllerName = controllerName;
+            this.currentValue = currentValue;
+            this.thresholdValue = thresholdValue;
+            this.rejectionCount = rejectionCount;
+        }
+
+        @JsonProperty(AllMetrics.AdmissionControlDimension.Constants.CONTROLLER_NAME)
+        public String getControllerName() {
+            return controllerName;
+        }
+
+        @JsonProperty(AllMetrics.AdmissionControlValue.Constants.CURRENT_VALUE)
+        public long getCurrentValue() {
+            return currentValue;
+        }
+
+        @JsonProperty(AllMetrics.AdmissionControlValue.Constants.THRESHOLD_VALUE)
+        public long getThresholdValue() {
+            return thresholdValue;
+        }
+
+        @JsonProperty(AllMetrics.AdmissionControlValue.Constants.REJECTION_COUNT)
+        public long getRejectionCount() {
+            return rejectionCount;
+        }
+    }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/AdmissionControlSnapshotTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/AdmissionControlSnapshotTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.AdmissionControlSnapshot.Fields;
+import org.jooq.BatchBindStep;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+
+import static org.junit.Assert.assertEquals;
+
+public class AdmissionControlSnapshotTest {
+
+    private static final String DB_URL = "jdbc:sqlite:";
+    private static final String TEST_CONTROLLER = "testController";
+    private static final Long TEST_REJECTION_COUNT = 1L;
+    private Connection connection;
+    AdmissionControlSnapshot snapshot;
+
+    @Before
+    public void setup() throws Exception {
+        Class.forName("org.sqlite.JDBC");
+        System.setProperty("java.io.tmpdir", "/tmp");
+        connection = DriverManager.getConnection(DB_URL);
+        snapshot = new AdmissionControlSnapshot(connection, System.currentTimeMillis());
+    }
+
+    @Test
+    public void testReadAdmissionControlSnapshot() throws Exception {
+        final BatchBindStep handle = snapshot.startBatchPut();
+        insertIntoTable(handle, TEST_CONTROLLER, TEST_REJECTION_COUNT);
+
+        final Result<Record> result = snapshot.fetchAll();
+
+        assertEquals(1, result.size());
+        assertEquals(TEST_CONTROLLER, result.get(0).get(Fields.CONTROLLER_NAME.toString()));
+        assertEquals(TEST_REJECTION_COUNT, result.get(0).get(Fields.REJECTION_COUNT.toString()));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        connection.close();
+    }
+
+    private void insertIntoTable(BatchBindStep handle, String controller, Long rejectionCount) {
+        handle.bind(controller, rejectionCount).execute();
+    }
+
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MetricsEmitterTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MetricsEmitterTests.java
@@ -458,6 +458,24 @@ public class MetricsEmitterTests extends AbstractReaderTests {
   }
 
   @Test
+  public void testEmitAdmissionControlMetric() throws Exception {
+    Connection connection = DriverManager.getConnection(DB_URL);
+    String testController = "testController";
+    String testRejectionCount = "1";
+    long currentTimeMillis = System.currentTimeMillis();
+
+    AdmissionControlSnapshot snapshot = new AdmissionControlSnapshot(connection, currentTimeMillis);
+    BatchBindStep handle = snapshot.startBatchPut();
+    handle.bind(testController, Long.parseLong(testRejectionCount)).execute();
+
+    MetricsDB metricsDB = new MetricsDB(currentTimeMillis);
+    MetricsEmitter.emitAdmissionControlMetrics(metricsDB, snapshot);
+
+    Result<Record> result = metricsDB.queryMetric(AllMetrics.AdmissionControlValue.REJECTION_COUNT.toString());
+    assertEquals(1, result.size());
+  }
+
+  @Test
   public void testMasterThrottlingMetricsEmitter() throws Exception {
     Connection conn = DriverManager.getConnection(DB_URL);
     MasterThrottlingMetricsSnapshot masterThrottlingMetricsSnapshot = new MasterThrottlingMetricsSnapshot(conn, 1L);


### PR DESCRIPTION
*Fixes #:*
https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/issues/570

*Description of changes:*
Publish AdmissionControl framework (external) metrics. These metrics are generated at node level.
- rejectionCount - Keeps track of the rejection count.
- currentValue - Keeps track of the controller's resource (Global JVM Memory Pressure / Request Size) current value.
- thresholdValue - Keeps track of the controller's resource (Global JVM Memory Pressure / Request Size) threshold value. 

*Tests:*

*If new tests are added, how long do the new ones take to complete*

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
