### PR TITLE
Return errors when fail to read temperature profile RCA

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
@@ -946,13 +946,14 @@ class SQLitePersistor extends PersistorBase {
         response.addNestedSummaryList(nodeLevelDimSummary);
       }
     } catch (DataAccessException dex) {
+      JsonObject json = new JsonObject();
       if (dex.getMessage().contains("no such table")) {
-        JsonObject json = new JsonObject();
         json.addProperty("error", "RCAs are not created yet.");
-        return json;
       } else {
         LOG.error("Failed to read temperature profile RCA for {}.", rca, dex);
+        json.addProperty("error", "Failed to read temperature profile RCA.");
       }
+      return json;
     }
     return response.toJson();
   }


### PR DESCRIPTION
*Fixes #:*

*Description of changes:*

Return errors response when fail to read temperature profile RCA.

This is to fix the NPE during ClusterTemperatureRca request:
```
[2021-03-10T21:17:23,442][ERROR][c.a.o.e.p.r.QueryRcaRequestHandler] QueryException java.lang.NullPointerException ExceptionCode: RequestError.
java.lang.NullPointerException: null
        at com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.SQLitePersistor.readTemperatureProfileRca(SQLitePersistor.java:959) ~[OpenDistroPerformanceAnalyzerEngine.jar:?]
        at com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.SQLitePersistor.getTemperatureRca(SQLitePersistor.java:857) ~[OpenDistroPerformanceAnalyzerEngine.jar:?]
        at com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.SQLitePersistor.readRca(SQLitePersistor.java:895) ~[OpenDistroPerformanceAnalyzerEngine.jar:?]
        at com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.persistence.PersistorBase.read(PersistorBase.java:144) ~[OpenDistroPerformanceAnalyzerEngine.jar:?]
        at com.amazon.opendistro.elasticsearch.performanceanalyzer.rest.QueryRcaRequestHandler.lambda$getRcaData$3(QueryRcaRequestHandler.java:252) ~[OpenDistroPerformanceAnalyzerEngine.jar:?]
        at java.util.Arrays$ArrayList.forEach(Arrays.java:4390) ~[?:?]
        at com.amazon.opendistro.elasticsearch.performanceanalyzer.rest.QueryRcaRequestHandler.getRcaData(QueryRcaRequestHandler.java:251) ~[OpenDistroPerformanceAnalyzerEngine.jar:?]
        at com.amazon.opendistro.elasticsearch.performanceanalyzer.rest.QueryRcaRequestHandler.handleClusterRcaRequest(QueryRcaRequestHandler.java:189) ~[OpenDistroPerformanceAnalyzerEngine.jar:?]
        at com.amazon.opendistro.elasticsearch.performanceanalyzer.rest.QueryRcaRequestHandler.handle(QueryRcaRequestHandler.java:131) [OpenDistroPerformanceAnalyzerEngine.jar:?]
        at com.sun.net.httpserver.Filter$Chain.doFilter(Filter.java:77) [jdk.httpserver:?]
        at sun.net.httpserver.AuthFilter.doFilter(AuthFilter.java:82) [jdk.httpserver:?]
        at com.sun.net.httpserver.Filter$Chain.doFilter(Filter.java:80) [jdk.httpserver:?]
        at sun.net.httpserver.ServerImpl$Exchange$LinkHandler.handle(ServerImpl.java:692) [jdk.httpserver:?]
        at com.sun.net.httpserver.Filter$Chain.doFilter(Filter.java:77) [jdk.httpserver:?]
        at sun.net.httpserver.ServerImpl$Exchange.run(ServerImpl.java:664) [jdk.httpserver:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:834) [?:?]
```

*Tests:*

*If new tests are added, how long do the new ones take to complete*
