### PR TITLE
Changed master total PendingQueueSize to PendingQueueSize per task type

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/AllMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/AllMetrics.java
@@ -824,6 +824,24 @@ public class AllMetrics {
     }
   }
 
+  public enum MasterPendingTaskDimension implements MetricDimension {
+    MASTER_PENDING_TASK_TYPE(Constants.PENDING_TASK_TYPE);
+
+    private final String value;
+
+    MasterPendingTaskDimension(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return value;
+    }
+
+    public static class Constants {
+      public static final String PENDING_TASK_TYPE = "Master_PendingTaskType";
+    }
+  }
   public enum ClusterApplierServiceStatsValue implements MetricValue {
     CLUSTER_APPLIER_SERVICE_LATENCY(ClusterApplierServiceStatsValue.Constants.CLUSTER_APPLIER_SERVICE_LATENCY),
     CLUSTER_APPLIER_SERVICE_FAILURE(ClusterApplierServiceStatsValue.Constants.CLUSTER_APPLIER_SERVICE_FAILURE);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/model/MetricsModel.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/model/MetricsModel.java
@@ -34,6 +34,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetric
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.IPDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.IPValue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.LatencyDimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.MasterPendingTaskDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.MasterPendingValue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.MetricUnits;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.OSMetrics;
@@ -330,7 +331,7 @@ public class MetricsModel {
     // Master Metrics
     allMetricsInitializer.put(
         MasterPendingValue.MASTER_PENDING_QUEUE_SIZE.toString(),
-        new MetricAttributes(MetricUnits.COUNT.toString(), EmptyDimension.values()));
+        new MetricAttributes(MetricUnits.COUNT.toString(), MasterPendingTaskDimension.values()));
 
     allMetricsInitializer.put(
         AllMetrics.MasterMetricValues.MASTER_TASK_QUEUE_TIME.toString(),
@@ -385,7 +386,7 @@ public class MetricsModel {
             AllMetrics.ClusterApplierServiceStatsValue.CLUSTER_APPLIER_SERVICE_FAILURE.toString(),
             new MetricAttributes(
                     MetricUnits.COUNT.toString(), EmptyDimension.values()));
-    
+
     allMetricsInitializer.put(
             AdmissionControlValue.REJECTION_COUNT.toString(),
             new MetricAttributes(MetricUnits.COUNT.toString(), AdmissionControlDimension.values())

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MetricPropertiesConfig.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MetricPropertiesConfig.java
@@ -30,6 +30,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetric
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.HeapValue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.IPDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.IPValue;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.MasterPendingTaskDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.MasterPendingValue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.MetricName;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ShardStatsDerivedDimension;
@@ -247,7 +248,7 @@ public final class MetricPropertiesConfig {
     metricName2Property.put(
         MetricName.MASTER_PENDING,
         new MetricProperties(
-            MetricProperties.EMPTY_DIMENSION,
+            MasterPendingTaskDimension.values(),
             MasterPendingValue.values(),
             createFileHandler(
                 metricPathMap.get(MetricName.MASTER_PENDING),

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessorTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessorTests.java
@@ -223,7 +223,7 @@ public class ReaderMetricsProcessorTests extends AbstractReaderTests {
             masterPendingFinal);
 
     Result<Record> res = alignedWindow.fetchAll();
-        assertTrue(2 == res.size());
+    assertTrue(2 == res.size());
     Field<Double> valueField =
         DSL.field(MasterPendingValue.MASTER_PENDING_QUEUE_SIZE.toString(), Double.class);
     Field<String> dimensionField =

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessorTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessorTests.java
@@ -146,20 +146,20 @@ public class ReaderMetricsProcessorTests extends AbstractReaderTests {
         new MemoryDBSnapshot(conn, MetricName.MASTER_PENDING, 6001L);
     long lastUpdateTime1 = 2000L;
     masterPendingSnap1.setLastUpdatedTime(lastUpdateTime1);
-        Object[][] values1 = {{"delete-index", 0}};
+    Object[][] values1 = {{"delete-index", 0}};
     masterPendingSnap1.insertMultiRows(values1);
 
     MemoryDBSnapshot masterPendingSnap2 =
         new MemoryDBSnapshot(conn, MetricName.MASTER_PENDING, 11001L);
     long lastUpdateTime2 = 7000L;
     masterPendingSnap2.setLastUpdatedTime(lastUpdateTime2);
-        Object[][] values2 = {{"create-index", 1}};
+    Object[][] values2 = {{"create-index", 1}};
     masterPendingSnap2.insertMultiRows(values2);
 
     MemoryDBSnapshot masterPendingSnap3 =
         new MemoryDBSnapshot(conn, MetricName.MASTER_PENDING, 16001L);
     masterPendingSnap2.setLastUpdatedTime(lastUpdateTime3);
-        Object[][] values3 = {{"updateSnapshot", 3}};
+    Object[][] values3 = {{"updateSnapshot", 3}};
     masterPendingSnap3.insertMultiRows(values3);
 
     NavigableMap<Long, MemoryDBSnapshot> metricMap = new TreeMap<>();
@@ -265,7 +265,7 @@ public class ReaderMetricsProcessorTests extends AbstractReaderTests {
     Record row0 = res.get(0);
     for (int i = 1; i < row0.size(); i++) {
       Double pending = Double.parseDouble(row0.get(i).toString());
-        assertEquals(1.0d, pending, 0.001);
+      assertEquals(1.0d, pending, 0.001);
     }
     assertEquals("create-index", row0.get(0).toString());
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessorTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessorTests.java
@@ -226,15 +226,15 @@ public class ReaderMetricsProcessorTests extends AbstractReaderTests {
         assertTrue(2 == res.size());
     Field<Double> valueField =
         DSL.field(MasterPendingValue.MASTER_PENDING_QUEUE_SIZE.toString(), Double.class);
-        Field<String> dimensionField =
-                DSL.field(MasterPendingTaskDimension.MASTER_PENDING_TASK_TYPE.toString(), String.class);
+    Field<String> dimensionField =
+        DSL.field(MasterPendingTaskDimension.MASTER_PENDING_TASK_TYPE.toString(), String.class);
     Double pending = Double.parseDouble(res.get(0).get(valueField).toString());
-        assertEquals(1.0d, pending, 0.001);
-        assertEquals("create-index", res.get(0).get(dimensionField));
+    assertEquals(1.0d, pending, 0.001);
+    assertEquals("create-index", res.get(0).get(dimensionField));
 
-        pending = Double.parseDouble(res.get(1).get(valueField).toString());
-        assertEquals(3.0d, pending, 0.001);
-        assertEquals("updateSnapshot", res.get(1).get(dimensionField));
+    pending = Double.parseDouble(res.get(1).get(valueField).toString());
+    assertEquals(3.0d, pending, 0.001);
+    assertEquals("updateSnapshot", res.get(1).get(dimensionField));
   }
 
   @Test
@@ -263,11 +263,18 @@ public class ReaderMetricsProcessorTests extends AbstractReaderTests {
     assertTrue(2 == res.size());
 
     Record row0 = res.get(0);
-        for (int i = 1; i < row0.size(); i++) {
+    for (int i = 1; i < row0.size(); i++) {
       Double pending = Double.parseDouble(row0.get(i).toString());
-            assertEquals(1.0d, pending, 0.001);
+        assertEquals(1.0d, pending, 0.001);
     }
-        assertEquals("create-index", row0.get(0).toString());
+    assertEquals("create-index", row0.get(0).toString());
+
+    Record row1 = res.get(1);
+    for (int i = 1; i < row1.size(); i++) {
+      Double pending = Double.parseDouble(row1.get(i).toString());
+      assertEquals(1.0d, pending, 0.001);
+    }
+    assertEquals("updateSnapshot", row1.get(0).toString());
 
     db.remove();
   }
@@ -310,7 +317,7 @@ public class ReaderMetricsProcessorTests extends AbstractReaderTests {
       Double pending = Double.parseDouble(row0.get(i).toString());
       assertEquals(3.0, pending, 0.001);
     }
-        assertEquals("updateSnapshot", row0.get(0));
+    assertEquals("updateSnapshot", row0.get(0));
 
     // db tables should not be deleted
     for (MemoryDBSnapshot value : metricMap.values()) {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessorTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessorTests.java
@@ -272,7 +272,7 @@ public class ReaderMetricsProcessorTests extends AbstractReaderTests {
     Record row1 = res.get(1);
     for (int i = 1; i < row1.size(); i++) {
       Double pending = Double.parseDouble(row1.get(i).toString());
-      assertEquals(1.0d, pending, 0.001);
+      assertEquals(3.0d, pending, 0.001);
     }
     assertEquals("updateSnapshot", row1.get(0).toString());
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessorTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderMetricsProcessorTests.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.fail;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.AppContext;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.core.Util;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.MasterPendingTaskDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.MasterPendingValue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.MetricName;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
@@ -145,20 +146,20 @@ public class ReaderMetricsProcessorTests extends AbstractReaderTests {
         new MemoryDBSnapshot(conn, MetricName.MASTER_PENDING, 6001L);
     long lastUpdateTime1 = 2000L;
     masterPendingSnap1.setLastUpdatedTime(lastUpdateTime1);
-    Object[][] values1 = {{0}};
+        Object[][] values1 = {{"delete-index", 0}};
     masterPendingSnap1.insertMultiRows(values1);
 
     MemoryDBSnapshot masterPendingSnap2 =
         new MemoryDBSnapshot(conn, MetricName.MASTER_PENDING, 11001L);
     long lastUpdateTime2 = 7000L;
     masterPendingSnap2.setLastUpdatedTime(lastUpdateTime2);
-    Object[][] values2 = {{1}};
+        Object[][] values2 = {{"create-index", 1}};
     masterPendingSnap2.insertMultiRows(values2);
 
     MemoryDBSnapshot masterPendingSnap3 =
         new MemoryDBSnapshot(conn, MetricName.MASTER_PENDING, 16001L);
     masterPendingSnap2.setLastUpdatedTime(lastUpdateTime3);
-    Object[][] values3 = {{3}};
+        Object[][] values3 = {{"updateSnapshot", 3}};
     masterPendingSnap3.insertMultiRows(values3);
 
     NavigableMap<Long, MemoryDBSnapshot> metricMap = new TreeMap<>();
@@ -222,11 +223,18 @@ public class ReaderMetricsProcessorTests extends AbstractReaderTests {
             masterPendingFinal);
 
     Result<Record> res = alignedWindow.fetchAll();
-    assertTrue(1 == res.size());
+        assertTrue(2 == res.size());
     Field<Double> valueField =
         DSL.field(MasterPendingValue.MASTER_PENDING_QUEUE_SIZE.toString(), Double.class);
+        Field<String> dimensionField =
+                DSL.field(MasterPendingTaskDimension.MASTER_PENDING_TASK_TYPE.toString(), String.class);
     Double pending = Double.parseDouble(res.get(0).get(valueField).toString());
-    assertEquals(2.2d, pending, 0.001);
+        assertEquals(1.0d, pending, 0.001);
+        assertEquals("create-index", res.get(0).get(dimensionField));
+
+        pending = Double.parseDouble(res.get(1).get(valueField).toString());
+        assertEquals(3.0d, pending, 0.001);
+        assertEquals("updateSnapshot", res.get(1).get(dimensionField));
   }
 
   @Test
@@ -252,13 +260,15 @@ public class ReaderMetricsProcessorTests extends AbstractReaderTests {
 
     Result<Record> res = db.queryMetric(MasterPendingValue.MASTER_PENDING_QUEUE_SIZE.toString());
 
-    assertTrue(1 == res.size());
+    assertTrue(2 == res.size());
 
     Record row0 = res.get(0);
-    for (int i = 0; i < row0.size(); i++) {
+        for (int i = 1; i < row0.size(); i++) {
       Double pending = Double.parseDouble(row0.get(i).toString());
-      assertEquals(2.2d, pending, 0.001);
+            assertEquals(1.0d, pending, 0.001);
     }
+        assertEquals("create-index", row0.get(0).toString());
+
     db.remove();
   }
 
@@ -296,10 +306,11 @@ public class ReaderMetricsProcessorTests extends AbstractReaderTests {
     assertTrue(1 == res.size());
 
     Record row0 = res.get(0);
-    for (int i = 0; i < row0.size(); i++) {
+    for (int i = 1; i < row0.size(); i++) {
       Double pending = Double.parseDouble(row0.get(i).toString());
       assertEquals(3.0, pending, 0.001);
     }
+        assertEquals("updateSnapshot", row0.get(0));
 
     // db tables should not be deleted
     for (MemoryDBSnapshot value : metricMap.values()) {


### PR DESCRIPTION
**Master Pending Queue size per task type**

Earlier we were publishing Total number of pending task. For RCA analysis Pending Queue size per task type will give better understanding. Changed total Queue Size to Queue size per task type

_Tests:_

Added some manual entry. Below are the output of manual entry

_1. Table of Master_PendingQueueSize_
```
sqlite> select * from Master_PendingQueueSize;
create-index|5.0|5.0|5.0|5.0
delete-index|3.0|3.0|3.0|3.0
shard-started|10.0|10.0|10.0|10.0
```
_2. Schema of PendingQueueSize_
```
sqlite> .schema Master_PendingQueueSize
CREATE TABLE Master_PendingQueueSize(Master_PendingTaskType varchar null, sum double null, avg double null, min double null, max double null);
```
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.