### PR TITLE
Publish cluster state update stats

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/AllMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/AllMetrics.java
@@ -45,6 +45,7 @@ public class AllMetrics {
     CLUSTER_APPLIER_SERVICE,
     ADMISSION_CONTROL_METRICS,
     SHARD_INDEXING_PRESSURE,
+    MASTER_CLUSTER_UPDATE_STATS,
   }
 
   // we don't store node details as a metric on reader side database.  We
@@ -842,6 +843,27 @@ public class AllMetrics {
     public static class Constants {
       public static final String CLUSTER_APPLIER_SERVICE_LATENCY = "ClusterApplierService_Latency";
       public static final String CLUSTER_APPLIER_SERVICE_FAILURE = "ClusterApplierService_Failure";
+    }
+  }
+
+  public enum MasterClusterUpdateStatsValue implements MetricValue {
+    PUBLISH_CLUSTER_STATE_LATENCY(Constants.PUBLISH_CLUSTER_STATE_LATENCY),
+    PUBLISH_CLUSTER_STATE_FAILURE(Constants.PUBLISH_CLUSTER_STATE_FAILURE);
+
+    private final String value;
+
+    MasterClusterUpdateStatsValue(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return value;
+    }
+
+    public static class Constants {
+      public static final String PUBLISH_CLUSTER_STATE_LATENCY = "PublishClusterState_Latency";
+      public static final String PUBLISH_CLUSTER_STATE_FAILURE = "PublishClusterState_Failure";
     }
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
@@ -45,6 +45,7 @@ public class PerformanceAnalyzerMetrics {
   public static final String sMasterTaskPath = "master_task";
   public static final String sFaultDetection = "fault_detection";
   public static final String sClusterApplierService = "cluster_applier_service";
+  public static final String sMasterClusterUpdate = "master_cluster_update";
   public static final String sHttpPath = "http";
   public static final String sOSPath = "os_metrics";
   public static final String sHeapPath = "heap_metrics";

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/model/MetricsModel.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/model/MetricsModel.java
@@ -385,6 +385,16 @@ public class MetricsModel {
             AllMetrics.ClusterApplierServiceStatsValue.CLUSTER_APPLIER_SERVICE_FAILURE.toString(),
             new MetricAttributes(
                     MetricUnits.COUNT.toString(), EmptyDimension.values()));
+
+    allMetricsInitializer.put(
+            AllMetrics.MasterClusterUpdateStatsValue.PUBLISH_CLUSTER_STATE_LATENCY.toString(),
+            new MetricAttributes(
+                    MetricUnits.MILLISECOND.toString(), EmptyDimension.values()));
+
+    allMetricsInitializer.put(
+            AllMetrics.MasterClusterUpdateStatsValue.PUBLISH_CLUSTER_STATE_FAILURE.toString(),
+            new MetricAttributes(
+                    MetricUnits.COUNT.toString(), EmptyDimension.values()));
     
     allMetricsInitializer.put(
             AdmissionControlValue.REJECTION_COUNT.toString(),

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/PublishClusterState_Failure.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/PublishClusterState_Failure.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics;
+
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.Metric;
+
+public class PublishClusterState_Failure extends Metric {
+    public PublishClusterState_Failure(long evaluationIntervalSeconds) {
+        super(AllMetrics.MasterClusterUpdateStatsValue.PUBLISH_CLUSTER_STATE_FAILURE.name(),
+                evaluationIntervalSeconds);
+    }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/PublishClusterState_Latency.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/api/metrics/PublishClusterState_Latency.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.api.metrics;
+
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.Metric;
+
+public class PublishClusterState_Latency extends Metric {
+    public PublishClusterState_Latency(long evaluationIntervalSeconds) {
+        super(AllMetrics.MasterClusterUpdateStatsValue.PUBLISH_CLUSTER_STATE_LATENCY.name(),
+                evaluationIntervalSeconds);
+    }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
@@ -59,6 +59,8 @@ public enum ExceptionsAndErrors implements MeasurementSet {
 
   CLUSTER_APPLIER_SERVICE_STATS_COLLECTOR_ERROR("ClusterApplierServiceStatsCollector"),
 
+  MASTER_CLUSTER_UPDATE_STATS_COLLECTOR_ERROR("MasterClusterStateUpdateStatsCollector"),
+
   SHARD_INDEXING_PRESSURE_COLLECTOR_ERROR("ShardIndexingPressureMetricsCollector");
 
   /** What we want to appear as the metric name. */

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
@@ -61,6 +61,8 @@ public enum ExceptionsAndErrors implements MeasurementSet {
 
   MASTER_CLUSTER_UPDATE_STATS_COLLECTOR_ERROR("MasterClusterStateUpdateStatsCollectorError"),
 
+  MASTER_CLUSTER_UPDATE_STATS_COLLECTOR_DISABLED("MasterClusterStateUpdateStatsCollectorDisabled"),
+
   SHARD_INDEXING_PRESSURE_COLLECTOR_ERROR("ShardIndexingPressureMetricsCollector");
 
   /** What we want to appear as the metric name. */

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
@@ -59,7 +59,7 @@ public enum ExceptionsAndErrors implements MeasurementSet {
 
   CLUSTER_APPLIER_SERVICE_STATS_COLLECTOR_ERROR("ClusterApplierServiceStatsCollector"),
 
-  MASTER_CLUSTER_UPDATE_STATS_COLLECTOR_ERROR("MasterClusterStateUpdateStatsCollector"),
+  MASTER_CLUSTER_UPDATE_STATS_COLLECTOR_ERROR("MasterClusterStateUpdateStatsCollectorError"),
 
   SHARD_INDEXING_PRESSURE_COLLECTOR_ERROR("ShardIndexingPressureMetricsCollector");
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
@@ -61,8 +61,6 @@ public enum ExceptionsAndErrors implements MeasurementSet {
 
   MASTER_CLUSTER_UPDATE_STATS_COLLECTOR_ERROR("MasterClusterStateUpdateStatsCollectorError"),
 
-  MASTER_CLUSTER_UPDATE_STATS_COLLECTOR_DISABLED("MasterClusterStateUpdateStatsCollectorDisabled"),
-
   SHARD_INDEXING_PRESSURE_COLLECTOR_ERROR("ShardIndexingPressureMetricsCollector");
 
   /** What we want to appear as the metric name. */

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
@@ -45,6 +45,10 @@ public enum WriterMetrics implements MeasurementSet {
             "millis", Arrays.asList(Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT,
             Statistics.SUM)),
 
+    MASTER_CLUSTER_UPDATE_STATS_COLLECTOR_EXECUTION_TIME("MasterClusterUpdateStatsCollectorExecutionTime",
+            "millis", Arrays.asList(Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT,
+            Statistics.SUM)),
+
     SHARD_INDEXING_PRESSURE_COLLECTOR_EXECUTION_TIME("ShardIndexingPressureCollectorExecutionTime", "millis", Arrays.asList(
         Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
@@ -45,6 +45,10 @@ public enum WriterMetrics implements MeasurementSet {
             "millis", Arrays.asList(Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT,
             Statistics.SUM)),
 
+    MASTER_CLUSTER_UPDATE_STATS_COLLECTOR_DISABLED("MasterClusterUpdateStatsCollectorDisabled", "count", Arrays.asList(
+            Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
+
+
     MASTER_CLUSTER_UPDATE_STATS_COLLECTOR_EXECUTION_TIME("MasterClusterUpdateStatsCollectorExecutionTime",
             "millis", Arrays.asList(Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT,
             Statistics.SUM)),

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MetricPropertiesConfig.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/MetricPropertiesConfig.java
@@ -173,6 +173,7 @@ public final class MetricPropertiesConfig {
     metricPathMap.put(MetricName.CLUSTER_APPLIER_SERVICE, PerformanceAnalyzerMetrics.sClusterApplierService);
     metricPathMap.put(MetricName.ADMISSION_CONTROL_METRICS, PerformanceAnalyzerMetrics.sAdmissionControlMetricsPath);
     metricPathMap.put(MetricName.SHARD_INDEXING_PRESSURE, PerformanceAnalyzerMetrics.sShardIndexingPressurePath);
+    metricPathMap.put(MetricName.MASTER_CLUSTER_UPDATE_STATS, PerformanceAnalyzerMetrics.sMasterClusterUpdate);
 
     eventKeyToMetricNameMap = new HashMap<>();
     eventKeyToMetricNameMap.put(PerformanceAnalyzerMetrics.sCacheConfigPath, MetricName.CACHE_CONFIG);
@@ -192,6 +193,7 @@ public final class MetricPropertiesConfig {
             MetricName.CLUSTER_APPLIER_SERVICE);
     eventKeyToMetricNameMap.put(PerformanceAnalyzerMetrics.sAdmissionControlMetricsPath, MetricName.ADMISSION_CONTROL_METRICS);
     eventKeyToMetricNameMap.put(PerformanceAnalyzerMetrics.sShardIndexingPressurePath, MetricName.SHARD_INDEXING_PRESSURE);
+    eventKeyToMetricNameMap.put(PerformanceAnalyzerMetrics.sMasterClusterUpdate, MetricName.MASTER_CLUSTER_UPDATE_STATS);
 
     metricName2Property = new HashMap<>();
 
@@ -278,6 +280,13 @@ public final class MetricPropertiesConfig {
             AllMetrics.ShardIndexingPressureDimension.values(),
             AllMetrics.ShardIndexingPressureValue.values(),
             createFileHandler(metricPathMap.get(MetricName.SHARD_INDEXING_PRESSURE))));
+    metricName2Property.put(
+            MetricName.MASTER_CLUSTER_UPDATE_STATS,
+            new MetricProperties(
+                    MetricProperties.EMPTY_DIMENSION,
+                    AllMetrics.MasterClusterUpdateStatsValue.values(),
+                    createFileHandler(
+                            metricPathMap.get(MetricName.MASTER_CLUSTER_UPDATE_STATS))));
   }
 
   public static MetricPropertiesConfig getInstance() {

--- a/src/test/resources/reader/1566413960000
+++ b/src/test/resources/reader/1566413960000
@@ -11,6 +11,9 @@ $
 ^cluster_applier_service
 {"current_time":1566413936555}
 {"ClusterApplierService_Latency":23,"ClusterApplierService_Failure":3}$
+^master_cluster_update
+{"current_time":1566413936555}
+{"PublishClusterState_Latency":23,"PublishClusterState_Failure":3}$
 ^shard_state_metrics
 {"current_time":1566413936488}
 {"IndexName":"pmc"}

--- a/src/test/resources/reader/1566413965000
+++ b/src/test/resources/reader/1566413965000
@@ -10,6 +10,9 @@ $
 ^cluster_applier_service
 {"current_time":1566413966544}
 {"ClusterApplierService_Latency":23,"ClusterApplierService_Failure":3}$
+^master_cluster_update
+{"current_time":1566413966493}
+{"PublishClusterState_Latency":23,"PublishClusterState_Failure":3}$
 ^shard_state_metrics
 {"current_time":1566413966493}
 {"IndexName":"pmc"}

--- a/src/test/resources/reader/1566413970000
+++ b/src/test/resources/reader/1566413970000
@@ -11,6 +11,9 @@ $
 ^cluster_applier_service
 {"current_time":1566413996947}
 {"ClusterApplierService_Latency":23,"ClusterApplierService_Failure":3}$
+^master_cluster_update
+{"current_time":1566413996664}
+{"PublishClusterState_Latency":23,"PublishClusterState_Failure":3}$
 ^shard_state_metrics
 {"current_time":1566413996664}
 {"IndexName":"pmc"}


### PR DESCRIPTION
This PR will start publishing latency and failure metrices for Publish Phase of Cluster update from Master's Persepctive. This is going to help us in RCA and live time tracking of issues where publication is failing again and agian and the cluster is unstable because of this.

1.Tested using Docker

Tmp file

^master_cluster_update
{"current_time":1614584101385}
{"PublishClusterState_Failure":2,"PublishClusterState_Latency":0}$

Table created

sqlite> .tables
PublishClusterState_Latency 
PublishClusterState_Failure

Contents of the table

sqlite> select * from PublishClusterState_Failure;
6.0|6.0|6.0|6.0
sqlite> select * from PublishClusterState_Latency;
29.0|29.0|29.0|29.0
