### PR TITLE
Remove canWrite check

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/PluginSettings.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/PluginSettings.java
@@ -244,16 +244,14 @@ public class PluginSettings {
       LOG.info("Trying to create directory {}.", path);
     }
 
-    boolean valid = dictCreated && dict.isDirectory() && dict.canWrite();
+    boolean valid = dictCreated && dict.isDirectory();
     if (!valid) {
       LOG.error(
           "Invalid metrics location {}."
-              + " Created: {} (Expect True), Directory: {} (Expect True),"
-              + " CanWrite: {} (Expect True)",
+              + " Created: {} (Expect True), Directory: {} (Expect True)",
           path,
           dict.exists(),
-          dict.isDirectory(),
-          dict.canWrite());
+          dict.isDirectory());
       throw new ConfigFatalException("Having issue to use path: " + path);
     }
   }


### PR DESCRIPTION
*Fixes #:*

*Description of changes:*
Reader does not write any files to the "metrics-location" - Shared memory space between the reader and the writer. 

1. Removing this canWrite() check on the reader. 

*Tests:*

*If new tests are added, how long do the new ones take to complete*

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
