### PR TITLE
Running OSMetricsCollector before metric collection begins

### DIFF
--- a/pa_config/log4j2.xml
+++ b/pa_config/log4j2.xml
@@ -14,7 +14,7 @@
         <Logger name="stats_log" level="info" additivity="false">
             <AppenderRef ref="StatsLog"/>
         </Logger>
-        <Root level="error">
+        <Root level="info">
             <AppenderRef ref="Console" />
             <AppenderRef ref="PerformanceAnalyzerLog"/>
         </Root>

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/OSMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/OSMetricsCollector.java
@@ -26,6 +26,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics_generator
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics_generator.OSMetricsGenerator;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics_generator.SchedMetricsGenerator;
 import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class OSMetricsCollector extends PerformanceAnalyzerMetricsCollector
     implements MetricsProcessor {
@@ -34,6 +36,7 @@ public class OSMetricsCollector extends PerformanceAnalyzerMetricsCollector
   private static final int KEYS_PATH_LENGTH = 1;
   private StringBuilder value;
   private OSMetricsGenerator osMetricsGenerator;
+  static final Logger LOGGER = LogManager.getLogger(OSMetricsCollector.class);
 
   public enum MetaDataFields {
     threadName
@@ -54,6 +57,7 @@ public class OSMetricsCollector extends PerformanceAnalyzerMetricsCollector
     SchedMetricsGenerator schedMetricsGenerator = osMetricsGenerator.getSchedMetricsGenerator();
     schedMetricsGenerator.addSample();
 
+    LOGGER.info("MOMO, Inside OSMetricsCollector#collectMetrics(). Invoking ThreadList.getNativeTidMap()");
     Map<Long, ThreadList.ThreadState> threadStates = ThreadList.getNativeTidMap();
 
     DiskIOMetricsGenerator diskIOMetricsGenerator = osMetricsGenerator.getDiskIOMetricsGenerator();

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ScheduledMetricCollectorsExecutor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ScheduledMetricCollectorsExecutor.java
@@ -86,17 +86,20 @@ public class ScheduledMetricCollectorsExecutor extends Thread {
     }
 
     // Ensure that OSMetricsCollector runs once, so jTidMap has thread state persisted.
+    LOG.info("MOMO, executing OSMetricsCollector to update jTidMap");
     metricsCollectors.keySet()
         .stream()
         .forEach(collector -> {
-            if (collector instanceof OSMetricsCollector) {
-                LOG.info("Executing OSMetricsCollector once before starting metric collection");
+            LOG.info("MOMO, the Collector is: {}", collector.getCollectorName());
+            if (collector.getCollectorName().equals("OSMetrics")) {
+		LOG.info("MOMO, found the OSMetricsCollector!!");
+                LOG.info("MOMO, Executing OSMetricsCollector once before starting metric collection");
                 metricsCollectorsTP.execute(collector);
             }
         });
 
     long prevStartTimestamp = System.currentTimeMillis();
-
+    LOG.info("MOMO, starting the infinite while loop");
     while (true) {
       try {
         long millisToSleep =
@@ -105,7 +108,8 @@ public class ScheduledMetricCollectorsExecutor extends Thread {
           Thread.sleep(millisToSleep);
         }
       } catch (Exception ex) {
-        LOG.error("Exception in Thread Sleep", ex);
+        LOG.info("MOMO, exiting the infinite while loop. Exception in Thread Sleep");
+	LOG.error("Exception in Thread Sleep", ex);
       }
 
       prevStartTimestamp = System.currentTimeMillis();

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ScheduledMetricCollectorsExecutor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ScheduledMetricCollectorsExecutor.java
@@ -85,6 +85,16 @@ public class ScheduledMetricCollectorsExecutor extends Thread {
               taskThreadFactory);
     }
 
+    // Ensure that OSMetricsCollector runs once, so jTidMap has thread state persisted.
+    metricsCollectors.keySet()
+        .stream()
+        .forEach(collector -> {
+            if (collector instanceof OSMetricsCollector) {
+                LOG.info("Executing OSMetricsCollector once before starting metric collection");
+                metricsCollectorsTP.execute(collector);
+            }
+        });
+
     long prevStartTimestamp = System.currentTimeMillis();
 
     while (true) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/jvm/ThreadList.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/jvm/ThreadList.java
@@ -122,6 +122,7 @@ public class ThreadList {
         // Thread dumps are expensive and therefore we make sure that at least
         // minRunInterval milliseconds have elapsed between two attempts.
         if (System.currentTimeMillis() > lastRunTime + minRunInterval) {
+          LOGGER.info("MOMO, performing runThreadDump. minRunInterval: {}", minRunInterval);
           runThreadDump(pid, new String[0]);
         }
       } finally {
@@ -161,6 +162,7 @@ public class ThreadList {
 
   // Attach to pid and perform a thread dump
   private static void runAttachDump(String pid, String[] args) {
+    LOGGER.info("MOMO, inside runAttachDump. Invoking createMap()");
     VirtualMachine vm = null;
     try {
       vm = VirtualMachine.attach(pid);
@@ -256,6 +258,7 @@ public class ThreadList {
 
   static void runThreadDump(String pid, String[] args) {
     String currentThreadName = Thread.currentThread().getName();
+    LOGGER.info("MOMO, currentThreadName: {}. Inside runThreadDump() and Executing runAttachDump()", currentThreadName);
     assert currentThreadName.startsWith(ScheduledMetricCollectorsExecutor.COLLECTOR_THREAD_POOL_NAME)
                    || currentThreadName.equals(ScheduledMetricCollectorsExecutor.class.getSimpleName()) :
             String.format("Thread dump called from a non os collector thread: %s", currentThreadName);
@@ -315,6 +318,7 @@ public class ThreadList {
   }
 
   private static void createMap(InputStream in) throws Exception {
+    LOGGER.info("MOMO, creating the jTidMap!!");
     BufferedReader br = new BufferedReader(new InputStreamReader(in));
     String line = null;
     while ((line = br.readLine()) != null) {
@@ -322,6 +326,10 @@ public class ThreadList {
         parseLine(line);
       }
     }
+
+    /*jTidMap.entrySet().forEach(entry -> {
+        LOGGER.info("MOMO, key: {}, value: {} ", entry.getKey(), entry.getValue());
+    });*/
   }
 
   // currently stores thread states to track locking periods


### PR DESCRIPTION
Running OSMetricsCollector before metric collection begins to allow jTidMap to be persisted.

*Fixes #:* https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/issues/586

*Description of changes:* OSMetricsCollector#collectMetrics() is responsible for persisting Thread related info in 'jTidMap'
In case the 'jTidMap' has not been updated and threadState is null, we return -1 when getNativeThreadId() is invoked. This happens during the first round of collectors execution, any [collector executed before](https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/blob/3749a2668f2947df68cfc4817eba3af0ad9b6fb3/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ScheduledMetricCollectorsExecutor.java#L96)   OSMetricsCollector will find the threadState as null in the 'jTidMap' and persist -1 value for threadID.



*Tests:*

*If new tests are added, how long do the new ones take to complete*

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
