### PR TITLE
Log COLLECTORS_MUTED and JVM_THREAD_DUMP_SUCCESSFUL as metric than exception

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ScheduledMetricCollectorsExecutor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ScheduledMetricCollectorsExecutor.java
@@ -108,7 +108,7 @@ public class ScheduledMetricCollectorsExecutor extends Thread {
           if (entry.getValue() <= currentTime) {
             PerformanceAnalyzerMetricsCollector collector = entry.getKey();
             if (collector.getState() == PerformanceAnalyzerMetricsCollector.State.MUTED) {
-              StatsCollector.instance().logException(StatExceptionCode.COLLECTORS_MUTED);
+              StatsCollector.instance().logMetric(StatExceptionCode.COLLECTORS_MUTED.toString());
               continue;
             }
             metricsCollectors.put(collector, entry.getValue() + collector.getTimeInterval());

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/jvm/ThreadList.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/jvm/ThreadList.java
@@ -185,7 +185,7 @@ public class ThreadList {
 
     try {
       vm.detach();
-      StatsCollector.instance().logException(StatExceptionCode.JVM_THREAD_DUMP_SUCCESSFUL);
+      StatsCollector.instance().logMetric(StatExceptionCode.JVM_THREAD_DUMP_SUCCESSFUL.toString());
     } catch (Exception ex) {
       StatsCollector.instance().logException(StatExceptionCode.JVM_ATTACH_ERROR);
     }


### PR DESCRIPTION
*Fixes #:*

*Description of changes:*
Counter `COLLECTORS_MUTED` and `JVM_THREAD_DUMP_SUCCESSFUL` are currently logged as exceptions. This PR change them to be logged as metrics, so it won't be added to TotalError.


*Tests:*

```
Marketplace=yujias-swift-dev
ClientProgram=842058741309:log-test4
Program=PerformanceAnalyzerPlugin
ESVersion=6.7
rca-version=0.0.1
StartTime=1617638466.731
EndTime=Mon, 05 Apr 2021 09:01:07 PDT
Time=821 msecs
Timing=total-time:821.0/1
Counters=TotalError=0,JvmThreadDumpSuccessful=1
EOE
```

*If new tests are added, how long do the new ones take to complete*

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
