### PR TITLE
Modify JVM gen tuning policy and update unit test

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmGenTuningPolicy.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmGenTuningPolicy.java
@@ -154,7 +154,7 @@ public class JvmGenTuningPolicy implements DecisionPolicy {
    * @return a ratio that will decrease the young generation size based on the current ratio
    */
   public int computeDecrease(double currentRatio) {
-    // Don't decrease the (old:young) ratio beyond 5:1
+    // Don't increase the (old:young) ratio beyond 5:1
     if (currentRatio < 0 || currentRatio > 5) {
       return -1;
     }
@@ -166,8 +166,8 @@ public class JvmGenTuningPolicy implements DecisionPolicy {
    * @return a ratio that will increase the young generation size based on the current ratio
    */
   public int computeIncrease(double currentRatio) {
-    // Don't increase the (old:young) ratio beyond 3:1
-    if (currentRatio < 3) {
+    // Don't decrease the (old:young) ratio below 3:1
+    if (currentRatio < 4) {
       return -1;
     }
     // If the current ratio is egregious (e.g. 50:1) set the ratio to 3:1 immediately

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmGenTuningPolicyTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmGenTuningPolicyTest.java
@@ -156,6 +156,15 @@ public class JvmGenTuningPolicyTest {
     Assert.assertEquals(1, actions.size());
     Assert.assertTrue(actions.get(0) instanceof JvmGenAction);
     Assert.assertEquals(5, ((JvmGenAction) actions.get(0)).getTargetRatio());
+    mockCurrentRatio(5);
+    actions = policy.evaluate();
+    Assert.assertEquals(1, actions.size());
+    Assert.assertTrue(actions.get(0) instanceof JvmGenAction);
+    Assert.assertEquals(6, ((JvmGenAction) actions.get(0)).getTargetRatio());
+    // Should not decrease the young gen size if the ratio is beyond 5:1
+    mockCurrentRatio(5.1);
+    actions = policy.evaluate();
+    Assert.assertTrue(actions.isEmpty());
     // Make the young generation seem undersized
     mockRcaIssues(10, YOUNG_GEN_PROMOTION_RATE);
     // The policy should suggest increasing young gen when it is undersized
@@ -167,5 +176,19 @@ public class JvmGenTuningPolicyTest {
     Assert.assertEquals(1, actions.size());
     Assert.assertTrue(actions.get(0) instanceof JvmGenAction);
     Assert.assertEquals(3, ((JvmGenAction) actions.get(0)).getTargetRatio());
+    mockCurrentRatio(5);
+    actions = policy.evaluate();
+    Assert.assertEquals(1, actions.size());
+    Assert.assertTrue(actions.get(0) instanceof JvmGenAction);
+    Assert.assertEquals(4, ((JvmGenAction) actions.get(0)).getTargetRatio());
+    mockCurrentRatio(4);
+    actions = policy.evaluate();
+    Assert.assertEquals(1, actions.size());
+    Assert.assertTrue(actions.get(0) instanceof JvmGenAction);
+    Assert.assertEquals(3, ((JvmGenAction) actions.get(0)).getTargetRatio());
+    // Should not increase the young gen size if the ratio is not beyond 4:1
+    mockCurrentRatio(3.9);
+    actions = policy.evaluate();
+    Assert.assertTrue(actions.isEmpty());
   }
 }


### PR DESCRIPTION
*Description of changes:*
Modify the JVM gen tuning policy -> computeIncrease function to prevent increasing young gen size if the ratio is not below 4:1. Update the Unit test.

*Tests:*
Unit test passed

*If new tests are added, how long do the new ones take to complete*

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
