### PR TITLE
Create writer file only if metrics are present

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,51 +15,129 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics;
 
+
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.eval.Statistics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 public enum WriterMetrics implements MeasurementSet {
-    SHARD_STATE_COLLECTOR_EXECUTION_TIME("ShardStateCollectorExecutionTime", "millis", Arrays.asList(
-            Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
+    SHARD_STATE_COLLECTOR_EXECUTION_TIME(
+            "ShardStateCollectorExecutionTime",
+            "millis",
+            Arrays.asList(
+                    Statistics.MAX,
+                    Statistics.MIN,
+                    Statistics.MEAN,
+                    Statistics.COUNT,
+                    Statistics.SUM)),
 
-    MASTER_THROTTLING_COLLECTOR_EXECUTION_TIME("MasterThrottlingCollectorExecutionTime", "millis", Arrays.asList(
-            Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
+    MASTER_THROTTLING_COLLECTOR_EXECUTION_TIME(
+            "MasterThrottlingCollectorExecutionTime",
+            "millis",
+            Arrays.asList(
+                    Statistics.MAX,
+                    Statistics.MIN,
+                    Statistics.MEAN,
+                    Statistics.COUNT,
+                    Statistics.SUM)),
 
-    MASTER_THROTTLING_COLLECTOR_NOT_AVAILABLE("MasterThrottlingCollectorNotAvailable", "count", Arrays.asList(
-            Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
+    MASTER_THROTTLING_COLLECTOR_NOT_AVAILABLE(
+            "MasterThrottlingCollectorNotAvailable",
+            "count",
+            Arrays.asList(
+                    Statistics.MAX,
+                    Statistics.MIN,
+                    Statistics.MEAN,
+                    Statistics.COUNT,
+                    Statistics.SUM)),
 
-    ADMISSION_CONTROL_COLLECTOR_EXECUTION_TIME("AdmissionControlCollectorExecutionTime", "millis", Arrays.asList(
-            Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
+    ADMISSION_CONTROL_COLLECTOR_EXECUTION_TIME(
+            "AdmissionControlCollectorExecutionTime",
+            "millis",
+            Arrays.asList(
+                    Statistics.MAX,
+                    Statistics.MIN,
+                    Statistics.MEAN,
+                    Statistics.COUNT,
+                    Statistics.SUM)),
 
-    ADMISSION_CONTROL_COLLECTOR_NOT_AVAILABLE("AdmissionControlCollectorNotAvailable", "count", Arrays.asList(
-            Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
+    ADMISSION_CONTROL_COLLECTOR_NOT_AVAILABLE(
+            "AdmissionControlCollectorNotAvailable",
+            "count",
+            Arrays.asList(
+                    Statistics.MAX,
+                    Statistics.MIN,
+                    Statistics.MEAN,
+                    Statistics.COUNT,
+                    Statistics.SUM)),
 
-    FAULT_DETECTION_COLLECTOR_EXECUTION_TIME("FaultDetectionCollectorExecutionTime", "millis", Arrays.asList(
-            Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
+    FAULT_DETECTION_COLLECTOR_EXECUTION_TIME(
+            "FaultDetectionCollectorExecutionTime",
+            "millis",
+            Arrays.asList(
+                    Statistics.MAX,
+                    Statistics.MIN,
+                    Statistics.MEAN,
+                    Statistics.COUNT,
+                    Statistics.SUM)),
 
-    CLUSTER_APPLIER_SERVICE_STATS_COLLECTOR_EXECUTION_TIME("ClusterApplierServiceStatsCollectorExecutionTime",
-            "millis", Arrays.asList(Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT,
-            Statistics.SUM)),
+    CLUSTER_APPLIER_SERVICE_STATS_COLLECTOR_EXECUTION_TIME(
+            "ClusterApplierServiceStatsCollectorExecutionTime",
+            "millis",
+            Arrays.asList(
+                    Statistics.MAX,
+                    Statistics.MIN,
+                    Statistics.MEAN,
+                    Statistics.COUNT,
+                    Statistics.SUM)),
 
-    MASTER_CLUSTER_UPDATE_STATS_COLLECTOR_DISABLED("MasterClusterUpdateStatsCollectorDisabled", "count", Arrays.asList(
-            Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
+    MASTER_CLUSTER_UPDATE_STATS_COLLECTOR_DISABLED(
+            "MasterClusterUpdateStatsCollectorDisabled",
+            "count",
+            Arrays.asList(
+                    Statistics.MAX,
+                    Statistics.MIN,
+                    Statistics.MEAN,
+                    Statistics.COUNT,
+                    Statistics.SUM)),
 
+    MASTER_CLUSTER_UPDATE_STATS_COLLECTOR_EXECUTION_TIME(
+            "MasterClusterUpdateStatsCollectorExecutionTime",
+            "millis",
+            Arrays.asList(
+                    Statistics.MAX,
+                    Statistics.MIN,
+                    Statistics.MEAN,
+                    Statistics.COUNT,
+                    Statistics.SUM)),
 
-    MASTER_CLUSTER_UPDATE_STATS_COLLECTOR_EXECUTION_TIME("MasterClusterUpdateStatsCollectorExecutionTime",
-            "millis", Arrays.asList(Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT,
-            Statistics.SUM)),
+    ELECTION_TERM_COLLECTOR_EXECUTION_TIME(
+            "ElectionTermCollectorExecutionTime",
+            "millis",
+            Arrays.asList(
+                    Statistics.MAX,
+                    Statistics.MIN,
+                    Statistics.MEAN,
+                    Statistics.COUNT,
+                    Statistics.SUM)),
 
-    ELECTION_TERM_COLLECTOR_EXECUTION_TIME("ElectionTermCollectorExecutionTime", "millis", Arrays.asList(
-            Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
-
-    SHARD_INDEXING_PRESSURE_COLLECTOR_EXECUTION_TIME("ShardIndexingPressureCollectorExecutionTime", "millis", Arrays.asList(
-        Statistics.MAX, Statistics.MIN, Statistics.MEAN, Statistics.COUNT, Statistics.SUM)),
+    SHARD_INDEXING_PRESSURE_COLLECTOR_EXECUTION_TIME(
+            "ShardIndexingPressureCollectorExecutionTime",
+            "millis",
+            Arrays.asList(
+                    Statistics.MAX,
+                    Statistics.MIN,
+                    Statistics.MEAN,
+                    Statistics.COUNT,
+                    Statistics.SUM)),
 
     STALE_METRICS("StaleMetrics", "count", Arrays.asList(Statistics.COUNT)),
+
+    /** This metric indicates that the writer file creation was skipped. */
+    WRITER_FILE_CREATION_SKIPPED(
+            "WriterFileCreationSkipped", "count", Arrays.asList(Statistics.COUNT)),
     ;
 
     /** What we want to appear as the metric name. */

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader_writer_shared/EventLogFileHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader_writer_shared/EventLogFileHandler.java
@@ -18,7 +18,9 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_sh
 import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.core.Util;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.WriterMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader.EventDispatcher;
 import java.io.File;
 import java.io.IOException;
@@ -102,11 +104,19 @@ public class EventLogFileHandler {
     public void renameFromTmpWithPrivilege(long epoch) {
         Path path = Paths.get(metricsLocation, String.valueOf(epoch));
         Path tmpPath = Paths.get(path.toString() + TMP_FILE_EXT);
-        // This is done only when no exception is thrown.
-        try {
-            Files.move(tmpPath, path, REPLACE_EXISTING, ATOMIC_MOVE);
-        } catch (IOException e) {
-            LOG.error("Error moving file {} to {}.", tmpPath.toString(), path.toString(), e);
+        File tempFile = new File(tmpPath.toString());
+        // Only if the tmp file is present, we want to create the writer file.
+        // If not, we will publish a metric.
+        if (tempFile.exists()) {
+            // This is done only when no exception is thrown.
+            try {
+                Files.move(tmpPath, path, REPLACE_EXISTING, ATOMIC_MOVE);
+            } catch (IOException e) {
+                LOG.error("Error moving file {} to {}.", tmpPath.toString(), path.toString(), e);
+            }
+        } else {
+            PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                    WriterMetrics.WRITER_FILE_CREATION_SKIPPED, "", 1);
         }
     }
 
@@ -120,7 +130,7 @@ public class EventLogFileHandler {
         File tempFile = new File(pathToFile.toString());
         if (!tempFile.exists()) {
             long mCurrT = System.currentTimeMillis();
-            LOG.info("Didnt find {} at {}", filename, mCurrT);
+            LOG.debug("Didnt find {} at {}", filename, mCurrT);
             return;
         }
         readInternal(pathToFile, BUFFER_SIZE, processor);


### PR DESCRIPTION
*Fixes #:*
https://github.com/opendistro-for-elasticsearch/performance-analyzer/issues/313

*Description of changes:*
Before renaming the tmp writer file to epoch writer files, check if tmp file exists before we create the writer file.
This will help with not having empty writer file.
Changes merged on opensearch: https://github.com/opensearch-project/performance-analyzer-rca/pull/23

*Tests:*

*If new tests are added, how long do the new ones take to complete*

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
